### PR TITLE
Organize imports

### DIFF
--- a/dis_snek/gateway.py
+++ b/dis_snek/gateway.py
@@ -26,22 +26,21 @@ import sys
 import threading
 import time
 import zlib
-from typing import Any
-from typing import Callable
-from typing import Coroutine
-from typing import List
-from typing import Optional
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    Optional
+)
 
 import orjson
 from aiohttp import WSMsgType
 
 from dis_snek.const import logger_name
-from dis_snek.errors import WebSocketClosed
-from dis_snek.errors import WebSocketRestart
-from dis_snek.http_client import DiscordClientWebSocketResponse
-from dis_snek.http_client import HTTPClient
-from dis_snek.models.enums import Intents
-from dis_snek.models.enums import WebSocketOPCodes as OPCODE
+from dis_snek.errors import WebSocketClosed, WebSocketRestart
+from dis_snek.http_client import HTTPClient, DiscordClientWebSocketResponse
+from dis_snek.models.enums import Intents, WebSocketOPCodes as OPCODE
 
 log = logging.getLogger(logger_name)
 


### PR DESCRIPTION
This is a way to organize the imports in a better manner. Invoking file modulation support through a tuple allows faster load times. (also more neat if you ask me idk)