### PR TITLE
Commented out un-used import.

### DIFF
--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, List, Optional, Union
 import attr
 from attr.converters import optional as optional_c
 
-from dis_snek.models.discord_objects.asset import Asset
+# from dis_snek.models.discord_objects.asset import Asset
 from dis_snek.models.enums import PremiumTypes, UserFlags
 from dis_snek.models.snowflake import Snowflake, Snowflake_Type
 from dis_snek.models.timestamp import Timestamp


### PR DESCRIPTION
I'm not sure what it will be used for so I just commented it out, but it was causing the bot not to start.

```
Traceback (most recent call last):
  File "/home/wolfhound/worker-bot-project/worker-bot-snek/main.py", line 4, in <module>
    from dis_snek.client import Snake
  File "/home/wolfhound/worker-bot-project/worker-bot-snek/snek-env/lib/python3.9/site-packages/dis_snek/client.py", line 22, in <module>
    from dis_snek.models.discord_objects.context import (
  File "/home/wolfhound/worker-bot-project/worker-bot-snek/snek-env/lib/python3.9/site-packages/dis_snek/models/discord_objects/context.py", line 9, in <module>
    from dis_snek.models.discord_objects.message import Message
  File "/home/wolfhound/worker-bot-project/worker-bot-snek/snek-env/lib/python3.9/site-packages/dis_snek/models/discord_objects/message.py", line 9, in <module>
    from dis_snek.models.discord_objects.application import Application
  File "/home/wolfhound/worker-bot-project/worker-bot-snek/snek-env/lib/python3.9/site-packages/dis_snek/models/discord_objects/application.py", line 5, in <module>
    from dis_snek.models.discord_objects.team import Team
  File "/home/wolfhound/worker-bot-project/worker-bot-snek/snek-env/lib/python3.9/site-packages/dis_snek/models/discord_objects/team.py", line 5, in <module>
    from dis_snek.models.discord_objects.user import User
  File "/home/wolfhound/worker-bot-project/worker-bot-snek/snek-env/lib/python3.9/site-packages/dis_snek/models/discord_objects/user.py", line 6, in <module>
    from dis_snek.models.discord_objects.asset import Asset
ModuleNotFoundError: No module named 'dis_snek.models.discord_objects.asset'
```