### PR TITLE
Add `history.search()` method to text channels

### DIFF
--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -115,7 +115,7 @@ class ChannelHistory(AsyncIterator):
 
         # loop through history
         async for message in self:
-            if message.id == message_id:
+            if message.id == int(message_id):
                 return True
 
         return False

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -105,6 +105,21 @@ class ChannelHistory(AsyncIterator):
         """Flatten this iterator into a list of objects"""
         return [elem async for elem in self]
 
+    async def search(self, message_id: "Snowflake_Type") -> bool:
+        """
+        Check if a message_id exists in the specified history.
+
+        parameters:
+            message_id: ID of message to check.
+        """
+
+        # loop through history
+        async for message in self:
+            if message.id == message_id:
+                return True
+
+        return False
+
 
 @define()
 class PermissionOverwrite(SnowflakeObject):


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition 

## Description

This PR adds the `search()` method to the ChannelHistory class. This includes documentation about it.
Taken from https://trello.com/c/Olhwmubt/77-helper-methods

This also stores the fetched messages in the ChannelHistory class. Otherwise querying the history multiple times wouldn't work
Example:
```py
history = channel.history(limit=5)

# True
await history.search(896787457658478623)

# Still True
await history.search(896787457658478623)
```

## Changes

- add `channel.history.search()`

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
