### PR TITLE
Fix ctx.edit_origin() and message.edit()

### DIFF
--- a/dis_snek/mixins/send.py
+++ b/dis_snek/mixins/send.py
@@ -48,7 +48,7 @@ class SendMixin:
             stickers: IDs of up to 3 stickers in the server to send in the message.
             allowed_mentions: Allowed mentions for the message.
             reply_to: Message to reference, must be from the same channel.
-            filepath: Location of file to send, defaults to None.
+            file: Location of file to send, or the file itself.
             tts: Should this message use Text To Speech.
             flags: Message flags to apply.
 

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -1,3 +1,4 @@
+from io import IOBase
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -286,10 +287,12 @@ class ComponentContext(InteractionContext):
     async def edit_origin(
         self,
         content: str = None,
-        embeds: List["Embed"] = None,
-        components: List[Union[Dict, "ActionRow"]] = None,
+        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        components: Optional[
+            Union[List[List[Union["BaseComponent", dict]]], List[Union["BaseComponent", dict]], "BaseComponent", dict]
+        ] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
-        filepath: Optional[Union[str, Path]] = None,
+        file: Optional[Union["IOBase", "Path", str]] = None,
         tts: bool = False,
     ) -> "Message":
         """
@@ -300,14 +303,13 @@ class ComponentContext(InteractionContext):
             embeds: Embedded rich content (up to 6000 characters).
             components: The components to include with the message.
             allowed_mentions: Allowed mentions for the message.
-            reply_to: Message to reference, must be from the same channel.
-            filepath: Location of file to send, defaults to None.
+            file: Location of file to send, or the file itself.
             tts: Should this message use Text To Speech.
 
         returns:
             The message after it was edited.
         """
-        if not self.responded and not self.deferred and filepath:
+        if not self.responded and not self.deferred and file:
             # Discord doesn't allow files at initial response, so we defer then edit.
             await self.defer(edit_origin=True)
 
@@ -316,7 +318,7 @@ class ComponentContext(InteractionContext):
             embeds=embeds,
             components=components,
             allowed_mentions=allowed_mentions,
-            file=filepath,
+            file=file,
             tts=tts,
         )
 

--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -292,11 +292,11 @@ class Message(DiscordObject):
         content: Optional[str] = None,
         embeds: Optional[Union[List[Union[Embed, dict]], Union[Embed, dict]]] = None,
         components: Optional[
-            Union[List[List[Union[BaseComponent, dict]]], List[Union[BaseComponent, dict]], BaseComponent, dict]
+            Union[List[List[Union["BaseComponent", dict]]], List[Union["BaseComponent", dict]], "BaseComponent", dict]
         ] = None,
         allowed_mentions: Optional[Union[AllowedMentions, dict]] = None,
         attachments: Optional[Optional[List[Union[Attachment, dict]]]] = None,
-        filepath: Optional[Union[str, Path]] = None,
+        file: Optional[Union["IOBase", "Path", str]] = None,
         tts: bool = False,
         flags: Optional[Union[int, MessageFlags]] = None,
     ) -> "Message":
@@ -309,7 +309,7 @@ class Message(DiscordObject):
             components: The components to include with the message.
             allowed_mentions: Allowed mentions for the message.
             attachments: The attachments to keep, only used when editing message.
-            filepath: Location of file to send, defaults to None.
+            file: Location of file to send, or the file itself.
             tts: Should this message use Text To Speech.
             flags: Message flags to apply.
         """
@@ -319,7 +319,7 @@ class Message(DiscordObject):
             components=components,
             allowed_mentions=allowed_mentions,
             attachments=attachments,
-            file=filepath,
+            file=file,
             tts=tts,
             flags=flags,
         )


### PR DESCRIPTION
## What type of pull request is this?

- [ ] Non-breaking code change
- [x] Breaking code change
- [x] Documentation change/addition 

## Description

ctx.edit_origin() and message.edit() had different arguments than .send()

I changed them to function the same, doesn't make sense to have `file` on .send() and `filepath` on .edit() for example.

This is technically breaking since an argument changed

## Changes

- ctx.edit_origin() and message.edit() now have the same args as .send()

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [ ] I've tested my code
