### PR TITLE
Convert `Message` to match other object types

### DIFF
--- a/dis_snek/models/discord_objects/application.py
+++ b/dis_snek/models/discord_objects/application.py
@@ -1,0 +1,32 @@
+from typing import List
+from typing import Optional
+
+import attr
+from attr.coverters import optional as optional_c
+
+from dis_snek.models.discord_objects.team import Team
+from dis_snek.models.discord_objects.user import User
+from dis_snek.models.snowflake import Snowflake
+from dis_snek.models.snowflake import Snowflake_Type
+from dis_snek.utils.attr_utils import DictSerializationMixin
+
+
+@attr.s(slots=True, kw_only=True)
+class Application(Snowflake, DictSerializationMixin):
+    name: str = attr.ib()
+    icon: Optional[str] = attr.ib(default=None)
+    description: Optional[str] = attr.ib()
+    rpc_origins: Optional[List[str]] = attr.ib(default=None)
+    bot_public: bool = attr.ib(default=True)
+    bot_require_code_grant: bool = attr.ib(default=False)
+    terms_of_service_url: Optional[str] = attr.ib(default=None)
+    privacy_policy_url: Optional[str] = attr.ib(default=None)
+    owner: Optional[User] = attr.ib(default=None)
+    summary: str = attr.ib()
+    verify_key: str = attr.ib()
+    team: Optional[Team] = attr.ib(default=None)
+    guild_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    primary_sku_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    slug: Optional[str] = attr.ib(default=None)
+    cover_image: Optional[str] = attr.ib(default=None)
+    flags: Optional[int] = attr.ib(default=None)  # TODO: flags enum

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -1,9 +1,15 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import Union
 
 import attr
 from attr.converters import optional as optional_c
+
 from dis_snek.models.enums import ChannelTypes
-from dis_snek.models.snowflake import Snowflake, Snowflake_Type
+from dis_snek.models.snowflake import Snowflake
+from dis_snek.models.snowflake import Snowflake_Type
 from dis_snek.models.timestamp import Timestamp
 from dis_snek.utils.attr_utils import DictSerializationMixin
 

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -1,15 +1,9 @@
-from typing import List
-from typing import Optional
-from typing import TYPE_CHECKING
-from typing import Union
-from typing import Any
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import attr
 from attr.converters import optional as optional_c
-
 from dis_snek.models.enums import ChannelTypes
-from dis_snek.models.snowflake import Snowflake
-from dis_snek.models.snowflake import Snowflake_Type
+from dis_snek.models.snowflake import Snowflake, Snowflake_Type
 from dis_snek.models.timestamp import Timestamp
 from dis_snek.utils.attr_utils import DictSerializationMixin
 
@@ -55,7 +49,7 @@ class BaseChannel(Snowflake, DictSerializationMixin):
 
 
 class _GuildMixin:
-    guild_id: Optional[int] = attr.ib(default=None)
+    guild_id: Optional[Snowflake_Type] = attr.ib(default=None)
     position: Optional[int] = attr.ib(default=0)
     nsfw: bool = attr.ib(default=False)
     parent_id: Optional[Snowflake_Type] = attr.ib(default=None)
@@ -122,9 +116,9 @@ class Thread(GuildText):
     member_count: int = attr.ib(default=0)
 
     archived: bool = attr.ib(default=False)
-    auto_archive_duration: int = attr.ib(default=attr.Factory(
-        lambda self: self.default_auto_archive_duration, takes_self=True
-    ))
+    auto_archive_duration: int = attr.ib(
+        default=attr.Factory(lambda self: self.default_auto_archive_duration, takes_self=True)
+    )
     locked: bool = attr.ib(default=False)
     archive_timestamp: Optional[Timestamp] = attr.ib(default=None, converter=optional_c(Timestamp.fromisoformat))
 
@@ -140,5 +134,15 @@ class Thread(GuildText):
 
 
 TYPE_ALL_CHANNEL = Union[
-    BaseChannel, GuildCategory, GuildStore, TextChannel, VoiceChannel, DM, GuildText, Thread, GuildNews, GuildVoice, GuildStageVoice
+    BaseChannel,
+    GuildCategory,
+    GuildStore,
+    TextChannel,
+    VoiceChannel,
+    DM,
+    GuildText,
+    Thread,
+    GuildNews,
+    GuildVoice,
+    GuildStageVoice,
 ]

--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -1,16 +1,55 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Union
+from typing import Any
+from typing import List
 from typing import Optional
+from typing import Union
 
