### PR TITLE
Remove `attr_utils.define` shortcut

### DIFF
--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -71,7 +71,14 @@ class Resolved:
         return new_cls
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Context:
     """Represents the context of a command"""
 
@@ -98,7 +105,14 @@ class Context:
         return self._client
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class _BaseInteractionContext(Context):
     """An internal object used to define the attributes of interaction context and its children"""
 
@@ -144,7 +158,14 @@ class _BaseInteractionContext(Context):
         return new_cls
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class InteractionContext(_BaseInteractionContext, SendMixin):
     """
     Represents the context of an interaction
@@ -237,7 +258,14 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
         return await super().send(content, embeds, components, stickers, allowed_mentions, reply_to, file, tts, flags)
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class ComponentContext(InteractionContext):
     custom_id: str = attr.ib(default="", metadata=docs("The ID given to the component that has been pressed"))
     component_type: int = attr.ib(default=0, metadata=docs("The type of component that has been pressed"))
@@ -341,7 +369,14 @@ class ComponentContext(InteractionContext):
             return self.message
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class AutocompleteContext(_BaseInteractionContext):
     focussed_option: str = attr.ib(default=MISSING, metadata=docs("The option the user is currently filling in"))
 
@@ -381,7 +416,14 @@ class AutocompleteContext(_BaseInteractionContext):
         await self._client.http.post_initial_response(payload, self.interaction_id, self._token)
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class MessageContext(Context, SendMixin):
     @classmethod
     def from_message(cls, client: "Snake", message: "Message"):

--- a/dis_snek/models/discord_objects/activity.py
+++ b/dis_snek/models/discord_objects/activity.py
@@ -11,7 +11,14 @@ from dis_snek.utils.attr_utils import define
 from dis_snek.utils.serializer import dict_filter_none
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Activity(DictSerializationMixin):
     name: str = attr.ib()
     type: ActivityType = attr.ib(default=ActivityType.GAME)

--- a/dis_snek/models/discord_objects/activity.py
+++ b/dis_snek/models/discord_objects/activity.py
@@ -7,7 +7,6 @@ from dis_snek.models.discord_objects.asset import Asset
 from dis_snek.models.enums import ActivityType
 from dis_snek.models.snowflake import Snowflake_Type
 from dis_snek.models.timestamp import Timestamp
-from dis_snek.utils.attr_utils import define
 from dis_snek.utils.serializer import dict_filter_none
 
 

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -24,7 +24,7 @@ from dis_snek.models.enums import (
 )
 from dis_snek.models.snowflake import SnowflakeObject, to_snowflake
 from dis_snek.models.timestamp import Timestamp
-from dis_snek.utils.attr_utils import define, field
+from dis_snek.utils.attr_utils import field
 from dis_snek.utils.converters import timestamp_converter
 from dis_snek.utils.serializer import to_image_data
 

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -84,7 +84,14 @@ class ChannelHistory(AsyncIterator):
         return messages
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class PermissionOverwrite(SnowflakeObject):
     """
     Channel Permissions Overwrite object
@@ -100,7 +107,14 @@ class PermissionOverwrite(SnowflakeObject):
     deny: "Permissions" = field(repr=True, converter=Permissions)
 
 
