### PR TITLE
Typing fix for `guild.get_channel()` and `guild.get_thread()`

### DIFF
--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -13,7 +13,8 @@ from dis_snek.models.discord_objects.channel import (
     GuildVoice,
     GuildStageVoice,
     PermissionOverwrite,
-    GuildChannel,
+    TYPE_GUILD_CHANNEL,
+    TYPE_THREAD_CHANNEL
 )
 from dis_snek.models.discord_objects.emoji import CustomEmoji
 from dis_snek.models.discord_objects.sticker import Sticker
@@ -736,7 +737,7 @@ class Guild(DiscordObject):
         result = await self._client.http.create_guild_role(guild_id=self.id, payload=payload, reason=reason)
         return self._client.cache.place_role_data(guild_id=self.id, data=[result])[to_snowflake(result["id"])]
 
-    async def get_channel(self, channel_id: "Snowflake_Type") -> Optional[Union["GuildChannel", "ThreadChannel"]]:
+    async def get_channel(self, channel_id: "Snowflake_Type") -> Optional[Union["TYPE_GUILD_CHANNEL", "TYPE_THREAD_CHANNEL"]]:
         """
         Returns a channel with the given `channel_id`
 
@@ -753,7 +754,7 @@ class Guild(DiscordObject):
             return await self._client.cache.get_channel(channel_id)
         return None
 
-    async def get_thread(self, thread_id: "Snowflake_Type") -> Optional["ThreadChannel"]:
+    async def get_thread(self, thread_id: "Snowflake_Type") -> Optional["TYPE_THREAD_CHANNEL"]:
         """
         Returns a Thread with the given `thread_id`
 

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -14,7 +14,7 @@ from dis_snek.models.discord_objects.channel import (
     GuildStageVoice,
     PermissionOverwrite,
     TYPE_GUILD_CHANNEL,
-    TYPE_THREAD_CHANNEL
+    TYPE_THREAD_CHANNEL,
 )
 from dis_snek.models.discord_objects.emoji import CustomEmoji
 from dis_snek.models.discord_objects.sticker import Sticker
@@ -737,7 +737,9 @@ class Guild(DiscordObject):
         result = await self._client.http.create_guild_role(guild_id=self.id, payload=payload, reason=reason)
         return self._client.cache.place_role_data(guild_id=self.id, data=[result])[to_snowflake(result["id"])]
 
-    async def get_channel(self, channel_id: "Snowflake_Type") -> Optional[Union["TYPE_GUILD_CHANNEL", "TYPE_THREAD_CHANNEL"]]:
+    async def get_channel(
+        self, channel_id: "Snowflake_Type"
+    ) -> Optional[Union["TYPE_GUILD_CHANNEL", "TYPE_THREAD_CHANNEL"]]:
         """
         Returns a channel with the given `channel_id`
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

This fixes type hints for `guild.get_channel()` and `guild.get_thread()`

Before this would have thrown type errors. Now it doesn't.
`channel: GuildText = await guild.get_channel(123)`

## Changes

- Change typing

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
