### PR TITLE
Make Timestamp more feature-filled

### DIFF
--- a/dis_snek/models/timestamp.py
+++ b/dis_snek/models/timestamp.py
@@ -50,7 +50,7 @@ class Timestamp(datetime):
 
     @classmethod
     def fromisocalendar(cls, year: int, week: int, day: int):
-        timestamp = super().fromisocalendar(year, week, day).astimezone()
+        return super().fromisocalendar(year, week, day).astimezone()
 
     @classmethod
     def fromtimestamp(cls, t: float, tz = None): # TODO: typehint this

--- a/dis_snek/models/timestamp.py
+++ b/dis_snek/models/timestamp.py
@@ -53,6 +53,14 @@ class Timestamp(datetime):
         return super().fromisocalendar(year, week, day).replace(tzinfo=timezone.utc)
 
     @classmethod
+    def fromtimestamp(cls, t: float, tz = None): # TODO: typehint this
+        timestamp = super().fromtimestamp(t, tz=tz)
+        
+        if timestamp.tzinfo is None: # assume naive datetimes are based on local timezone
+            return timestamp.astimezone()
+        return timestamp
+
+    @classmethod
     def fromordinal(cls, n: int):
         return super().fromordinal(n).replace(tzinfo=timezone.utc)
 

--- a/dis_snek/models/timestamp.py
+++ b/dis_snek/models/timestamp.py
@@ -50,7 +50,7 @@ class Timestamp(datetime):
 
     @classmethod
     def fromisocalendar(cls, year: int, week: int, day: int):
-        return super().fromisocalendar(year, week, day).replace(tzinfo=timezone.utc)
+        timestamp = super().fromisocalendar(year, week, day).astimezone()
 
     @classmethod
     def fromtimestamp(cls, t: float, tz = None): # TODO: typehint this
@@ -62,7 +62,7 @@ class Timestamp(datetime):
 
     @classmethod
     def fromordinal(cls, n: int):
-        return super().fromordinal(n).replace(tzinfo=timezone.utc)
+        return super().fromordinal(n).astimezone()
 
     def tosnowflake(self, high: bool = False) -> Snowflake:
         """Returns a numeric snowflake pretending to be created at the given date.

--- a/dis_snek/models/timestamp.py
+++ b/dis_snek/models/timestamp.py
@@ -56,7 +56,7 @@ class Timestamp(datetime):
     def fromordinal(cls, n: int):
         return super().fromordinal(n).replace(tzinfo=timezone.utc)
 
-    def tosnowflake(self, high: bool = False):
+    def tosnowflake(self, high: bool = False) -> Snowflake:
         """Returns a numeric snowflake pretending to be created at the given date.
 
         When using as the lower end of a range, use ``tosnowflake(high=False) - 1``

--- a/dis_snek/models/timestamp.py
+++ b/dis_snek/models/timestamp.py
@@ -1,7 +1,10 @@
 from datetime import datetime
+from datetime import timezone
 from enum import Enum
 from typing import Optional
+from .snowflake import Snowflake
 
+DISCORD_EPOCH = 1420070400000
 
 class TimestampStyles(str, Enum):
     ShortTime = "t"
@@ -14,9 +17,55 @@ class TimestampStyles(str, Enum):
 
 
 class Timestamp(datetime):
+    """A special class that represents Discord timestamps."""
+
     @classmethod
-    def from_datetime(cls, dt: datetime):
-        return cls.utcfromtimestamp(dt.timestamp())
+    def fromdatetime(cls, dt: datetime):
+        timestamp = cls.fromtimestamp(dt.timestamp(), tz=dt.tzinfo)
+
+        if timestamp.tzinfo is None: # assume naive datetimes are based on local timezone
+            return timestamp.astimezone()
+        return timestamp 
+
+    @classmethod
+    def utcfromtimestamp(cls, t: float):
+        """Construct a timezone-aware UTC datetime from a POSIX timestamp."""
+        return super().utcfromtimestamp(t).replace(tzinfo=timezone.utc)
+        
+    @classmethod
+    def fromsnowflake(cls, snowflake: Snowflake):
+        if isinstance(snowflake, str):
+            snowflake = int(snowflake)
+
+        timestamp = ((snowflake >> 22) + DISCORD_EPOCH) / 1000
+        return cls.utcfromtimestamp(timestamp)
+
+    @classmethod
+    def fromisoformat(cls, date_string: str):
+        timestamp = super().fromisoformat(date_string)
+        
+        if timestamp.tzinfo is None: # assume naive datetimes are based on local timezone
+            return timestamp.astimezone()
+        return timestamp
+
+    @classmethod
+    def fromisocalendar(cls, year: int, week: int, day: int):
+        return super().fromisocalendar(year, week, day).replace(tzinfo=timezone.utc)
+
+    @classmethod
+    def fromordinal(cls, n: int):
+        return super().fromordinal(n).replace(tzinfo=timezone.utc)
+
+    def tosnowflake(self, high: bool = False):
+        """Returns a numeric snowflake pretending to be created at the given date.
+
+        When using as the lower end of a range, use ``tosnowflake(high=False) - 1``
+        to be inclusive, ``high=True`` to be exclusive.
+        When using as the higher end of a range, use ``tosnowflake(high=True) + 1``
+        to be inclusive, ``high=False`` to be exclusive"""
+
+        discord_millis = int(self.timestamp() * 1000 - DISCORD_EPOCH)
+        return (discord_millis << 22) + (2 ** 22 - 1 if high else 0)
 
     def format(self, style: Optional[TimestampStyles] = None):
         if not style:


### PR DESCRIPTION
Tried making it more feature-filled while also making it still somewhat close to how `datetime` is.

Couple of things to note:
- I removed the underscore from `to_datetime` since that was inconsistent with `datetime`.
- `Timestamp` assumes, if not in a function with `utc` in it, that times given are have the user's local timezone (a la d.py 2.0).
- Due to snowflakes being not-exactly-timezones, `tosnowflake` is a bit more complex and allows for some options in order to get the result as the user wishes (a la d.py).