### PR TITLE
💥Fix subcmds and enable multi-scopes

### DIFF
--- a/dis_snek/models/scale.py
+++ b/dis_snek/models/scale.py
@@ -4,7 +4,7 @@ import logging
 from typing import List, TYPE_CHECKING, Callable, Coroutine
 
 from dis_snek.const import logger_name
-from dis_snek.models.application_commands import InteractionCommand, ComponentCommand
+from dis_snek.models.application_commands import InteractionCommand, ComponentCommand, SlashCommand
 from dis_snek.models.command import MessageCommand
 from dis_snek.models.listener import Listener
 from dis_snek.utils.misc_utils import wrap_partial
@@ -73,7 +73,7 @@ class Scale:
         new_cls = super().__new__(cls)
 
         for name, val in cls.__dict__.items():
-            if isinstance(val, (InteractionCommand, MessageCommand, ComponentCommand)):
+            if isinstance(val, (SlashCommand, MessageCommand, ComponentCommand)):
                 val.scale = new_cls
                 val = wrap_partial(val, new_cls)
 
@@ -81,7 +81,7 @@ class Scale:
 
                 if isinstance(val, ComponentCommand):
                     bot.add_component_callback(val)
-                elif isinstance(val, InteractionCommand):
+                elif isinstance(val, SlashCommand):
                     bot.add_interaction(val)
                 else:
                     bot.add_message_command(val)
@@ -121,8 +121,8 @@ class Scale:
                 for listener in func.listeners:
                     self.bot._component_callbacks.pop(listener)
             elif isinstance(func, InteractionCommand):
-                if self.bot.interactions.get(func.scope) and self.bot.interactions[func.scope].get(func.name):
-                    self.bot.interactions[func.scope].pop(func.name)
+                if self.bot.interactions.get(func.scopes) and self.bot.interactions[func.scopes].get(func.name):
+                    self.bot.interactions[func.scopes].pop(func.name)
             elif isinstance(func, MessageCommand):
                 if self.bot.commands[func.name]:
                     self.bot.commands.pop(func.name)

--- a/dis_snek/models/snowflake.py
+++ b/dis_snek/models/snowflake.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from typing import Union
+from typing import Union, List
 
 from dis_snek.models.timestamp import Timestamp
 from dis_snek.utils.attr_utils import define, field
@@ -24,6 +24,10 @@ def to_snowflake(snowflake: Union[Snowflake_Type, "SnowflakeObject"]) -> int:
         raise ValueError("ID (snowflake) is not in correct discord format!")
 
     return snowflake
+
+
+def to_snowflake_list(snowflakes: List[Union[Snowflake_Type, "SnowflakeObject"]]) -> List[int]:
+    return [to_snowflake(c) for c in snowflakes]
 
 
 @define()

--- a/dis_snek/utils/misc_utils.py
+++ b/dis_snek/utils/misc_utils.py
@@ -57,7 +57,8 @@ def wrap_partial(obj, cls):
     Returns:
         The original command object with its callback methods wrapped
     """
-    obj.callback = functools.partial(obj.callback, cls)
+    if "_no_wrap" not in getattr(obj.callback, "__name__", ""):
+        obj.callback = functools.partial(obj.callback, cls)
 
     if getattr(obj, "error_callback", None):
         obj.error_callback = functools.partial(obj.error_callback, cls)
@@ -67,5 +68,7 @@ def wrap_partial(obj, cls):
         obj.post_run_callback = functools.partial(obj.post_run_callback, cls)
     if getattr(obj, "autocomplete_callbacks", None):
         obj.autocomplete_callbacks = {k: functools.partial(v, cls) for k, v in obj.autocomplete_callbacks.items()}
+    if getattr(obj, "subcommands", None):
+        obj.subcommands = {k: wrap_partial(v, cls) for k, v in obj.subcommands.items()}
 
     return obj


### PR DESCRIPTION
## What type of pull request is this?

- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition 

## Description

Enables multiple-scopes for application commands. Also fixes various flaws with the previous subcommand implementation

## Changes

- Complete restructure of Slash/Sub-Commands
- Add `to_snowflake_list`
- Add support for multiple scopes to be passed to commands
- Removed subcommand decorator
- Added subcommand decorator to slash commands

Example Usage
```python
@slash_command("cmd", group_name="group", sub_cmd_name="sub_cmd", scopes=[701347683591389185, 707631108753195008])
async def cmd(ctx: InteractionContext, **kwargs):
    await ctx.send(ctx.invoked_name)
    print(kwargs)


@cmd.subcommand("sub_cmd_2", group_name="group")
@slash_option("test_option", "help me", 3)
async def sub_group_b(ctx: InteractionContext, **kwargs):
    await ctx.send(ctx.invoked_name)
    print(kwargs)


@cmd.subcommand("solo_sub")
@slash_option("test_option", "help me", 3)
async def sub_solo(ctx: InteractionContext, **kwargs):
    await ctx.send(ctx.invoked_name)
    print(kwargs)

```

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
