### PR TITLE
Application command permissions support

### DIFF
--- a/dis_snek/client.py
+++ b/dis_snek/client.py
@@ -30,6 +30,7 @@ from dis_snek.models.discord_objects.interactions import (
     SlashCommand,
     SlashCommandChoice,
     SlashCommandOption,
+    SlashPermission,
 )
 from dis_snek.models.discord_objects.message import Message
 from dis_snek.models.discord_objects.user import Member, SnakeBotUser, User
@@ -248,19 +249,22 @@ class Snake:
 
         # first we need to make sure our local copy of cmd_ids is up-to-date
         await self._cache_interactions()
-        scopes = [k for k in self.interactions.keys()]
+        cmd_scopes = [k for k in self.interactions.keys()]
+        guild_perms = {}
 
-        for scope in scopes:
-            resp_data = await self.http.get_interaction_element(self.user.id, scope if scope != "global" else None)
-            to_sync = []
+        for cmd_scope in cmd_scopes:
+            cmds_resp_data = await self.http.get_interaction_element(
+                self.user.id, cmd_scope if cmd_scope != "global" else None
+            )
+            cmds_to_sync = []
 
-            for local_cmd in self.interactions[scope].values():
+            for local_cmd in self.interactions[cmd_scope].values():
                 # try and find remote equiv of this command
-                remote_cmd = next((v for v in resp_data if v["id"] == local_cmd.cmd_id), None)
+                remote_cmd = next((v for v in cmds_resp_data if v["id"] == local_cmd.cmd_id), None)
                 local_cmd = local_cmd.to_dict()
                 if not remote_cmd:
                     # if no remote, likely a new command, sync it
-                    to_sync.append(local_cmd)
+                    cmds_to_sync.append(local_cmd)
                     continue
 
                 if (
@@ -269,20 +273,33 @@ class Snake:
                     or local_cmd.get("default_permission", True) != remote_cmd.get("default_permission", True)
                     or local_cmd.get("options") != remote_cmd.get("options")
                 ):  # if command local data doesnt match remote, a change has been made, sync it
-                    # todo: check permission data when we implement interaction perms
-                    to_sync.append(local_cmd)
+                    cmds_to_sync.append(local_cmd)
 
