### PR TITLE
Fix dict conversion filter for SlashCommandOption as well.

### DIFF
--- a/dis_snek/models/discord_objects/interactions.py
+++ b/dis_snek/models/discord_objects/interactions.py
@@ -174,7 +174,7 @@ class SlashCommandOption:
 
         :return: dict
         """
-        return attr.asdict(self, filter=lambda key, value: value)
+        return attr.asdict(self, filter=lambda key, value: isinstance(value, bool) or value)
 
 
 @attr.s(slots=True)


### PR DESCRIPTION
If required is False, it was being filtered away.