### PR TITLE
Fix Embed sending

### DIFF
--- a/dis_snek/models/discord_objects/embed.py
+++ b/dis_snek/models/discord_objects/embed.py
@@ -34,7 +34,7 @@ from dis_snek.utils.serializer import no_export_meta
 
 
 @attr.s(slots=True)
-class EmbedField:
+class EmbedField(DictSerializationMixin):
     """Represents an embed field."""
 
     name: str = attr.ib()
@@ -241,6 +241,6 @@ def process_embeds(embeds: Optional[Union[List[Union[Embed, Dict]], Union[Embed,
 
     if isinstance(embeds, list):
         # A list of embeds, convert Embed to dict representation if needed.
-        return [embed.to_dict() if isinstance(embeds, Embed) else embed for embed in embeds]
+        return [embed.to_dict() if isinstance(embed, Embed) else embed for embed in embeds]
 
     raise ValueError(f"Invalid embeds: {embeds}")

--- a/dis_snek/utils/converters.py
+++ b/dis_snek/utils/converters.py
@@ -17,6 +17,9 @@ def timestamp_converter(value: Union[datetime, int, float, str]) -> Timestamp:
 def list_converter(converter):
     def convert_action(value):
         print(converter, value)
-        return [converter(**element) for element in value]
+        return [
+            converter(**element) if not hasattr(element, "to_dict") else converter(**element.to_dict())
+            for element in value
+        ]
 
     return convert_action


### PR DESCRIPTION
EmbedField needs DictSerializationMixin in order for it to be automatically converted by the list_converter.

There was also a small typo in process_embeds that caused it to not convert Embeds to dicts