+import attr
+from attr.converters import optional as optional_c
+
+from dis_snek.models.discord_objects.application import Application
+from dis_snek.models.discord_objects.channel import Thread
+from dis_snek.models.discord_objects.components import ComponentType
+from dis_snek.models.discord_objects.embed import Embed
 from dis_snek.models.discord_objects.emoji import Emoji
+from dis_snek.models.discord_objects.interactions import InteractionType
+from dis_snek.models.discord_objects.reaction import Reaction
+from dis_snek.models.discord_objects.role import Role
+from dis_snek.models.discord_objects.sticker import Sticker
 from dis_snek.models.discord_objects.user import Member
 from dis_snek.models.discord_objects.user import User
+from dis_snek.models.enum import ChannelTypes
 from dis_snek.models.enums import MessageActivityTypes
 from dis_snek.models.enums import MessageFlags
 from dis_snek.models.enums import MessageTypes
 from dis_snek.models.snowflake import Snowflake
 from dis_snek.models.snowflake import Snowflake_Type
+from dis_snek.models.timestamp import Timestamp
+from dis_snek.utils.attr_utils import default_kwargs
+from dis_snek.utils.attr_utils import DictSerializationMixin
+
+
+@attr.s(slots=True, kw_only=True)
+class Attachment(Snowflake, DictSerializationMixin):
+    filename: str = attr.ib()
+    content_type: Optional[str] = attr.ib(default=None)
+    size: int = attr.ib()
+    url: str = attr.ib()
+    proxy_url: str = attr.ib()
+    height: Optional[int] = attr.ib(default=None)
+    width: Optional[int] = attr.ib(default=None)
+
+    @property
+    def size(self):
+        return self.height, self.width
+
+
+@attr.s(slots=True, kw_only=True)
+class ChannelMention(Snowflake, DictSerializationMixin):
+    guild_id: Snowflake_Type = attr.ib()
+    type: ChannelTypes = attr.ib(converter=ChannelTypes)
+    name: str = attr.ib()
 
 
 @dataclass
@@ -19,7 +58,6 @@ class MessageActivity:
     party_id: str = None
 
 
-@dataclass
 class MessageReference:  # todo refactor into actual class, add pointers to actual message, channel, guild objects
     message_id: Optional[int] = None
     channel_id: Optional[int] = None
@@ -27,63 +65,37 @@ class MessageReference:  # todo refactor into actual class, add pointers to actu
     fail_if_not_exists: bool = True
 
 
