### PR TITLE
Fix attr_utils.define shortcut for typehinting

### DIFF
--- a/dis_snek/utils/attr_utils.py
+++ b/dis_snek/utils/attr_utils.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Any, Dict
+from typing import Any, Dict, TypeVar, Callable
 
 import attr
 from dis_snek.const import logger_name, MISSING
@@ -19,7 +19,10 @@ class_defaults = dict(
 field_defaults = dict(repr=False)
 
 
-define = partial(attr.define, **class_defaults)
+# have to do some TypeVar weirdness in order to make classes defined
+# with the define decorator typehint properly in VSC
+_T = TypeVar("_T")
+define: Callable[[_T], _T] = partial(attr.define, **class_defaults)
 field = partial(attr.field, **field_defaults)
 
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

A shortcut for `attr.define` with commonly-used options (`attr_utils.define`) had been used for a decent bit of the code. However, it also broke Visual Studio Code's typehinting, with the typehinting reporting the classes defined with this as `None` instead of themselves. This PR fixes that.

## Changes

- Fix attr_utils.define shortcut for typehinting by using TypeVar and Callable

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
