### PR TITLE
Prepend option to command option list

### DIFF
--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -593,7 +593,7 @@ def slash_option(
 
         if not hasattr(func, "options"):
             func.options = []
-        func.options.append(option)
+        func.options.insert(0, option)
         return func
 
     return wrapper


### PR DESCRIPTION
## What type of pull request is this?

- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition 

## Description

This fixes https://canary.discord.com/channels/870046872864165888/893158404237979688/900334868532195388 and makes options appear in the order they are defined.

## Changes

- Prepend options to list instead of appending them

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