-@define(slots=False)
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=False,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class MessageableMixin(SendMixin):
     last_message_id: Optional["Snowflake_Type"] = attr.ib(
         default=None
@@ -299,7 +313,14 @@ class MessageableMixin(SendMixin):
         await self._client.http.trigger_typing_indicator(self.id)
 
 
-@define(slots=False)
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=False,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class InvitableMixin:
     async def create_invite(
         self,
@@ -356,7 +377,14 @@ class InvitableMixin:
         return Invite.from_list(invites_data, self._client)
 
 
-@define(slots=False)
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=False,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class ThreadableMixin:
     async def create_thread_with_message(
         self,
@@ -466,7 +494,14 @@ class ThreadableMixin:
         return []
 
 
-@define(slots=False)
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=False,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class BaseChannel(DiscordObject):
     name: Optional[str] = field(default=None)
     type: Union[ChannelTypes, int] = field(converter=ChannelTypes)
@@ -523,7 +558,14 @@ class BaseChannel(DiscordObject):
 # DMs
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class DMChannel(BaseChannel, MessageableMixin):
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:
@@ -541,7 +583,14 @@ class DMChannel(BaseChannel, MessageableMixin):
         await self._edit(payload=payload, reason=reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class DM(DMChannel):
     recipient: "User" = field()
 
@@ -553,7 +602,14 @@ class DM(DMChannel):
         return data
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class DMGroup(DMChannel):
     owner_id: "Snowflake_Type" = attr.ib()
     application_id: Optional["Snowflake_Type"] = attr.ib(default=None)
@@ -579,7 +635,14 @@ class DMGroup(DMChannel):
 # Guild
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildChannel(BaseChannel):
     position: Optional[int] = attr.ib(default=0)
     nsfw: bool = attr.ib(default=False)
@@ -616,7 +679,14 @@ class GuildChannel(BaseChannel):
         await self._client.http.delete_channel_permission(self.id, target, reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildCategory(GuildChannel):
     async def edit(self, name, position, permission_overwrites, reason):
         payload = dict(  # TODO Proper processing
@@ -627,7 +697,14 @@ class GuildCategory(GuildChannel):
         await self._edit(payload=payload, reason=reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildStore(GuildChannel):
     async def edit(self, name, position, permission_overwrites, parent_id, nsfw, reason):
         payload = dict(  # TODO Proper processing
@@ -640,7 +717,14 @@ class GuildStore(GuildChannel):
         await self._edit(payload=payload, reason=reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildNews(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin):
     topic: Optional[str] = attr.ib(default=None)
 
@@ -672,7 +756,14 @@ class GuildNews(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin)
         await self._client.http.follow_news_channel(self.id, webhook_channel_id)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin):
     topic: Optional[str] = attr.ib(default=None)
     rate_limit_per_user: int = attr.ib(default=0)
@@ -711,7 +802,14 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin)
 # Guild Threads
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class ThreadChannel(GuildChannel, MessageableMixin):
     owner_id: "Snowflake_Type" = attr.ib(default=None)
     topic: Optional[str] = attr.ib(default=None)
@@ -764,7 +862,14 @@ class ThreadChannel(GuildChannel, MessageableMixin):
         await self._client.http.leave_thread(self.id)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildNewsThread(ThreadChannel):
     async def edit(self, name, archived, auto_archive_duration, locked, rate_limit_per_user, reason):
         payload = dict(  # TODO Proper processing
@@ -777,7 +882,14 @@ class GuildNewsThread(ThreadChannel):
         await self._edit(payload=payload, reason=reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildPublicThread(ThreadChannel):
     async def edit(self, name, archived, auto_archive_duration, locked, rate_limit_per_user, reason):
         payload = dict(  # TODO Proper processing
@@ -790,7 +902,14 @@ class GuildPublicThread(ThreadChannel):
         await self._edit(payload=payload, reason=reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildPrivateThread(ThreadChannel):
     invitable: bool = field(default=False)
 
@@ -810,7 +929,14 @@ class GuildPrivateThread(ThreadChannel):
 # Guild Voices
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class VoiceChannel(GuildChannel):  # TODO May not be needed, can be directly just GuildVoice.
     bitrate: int = attr.ib()
     user_limit: int = attr.ib()
@@ -842,12 +968,26 @@ class VoiceChannel(GuildChannel):  # TODO May not be needed, can be directly jus
         await self._edit(payload=payload, reason=reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildVoice(VoiceChannel, InvitableMixin):
     pass
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildStageVoice(GuildVoice):
     stage_instance: "StageInstance" = attr.ib(default=MISSING)
 

--- a/dis_snek/models/discord_objects/emoji.py
+++ b/dis_snek/models/discord_objects/emoji.py
@@ -17,7 +17,14 @@ if TYPE_CHECKING:
     from dis_snek.models.snowflake import Snowflake_Type
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Emoji(SnowflakeObject, DictSerializationMixin):
     """Represent a basic emoji used in discord."""
 
@@ -53,7 +60,14 @@ class Emoji(SnowflakeObject, DictSerializationMixin):
             return self.name
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class CustomEmoji(Emoji):
     """Represent a custom emoji in a guild with all its properties."""
 

--- a/dis_snek/models/discord_objects/emoji.py
+++ b/dis_snek/models/discord_objects/emoji.py
@@ -5,7 +5,7 @@ from attr.converters import optional
 
 from dis_snek.mixins.serialization import DictSerializationMixin
 from dis_snek.models.snowflake import SnowflakeObject, to_snowflake
-from dis_snek.utils.attr_utils import define, field
+from dis_snek.utils.attr_utils import field
 from dis_snek.utils.converters import list_converter
 from dis_snek.utils.serializer import dict_filter_none, no_export_meta
 

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -25,7 +25,7 @@ from dis_snek.models.enums import (
     IntegrationExpireBehaviour,
 )
 from dis_snek.models.snowflake import to_snowflake
-from dis_snek.utils.attr_utils import define, docs
+from dis_snek.utils.attr_utils import docs
 from dis_snek.utils.converters import timestamp_converter
 from dis_snek.utils.serializer import to_image_data, dict_filter_none
 

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -39,13 +39,27 @@ if TYPE_CHECKING:
     from dis_snek.models.timestamp import Timestamp
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildBan:
     reason: Optional[str]
     user: "User"
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Guild(DiscordObject):
     """Guilds in Discord represent an isolated collection of users and channels, and are often referred to as "servers" in the UI."""
 
@@ -957,7 +971,14 @@ class Guild(DiscordObject):
         return [GuildIntegration.from_dict(d | {"guild_id": self.id}, self._client) for d in data]
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildTemplate(ClientObject):
     code: str = attr.ib(metadata=docs("the template code (unique ID)"))
     name: str = attr.ib(metadata=docs("the name"))
@@ -1009,7 +1030,14 @@ class GuildTemplate(ClientObject):
         await self._client.http.delete_guild_template(self.source_guild_id, self.code)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildWelcomeChannel(ClientObject):
     channel_id: "Snowflake_Type" = attr.ib(metadata=docs("Welcome Channel ID"))
     description: str = attr.ib(metadata=docs("Welcome Channel description"))
@@ -1021,7 +1049,14 @@ class GuildWelcomeChannel(ClientObject):
     )
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class GuildWelcome(ClientObject):
     description: Optional[str] = attr.ib(default=None, metadata=docs("Welcome Screen server description"))
     welcome_channels: List["GuildWelcomeChannel"] = attr.ib(metadata=docs("List of Welcome Channel objects, up to 5"))

--- a/dis_snek/models/discord_objects/invite.py
+++ b/dis_snek/models/discord_objects/invite.py
@@ -24,7 +24,14 @@ class InviteTargetTypes(IntEnum):
     EMBEDDED_APPLICATION = 2
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class InviteStageInstance(DictSerializationMixin):
     members: List["Member"] = field()  # TODO Get from cache
     participant_count: int = field()
@@ -32,7 +39,14 @@ class InviteStageInstance(DictSerializationMixin):
     topic: str = field()
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class InviteMetadata(DictSerializationMixin):  # TODO This should be part of invite.
     uses: int = field()
     max_uses: int = field()
@@ -41,7 +55,14 @@ class InviteMetadata(DictSerializationMixin):  # TODO This should be part of inv
     created_at: Timestamp = field(converter=timestamp_converter)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Invite(ClientObject):
     code: str = field()
     target_type: Optional[Union[InviteTargetTypes, int]] = field(default=None, converter=optional_c(InviteTargetTypes))

--- a/dis_snek/models/discord_objects/invite.py
+++ b/dis_snek/models/discord_objects/invite.py
@@ -8,7 +8,7 @@ from dis_snek.mixins.serialization import DictSerializationMixin
 from dis_snek.models.discord import ClientObject
 from dis_snek.models.snowflake import to_snowflake
 from dis_snek.models.timestamp import Timestamp
-from dis_snek.utils.attr_utils import define, field
+from dis_snek.utils.attr_utils import field
 from dis_snek.utils.converters import timestamp_converter
 
 if TYPE_CHECKING:

--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -29,7 +29,6 @@ from dis_snek.models.enums import (
 from dis_snek.models.file import File
 from dis_snek.models.snowflake import to_snowflake
 from dis_snek.models.timestamp import Timestamp
-from dis_snek.utils.attr_utils import define
 from dis_snek.utils.converters import timestamp_converter
 from dis_snek.utils.input_utils import OverriddenJson
 from dis_snek.utils.serializer import dict_filter_none
@@ -111,7 +110,14 @@ class MessageReference(DictSerializationMixin):
         )
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class MessageInteraction(DiscordObject):
     type: InteractionTypes = attr.ib(converter=InteractionTypes)
     name: str = attr.ib()

--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -46,7 +46,14 @@ if TYPE_CHECKING:
     from dis_snek.models.snowflake import Snowflake_Type
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Attachment(DiscordObject):
     filename: str = attr.ib()
     content_type: Optional[str] = attr.ib(default=None)
@@ -61,7 +68,14 @@ class Attachment(DiscordObject):
         return self.height, self.width
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class ChannelMention(DiscordObject):
     guild_id: "Snowflake_Type" = attr.ib()
     type: ChannelTypes = attr.ib(converter=ChannelTypes)
@@ -157,7 +171,14 @@ class AllowedMentions:
         return cls()
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Message(DiscordObject):
     content: str = attr.ib()
     timestamp: Timestamp = attr.ib(converter=timestamp_converter)

--- a/dis_snek/models/discord_objects/reaction.py
+++ b/dis_snek/models/discord_objects/reaction.py
@@ -10,7 +10,6 @@ from dis_snek.models.discord import ClientObject
 from dis_snek.models.discord_objects.emoji import Emoji
 from dis_snek.models.iterator import AsyncIterator
 from dis_snek.models.snowflake import to_snowflake
-from dis_snek.utils.attr_utils import define
 
 if TYPE_CHECKING:
     from dis_snek.models.snowflake import Snowflake_Type

--- a/dis_snek/models/discord_objects/reaction.py
+++ b/dis_snek/models/discord_objects/reaction.py
@@ -56,7 +56,14 @@ class ReactionUsers(AsyncIterator):
             raise QueueEmpty()
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Reaction(ClientObject):
     count: int = attr.ib()
     me: bool = attr.ib(default=False)

--- a/dis_snek/models/discord_objects/role.py
+++ b/dis_snek/models/discord_objects/role.py
@@ -7,7 +7,7 @@ from dis_snek.const import MISSING
 from dis_snek.models.color import Color
 from dis_snek.models.discord import DiscordObject
 from dis_snek.models.enums import Permissions
-from dis_snek.utils.attr_utils import define, field
+from dis_snek.utils.attr_utils import field
 from dis_snek.utils.serializer import dict_filter_missing
 
 if TYPE_CHECKING:

--- a/dis_snek/models/discord_objects/role.py
+++ b/dis_snek/models/discord_objects/role.py
@@ -25,7 +25,14 @@ def sentinel_converter(value, sentinel=attr.NOTHING):
     return value
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Role(DiscordObject):
     _sentinel = object()
 

--- a/dis_snek/models/discord_objects/stage_instance.py
+++ b/dis_snek/models/discord_objects/stage_instance.py
@@ -6,13 +6,19 @@ from dis_snek.const import MISSING
 from dis_snek.models.discord import DiscordObject
 from dis_snek.models.snowflake import to_snowflake
 from dis_snek.models.enums import StagePrivacyLevel
-from dis_snek.utils.attr_utils import define
 
 if TYPE_CHECKING:
     from dis_snek.models import Guild, GuildStageVoice, Snowflake_Type
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class StageInstance(DiscordObject):
     topic: str = attr.ib()
     privacy_level: StagePrivacyLevel = attr.ib()

--- a/dis_snek/models/discord_objects/sticker.py
+++ b/dis_snek/models/discord_objects/sticker.py
@@ -7,7 +7,6 @@ from attr.converters import optional
 from dis_snek.const import MISSING
 from dis_snek.models.discord import DiscordObject
 from dis_snek.models.snowflake import to_snowflake
-from dis_snek.utils.attr_utils import define
 from dis_snek.utils.serializer import dict_filter_none
 
 if TYPE_CHECKING:

--- a/dis_snek/models/discord_objects/sticker.py
+++ b/dis_snek/models/discord_objects/sticker.py
@@ -33,7 +33,14 @@ class StickerFormatTypes(IntEnum):
     LOTTIE = 3
 
 
-@define(kw_only=False)
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=False,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class StickerItem(DiscordObject):
     name: str = attr.ib()
     """Name of the sticker."""
@@ -41,7 +48,14 @@ class StickerItem(DiscordObject):
     """Type of sticker image format."""
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Sticker(StickerItem):
     """Represents a sticker that can be sent in messages."""
 
@@ -121,7 +135,14 @@ class Sticker(StickerItem):
         await self._client.http.delete_guild_sticker(self._guild_id, self.id, reason)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class StickerPack(DiscordObject):
     """Represents a pack of standard stickers."""
 

--- a/dis_snek/models/discord_objects/team.py
+++ b/dis_snek/models/discord_objects/team.py
@@ -4,7 +4,6 @@ import attr
 
 from dis_snek.models.discord import DiscordObject
 from dis_snek.models.enums import TeamMembershipState
-from dis_snek.utils.attr_utils import define
 
 if TYPE_CHECKING:
     from dis_snek.models.discord_objects.user import User

--- a/dis_snek/models/discord_objects/team.py
+++ b/dis_snek/models/discord_objects/team.py
@@ -11,7 +11,14 @@ if TYPE_CHECKING:
     from dis_snek.models.snowflake import Snowflake_Type
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class TeamMember:
     membership_state: TeamMembershipState = attr.ib(converter=TeamMembershipState)
     permissions: List[str] = attr.ib(default=["*"])
@@ -19,7 +26,14 @@ class TeamMember:
     user: "User" = attr.ib()  # TODO: cache partial user (avatar, discrim, id, username)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Team(DiscordObject):
     icon: Optional[str] = attr.ib(default=None)
     members: List[TeamMember] = attr.ib(factory=list)

--- a/dis_snek/models/discord_objects/thread.py
+++ b/dis_snek/models/discord_objects/thread.py
@@ -6,7 +6,7 @@ from dis_snek.mixins.send import SendMixin
 from dis_snek.models.discord import DiscordObject, ClientObject
 from dis_snek.models.snowflake import to_snowflake
 from dis_snek.models.timestamp import Timestamp
-from dis_snek.utils.attr_utils import define, field
+from dis_snek.utils.attr_utils import field
 from dis_snek.utils.converters import timestamp_converter
 
 if TYPE_CHECKING:
@@ -59,7 +59,14 @@ class ThreadMember(DiscordObject, SendMixin):
         return await self._client.http.create_message(message_payload, dm_id)
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class ThreadList(ClientObject):
     """Represents a list of one or more threads."""
 

--- a/dis_snek/models/discord_objects/thread.py
+++ b/dis_snek/models/discord_objects/thread.py
@@ -18,7 +18,14 @@ if TYPE_CHECKING:
     from dis_snek.models.snowflake import Snowflake_Type
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class ThreadMember(DiscordObject, SendMixin):
     """A thread member is used to indicate whether a user has joined a thread or not."""
 

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -15,7 +15,7 @@ from dis_snek.models.enums import Permissions, PremiumTypes, UserFlags
 from dis_snek.models.snowflake import Snowflake_Type
 from dis_snek.models.snowflake import to_snowflake
 from dis_snek.models.timestamp import Timestamp
-from dis_snek.utils.attr_utils import define, field, class_defaults, docs
+from dis_snek.utils.attr_utils import field, class_defaults, docs
 from dis_snek.utils.converters import list_converter
 from dis_snek.utils.converters import timestamp_converter
 from dis_snek.utils.input_utils import _bytes_to_base64_data

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -35,7 +35,14 @@ class _SendDMMixin(SendMixin):
         return await self._client.http.create_message(message_payload, dm_id)
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class BaseUser(DiscordObject, _SendDMMixin):
     """Base class for User, essentially partial user discord model"""
 
@@ -78,7 +85,14 @@ class BaseUser(DiscordObject, _SendDMMixin):
         return [g for g in self._client.guilds if g.id in self.user_guilds]
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class User(BaseUser):
     bot: bool = field(repr=True, default=False, metadata=docs("Is this user a bot?"))
     system: bool = field(
@@ -108,7 +122,14 @@ class User(BaseUser):
         return data
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class SnakeBotUser(User):
     verified: bool = field(repr=True, metadata={"docs": ""})
     mfa_enabled: bool = field(default=False, metadata={"docs": ""})

--- a/dis_snek/models/discord_objects/webhooks.py
+++ b/dis_snek/models/discord_objects/webhooks.py
@@ -8,7 +8,6 @@ from dis_snek.const import MISSING
 from dis_snek.mixins.send import SendMixin
 from dis_snek.models.discord import DiscordObject
 from dis_snek.models.snowflake import to_snowflake
-from dis_snek.utils.attr_utils import define
 from dis_snek.utils.input_utils import _bytes_to_base64_data
 
 if TYPE_CHECKING:
@@ -34,7 +33,14 @@ class WebhookTypes(IntEnum):
     """Application webhooks are webhooks used with Interactions"""
 
 
-@define
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class Webhook(DiscordObject, SendMixin):
     type: WebhookTypes = attr.ib()
     """The type of webhook"""

--- a/dis_snek/models/snowflake.py
+++ b/dis_snek/models/snowflake.py
@@ -2,7 +2,7 @@ from contextlib import suppress
 from typing import Union, List
 
 from dis_snek.models.timestamp import Timestamp
-from dis_snek.utils.attr_utils import define, field
+from dis_snek.utils.attr_utils import field
 
 Snowflake_Type = Union[str, int]
 

--- a/dis_snek/models/snowflake.py
+++ b/dis_snek/models/snowflake.py
@@ -30,7 +30,14 @@ def to_snowflake_list(snowflakes: List[Union[Snowflake_Type, "SnowflakeObject"]]
     return [to_snowflake(c) for c in snowflakes]
 
 
-@define()
+@attr.define(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 class SnowflakeObject:
     id: "Snowflake_Type" = field(repr=True, converter=to_snowflake)
 

--- a/dis_snek/utils/attr_utils.py
+++ b/dis_snek/utils/attr_utils.py
@@ -8,18 +8,7 @@ from dis_snek.const import logger_name, MISSING
 log = logging.getLogger(logger_name)
 
 
-class_defaults = dict(
-    eq=False,
-    order=False,
-    hash=False,
-    slots=True,
-    kw_only=True,
-    on_setattr=[attr.setters.convert, attr.setters.validate],
-)
 field_defaults = dict(repr=False)
-
-
-define = partial(attr.define, **class_defaults)
 field = partial(attr.field, **field_defaults)
 
 

--- a/dis_snek/utils/attr_utils.py
+++ b/dis_snek/utils/attr_utils.py
@@ -7,8 +7,17 @@ from dis_snek.const import logger_name, MISSING
 
 log = logging.getLogger(logger_name)
 
-
+class_defaults = dict(
+    eq=False,
+    order=False,
+    hash=False,
+    slots=True,
+    kw_only=True,
+    on_setattr=[attr.setters.convert, attr.setters.validate],
+)
 field_defaults = dict(repr=False)
+
+
 field = partial(attr.field, **field_defaults)
 
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

A shortcut for `attr.define` with commonly-used options (`attr_utils.define`) had been used for a decent bit of the code. However, it also broke Visual Studio Code's typehinting, with the typehinting reporting the classes defined with this as `None` instead of themselves. This PR removes the shortcut in order to fix the typehinting and replaces the current instances of it with what the shortcut did.

## Changes

- Removed `attr_utils.define`
- Removed instances where `attr_utils.define` was used, and replaced it with what it did behind the scenes.
  - Special cases where parts of the shortcut were changed around were accounted for.

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code