-            if to_sync:
-                log.debug(f"Updating {len(to_sync)} commands in {scope}")
-                sync_resp = await self.http.post_interaction_element(
-                    self.user.id, to_sync, guild_id=scope if scope != "global" else None
+            if cmds_to_sync:
+                log.debug(f"Updating {len(cmds_to_sync)} commands in {cmd_scope}")
+                cmd_sync_resp = await self.http.post_interaction_element(
+                    self.user.id, cmds_to_sync, guild_id=cmd_scope if cmd_scope != "global" else None
                 )
                 # cache cmd_ids and their scopes
-                for cmd_data in sync_resp:
-                    self._interaction_scopes[str(cmd_data["id"])] = scope
-                    self.interactions[scope][cmd_data["name"]].cmd_id = str(cmd_data["id"])
+                for cmd_data in cmd_sync_resp:
+                    self._interaction_scopes[str(cmd_data["id"])] = cmd_scope
+                    self.interactions[cmd_scope][cmd_data["name"]].cmd_id = str(cmd_data["id"])
             else:
-                log.debug(f"{scope} is already up-to-date")
+                log.debug(f"{cmd_scope} is already up-to-date")
+
+            for local_cmd in self.interactions[cmd_scope].values():
+                for perm_scope, perms in local_cmd.permissions.items():
+                    if perm_scope not in guild_perms:
+                        guild_perms[perm_scope] = []
+                    guild_perms[perm_scope].append(
+                        {"id": local_cmd.cmd_id, "permissions": [perm.to_dict() for perm in perms]}
+                    )
+
+            for perm_scope in guild_perms:
+                log.debug(f"Updating {len(guild_perms[perm_scope])} commands in {perm_scope}")
+                perm_sync_resp = await self.http.batch_edit_application_command_permissions(
+                    application_id=self.user.id, scope=perm_scope, data=guild_perms[perm_scope]
+                )
 
     async def get_context(self, data: Dict, interaction: bool = False) -> Union[Context, InteractionContext]:
         """
@@ -464,7 +481,13 @@ class Snake:
         await self.http.create_message(channel, content)
 
     def slash_command(
-        self, name: str, description: str = "No description set", scope: Snowflake_Type = "global", options=None
+        self,
+        name: str,
+        description: str = "No description set",
+        scope: Snowflake_Type = "global",
+        options=None,
+        default_permission: bool = True,
+        permissions: Optional[Dict[Snowflake_Type, Union[SlashPermission, Dict]]] = None,
     ):
         def wrapper(func):
             if not asyncio.iscoroutinefunction(func):
@@ -477,7 +500,22 @@ class Snake:
                 else:
                     opt = func.options
 
-            cmd = SlashCommand(name, description, scope, call=func, options=opt)
+            perm = permissions
+            if hasattr(func, "permissions"):
+                if perm:
+                    perm.update(func.permissions)
+                else:
+                    perm = func.permissions
+
+            cmd = SlashCommand(
+                name,
+                description,
+                scope,
+                call=func,
+                options=opt,
+                default_permission=default_permission,
+                permissions=perm,
+            )
             func.cmd_id = f"{scope}::{name}"
             self.add_interaction(cmd)
             return func
@@ -531,6 +569,23 @@ class Snake:
             if not hasattr(func, "options"):
                 func.options = []
             func.options.append(option)
+            return func
+
+        return wrapper
+
+    def slash_permission(self, guild_id: Snowflake_Type, permissions: List[Union[SlashPermission, Dict]]):
+        def wrapper(func):
+            if hasattr(func, "cmd_id"):
+                raise Exception("slash_option decorators must be positioned under a slash_command decorator")
+
+            if not hasattr(func, "permissions"):
+                func.permissions = {}
+
+            if guild_id not in func.permissions:
+                func.permissions[guild_id] = permissions
+            else:
+                func.permissions[guild_id] += permissions
+
             return func
 
         return wrapper

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -97,7 +97,9 @@ class Guild(BaseGuild):
         return data
 
     @property
-    def channels(self) -> Union[CacheView, Awaitable[Dict[Snowflake_Type, TYPE_GUILD_CHANNEL]], AsyncIterator[TYPE_GUILD_CHANNEL]]:
+    def channels(
+        self,
+    ) -> Union[CacheView, Awaitable[Dict[Snowflake_Type, TYPE_GUILD_CHANNEL]], AsyncIterator[TYPE_GUILD_CHANNEL]]:
         return CacheView(ids=self.channel_ids, method=self._client.cache.get_channel)
 
     @property

--- a/dis_snek/models/discord_objects/interactions.py
+++ b/dis_snek/models/discord_objects/interactions.py
@@ -211,7 +211,9 @@ class SlashCommand:
         """
         self._name_validator("name", self.name)
         self._description_validator("description", self.description)
-        data = attr.asdict(self, filter=lambda key, value: value)
+
+        # Don't convert None or empty data structures
+        data = attr.asdict(self, filter=lambda key, value: isinstance(value, bool) or value)
 
         # remove internal data from dictionary
         data.pop("scope", None)

--- a/dis_snek/models/discord_objects/interactions.py
+++ b/dis_snek/models/discord_objects/interactions.py
@@ -211,6 +211,7 @@ class SlashCommand:
         """
         self._name_validator("name", self.name)
         self._description_validator("description", self.description)
+        self._options_validator("options", self.options)
 
         # Don't convert None or empty data structures
         data = attr.asdict(self, filter=lambda key, value: isinstance(value, bool) or value)

--- a/dis_snek/models/discord_objects/interactions.py
+++ b/dis_snek/models/discord_objects/interactions.py
@@ -19,6 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+from dis_snek.models.discord_objects.role import Role
 import re
 from enum import IntEnum
 from typing import Callable, Coroutine, Dict, List, Union
@@ -66,6 +67,19 @@ class OptionType(IntEnum):
         # todo role
         if issubclass(t, float):
             return cls.NUMBER
+
+
+class PermissionType(IntEnum):
+
+    ROLE = 1
+    USER = 2
+
+    @classmethod
+    def from_type(cls, t: type):
+        if issubclass(t, Role):
+            return cls.ROLE
+        if issubclass(t, BaseUser):
+            return cls.USER
 
 
 @attr.s(slots=True, on_setattr=[attr.setters.convert, attr.setters.validate])
@@ -163,6 +177,22 @@ class SlashCommandOption:
         return attr.asdict(self, filter=lambda key, value: value)
 
 
+@attr.s(slots=True)
+class SlashPermission:
+
+    id: Snowflake_Type = attr.ib()
+    type: Union[PermissionType, int] = attr.ib()
+    permission: bool = attr.ib()
+
+    def to_dict(self) -> dict:
+        """
+        Convert this object into a dict ready for discord.
+
+        :return: dict
+        """
+        return attr.asdict(self)
+
+
 @attr.s(slots=True, on_setattr=[attr.setters.convert, attr.setters.validate])
 class SlashCommand:
     """
@@ -179,6 +209,7 @@ class SlashCommand:
     scope: Snowflake_Type = attr.ib(default="global", converter=str)
     options: List[Union[SlashCommandOption, Dict]] = attr.ib(factory=list)
     default_permission: bool = attr.ib(default=True)
+    permissions: Dict[Snowflake_Type, Union[SlashPermission, Dict]] = attr.ib(factory=dict)
     cmd_id: Snowflake_Type = attr.ib(default=None)
     call: Callable[..., Coroutine] = attr.ib(default=None)
 


### PR DESCRIPTION
Generally the same idea as what I did with the other libs. Just had to fix a few bugs that were present:
* Fix default_permission not present in the dict if set to false. It was due to the filter used to try and remove those empty choice lists.
* Fix commands going missing during sync. Unfortunately, the put request overrides all existing commands, so we can't just sync the commands that are updated.

Example usages:
```py
# With parameter
@bot.slash_command(name='test', scope=877496477302284289, default_permission=False, permissions={
    877496477302284289: [SlashPermission(id=877899650420584508, type=PermissionType.ROLE, permission=True)]
})
async def name(ctx: InteractionContext):
    await ctx.send(f'This is a test command.')

# With decorator
@bot.slash_command(name='test2', scope=877496477302284289, default_permission=False)
@bot.slash_option(name='name', description='this is a test', opt_type=OptionType.BOOLEAN, required=True)
@bot.slash_permission(guild_id=877496477302284289, permissions=[
    SlashPermission(id=877899650420584508, type=PermissionType.ROLE, permission=True)
])
async def name(ctx: InteractionContext, name: bool):
    await ctx.send(f'This is {name}.')
```
