### PR TITLE
Add proto_url to message

### DIFF
--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -288,8 +288,12 @@ class Message(DiscordObject):
     @property
     def jump_url(self) -> str:
         """A url that allows the client to *jump* to this message"""
-        # todo: Add a `discord://` version of this
         return f"https://discord.com/channels/{self._guild_id or '@me'}/{self._channel_id}/{self.id}"
+
+    @property
+    def proto_url(self) -> str:
+        """A URL like `jump_url` that uses protocols"""
+        return f"discord://-/channels/{self._guild_id or '@me'}/{self._channel_id}/{self.id}"
 
     async def edit(
         self,


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition 

## Description

Add `Message.proto_url` to return a `discord://` url for Messages

## Changes

- Add `Message.proto_url`

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
