### PR TITLE
Remove self from unicode reaction add

### DIFF
--- a/dis_snek/event_processors/reaction_events.py
+++ b/dis_snek/event_processors/reaction_events.py
@@ -20,7 +20,7 @@ class ReactionEvents(EventMixinTemplate):
         if event.data["emoji"].get("id") is not None:
             emoji = CustomEmoji.from_dict(event.data.get("emoji"), self)  # type: ignore
         else:
-            emoji = Emoji.from_dict(event.data.get("emoji"), self)  # type: ignore
+            emoji = Emoji.from_dict(event.data.get("emoji"))  # type: ignore
 
         message = await self.cache.get_message(
             event.data.get("channel_id"), event.data.get("message_id")


### PR DESCRIPTION



## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

```
Traceback (most recent call last):
  File "E:\popularity-contest\env\lib\site-packages\dis_snek\client.py", line 326, in _async_wrap
    await _coro(_event, *_args, **_kwargs)
  File "E:\popularity-contest\env\lib\site-packages\dis_snek\models\listener.py", line 13, in __call__
    return await self.callback(*args, **kwargs)
  File "E:\popularity-contest\env\lib\site-packages\dis_snek\event_processors\reaction_events.py", line 24, in _on_raw_message_reaction_add
    emoji = Emoji.from_dict(event.data.get("emoji"), self)  # type: ignore
TypeError: DictSerializationMixin.from_dict() takes 2 positional arguments but 3 were given
```

`Emoji.from_dict()` doesn't need/use client.

## Changes

- Remove self from unicode reaction add

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