-class Message(Snowflake):
-    def __init__(self, data: dict, client):
-        self._client = client
-
-        # ids
-        self.id: Snowflake_Type = data["id"]
-        self.channel_id: Snowflake_Type = data["channel_id"]
-        self.guild_id: Optional[Snowflake_Type] = data.get("guild_id")
-        self.webhook_id: Optional[Snowflake_Type] = data.get("webhook_id")
-        self.application_id: Optional[Snowflake_Type] = data.get("application_id")
-        self.nonce: Optional[str] = data.get("nonce")
-
-        # objects
-        if "member" not in data:
-            self.author: User = User.from_dict(data.get("author"), client)
-        else:
-            self.author: Member = Member.from_dict({**data.get("member"), **data.get("author")}, client)
-
-        self.application: Optional[dict] = data.get("application") if self.application_id else None
-        self.thread: Optional[dict] = data.get("thread")
-        self.interaction: Optional[dict] = data.get("interaction")
-
-        # content
-        self.content: str = data["content"]
-        self.mentions: List = data["mentions"]
-        self.mention_roles: List[Snowflake_Type] = data["mention_roles"]
-        self.mention_channels: Optional[List[Snowflake_Type]] = data.get("mention_channels")
-        self.mention_everyone = data["mention_everyone"]
-        self.attachments: Optional[List[dict]] = data.get("attachments", [])
-        self.embeds: Optional[List[dict]] = data.get("embeds", [])
-        self.sticker_items: Optional[List[dict]] = data.get("sticker_items")
-        self.components: Optional[List[dict]] = data.get("components")
-        self.pinned: bool = data.get("pinned", False)
-        self.flags: int = MessageFlags(data.get("flags", 0))
-        self.tts: bool = data["tts"]
-        self.type: int = MessageTypes(data["type"])
-
-        # related content
-        self.reactions: Optional[List[dict]] = data.get("reactions", [])
-        self.message_reference: Optional[MessageReference] = None
-        self.referenced_message: Optional[Message] = None
-        self.activity: Optional[MessageActivity] = None
-
-        if m_ref := data.get("message_reference"):
-            self.message_reference = MessageReference(**m_ref)
-
-        if ref_m := data.get("referenced_message"):
-            self.referenced_message = Message(ref_m, self._client)
-
-        if act := data.get("activity"):
-            self.activity = MessageActivity(**act)
-
-        # time
-        self.sent_at: datetime = datetime.fromisoformat(data["timestamp"])
-        self.edited_at: Optional[datetime] = None
-        if timestamp := data.get("edited_timestamp"):
-            self.edited_at = datetime.fromisoformat(timestamp)
+@attr.s(slots=True, kw_only=True)
+class Message(Snowflake, DictSerializationMixin):
+    _client: Any = attr.ib(repr=False)
+    channel_id: Snowflake_Type = attr.ib()
+    guild_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    author: Union[Member, User] = attr.ib()  # TODO: create override for detecting PartialMember
+    content: str = attr.ib()
+    timestamp: Timestamp = attr.ib(converter=Timestamp.fromisoformat)
+    edited_timestamp: Optional[Timestamp] = attr.ib(default=None, converter=optional_c(Timestamp.from_isoformat))
+    tts: bool = attr.ib(default=False)
+    mention_everyone: bool = attr.ib(default=False)
+    mentions: List[Member] = attr.ib(factory=list)
+    mention_roles: List[Role] = attr.ib(factory=list)
+    mention_channels: Optional[List[ChannelMention]] = attr.ib(default=None)
+    attachments: List["Attachment"] = attr.ib(factory=list)
+    embeds: List[Embed] = attr.ib(factory=list)
+    reactions: Optional[List[Reaction]] = attr.ib(default=None)
+    nonce: Optional[Union[int, str]] = attr.ib(default=None)
+    pinned: bool = attr.ib(default=False)
+    webhook_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    type: MessageTypes = attr.ib(converter=MessageTypes)
+    activity: Optional[MessageActivity] = attr.ib(default=None, converter=optional_c(MessageActivity))
+    application: Optional[Application] = attr.ib(default=None)  # TODO: partial application
+    application_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    message_reference: Optional[MessageReference] = attr.ib(default=None)
+    flags: Optional[MessageFlags] = attr.ib(default=None, converter=optional_c(MessageFlags))
+    referenced_message: Optional["Message"] = attr.ib(default=None)
+    interaction: Optional[InteractionType] = attr.ib(default=None)
+    thread: Optional[Thread] = attr.ib(default=None)  # TODO: Validation
+    components: Optional[List[ComponentType]] = attr.ib(default=None)
+    sticker_items: Optional[List[Sticker]] = attr.ib(default=None)  # TODO: StickerItem -> Sticker
 
     async def add_reaction(self, emoji: Union[Emoji, str]):
         """

--- a/dis_snek/models/discord_objects/reaction.py
+++ b/dis_snek/models/discord_objects/reaction.py
@@ -1,0 +1,14 @@
+import attr
+
+from dis_snek.models.discord_objects.emoji import Emoji
+from dis_snek.utils.attr_utils import DictSerializationMixin
+
+
+@attr.s(slots=True, kw_only=True)
+class Reaction(DictSerializationMixin):
+    # TODO: custom_emoji, message
+    count: int = attr.ib()
+    me: bool = attr.ib(default=False)
+    emoji: Emoji = attr.ib()  # TODO: partial emoji (name is null)
+
+    # TODO: clear, remove, users

--- a/dis_snek/models/discord_objects/role.py
+++ b/dis_snek/models/discord_objects/role.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import attr
+
+from dis_snek.models.snowflake import Snowflake
+from dis_snek.models.snowflake import Snowflake_Type
+from dis_snek.utils.attr_utils import DictSerializationMixin
+
+
+@attr.s(slots=True, kw_only=True)
+class RoleTags:
+    bot_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    integration_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    premium_subscriber: bool = attr.ib(default=False)  # TODO: detect null in process_dict
+
+
+@attr.s(slots=True, kw_only=True)
+class Role(Snowflake, DictSerializationMixin):
+    name: str = attr.ib()
+    color: int = attr.ib()
+    hoist: bool = attr.ib(default=False)
+    position: int = attr.ib()
+    permissions: str = attr.ib()  # TODO: permissions object
+    managed: bool = attr.ib(default=False)
+    mentionable: bool = attr.ib(default=True)
+    tags: Optional["RoleTags"] = attr.ib(default=None)
+
+    @property
+    def is_bot_managed(self):
+        if self.tags is not None:
+            return self.tags.bot_id is not None
+        return False
+
+    @property
+    def is_integration(self):
+        if self.tags is not None:
+            return self.tags.integration_id is not None
+        return False
+
+    @property
+    def is_premium(self):
+        if self.tags is not None:
+            return self.tags.premium_subscriber
+        return False
+
+    # TODO: is_default, requires guild_id == self.id

--- a/dis_snek/models/discord_objects/sticker.py
+++ b/dis_snek/models/discord_objects/sticker.py
@@ -1,0 +1,35 @@
+from typing import List
+from typing import Optional
+
+import attr
+
+from dis_snek.models.discord_objects.user import User
+from dis_snek.models.enums import StickerFormatTypes
+from dis_snek.models.enums import StickerTypes
+from dis_snek.models.snowflake import Snowflake
+from dis_snek.models.snowflake import Snowflake_Type
+from dis_snek.utils.attr_utils import DictSerializationMixin
+
+
+@attr.s(slots=True, kw_only=True)
+class Sticker(Snowflake, DictSerializationMixin):
+    pack_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    name: str = attr.ib()
+    description: Optional[str] = attr.ib(default=None)
+    tags: str = attr.ib()
+    type: StickerTypes = attr.ib(converter=StickerTypes)
+    format_type: StickerFormatTypes = attr.ib(converter=StickerFormatTypes)
+    available: Optional[bool] = attr.ib(default=True)
+    guild_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    user: Optional[User] = attr.ib(default=None)
+    sort_value: Optional[int] = attr.ib(default=None)
+
+
+@attr.s(slots=True, kw_only=True)
+class StickerPack(Snowflake, DictSerializationMixin):
+    stickers: List["Sticker"] = attr.ib(factory=list)
+    name: str = attr.ib()
+    sku_id: Snowflake_Type = attr.ib()
+    cover_sticker_id: Optional[Snowflake_Type] = attr.ib(default=None)
+    description: str = attr.ib()
+    banner_asset_id: Snowflake_Type = attr.ib()

--- a/dis_snek/models/discord_objects/team.py
+++ b/dis_snek/models/discord_objects/team.py
@@ -1,0 +1,28 @@
+from typing import List
+from typing import Optional
+
+import attr
+
+from dis_snek.models.discord_objects.user import User
+from dis_snek.models.enums import TeamMembershipState
+from dis_snek.models.snowflake import Snowflake
+from dis_snek.models.snowflake import Snowflake_Type
+from dis_snek.utils.attr_utils import DictSerializationMixin
+
+
+@attr.s(slots=True, kw_only=True)
+class TeamMember(DictSerializationMixin):
+    membership_state: TeamMembershipState = attr.ib(converter=TeamMembershipState)
+    permissions: List[str] = attr.ib(default=["*"])
+    team_id: Snowflake_Type = attr.ib()
+    user: User = attr.ib()  # TODO: partial user (avatar, discrim, id, username)
+
+
+@attr.s(slots=True, kw_only=True)
+class Team(Snowflake, DictSerializationMixin):
+    icon: Optional[str] = attr.ib(default=None)
+    members: List[TeamMember] = attr.ib(factory=list)
+    name: str = attr.ib()
+    owner_user_id: Snowflake_Type = attr.ib()
+
+    # TODO: Lots of functions related to getting items

--- a/dis_snek/models/enums.py
+++ b/dis_snek/models/enums.py
@@ -149,6 +149,11 @@ class UserFlags(DistinctMixin, IntFlag, metaclass=DistinctFlag):  # type: ignore
     ALL = AntiFlag()
 
 
+class TeamMembershipState(IntEnum):
+    INVITED = 1
+    ACCEPTED = 2
+
+
 class PremiumTypes(IntEnum):
     NONE = 0
     NITRO_CLASSIC = 1
@@ -201,6 +206,17 @@ class MessageFlags(DistinctMixin, IntFlag, metaclass=DistinctFlag):  # type: ign
     # Special members
     NONE = 0
     ALL = AntiFlag()
+
+
+class StickerTypes(IntEnum):
+    STANDARD = 1
+    GUILD = 2
+
+
+class StickerFormatTypes(IntEnum):
+    PNG = 1
+    APNG = 2
+    LOTTIE = 3
 
 
 class Permissions(DistinctMixin, IntFlag, metaclass=DistinctFlag):  # type: ignore


### PR DESCRIPTION
Leaves a lot to be desired in terms of functions, but object implementations are there at the very least. 

Implements:
- Role
  - RoleTags
- ChannelMention
- Attachment
- Reaction
- Application
  - Team
    - TeamMember
- Sticker
  - StickerPack