### PR TITLE
INVISIBLE on bot stop

### DIFF
--- a/dis_snek/client.py
+++ b/dis_snek/client.py
@@ -398,6 +398,7 @@ class Snake(
 
     async def stop(self):
         log.debug("Stopping the bot.")
+        await self.change_presence(Status.INVISIBLE)
         await self.ws.close()
 
     def dispatch(self, event: events.BaseEvent, *args, **kwargs):


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

Fixes bots appearing online for some time after `bot.stop()` or <kbd>Ctrl</kbd> + <kbd>c</kbd>

## Changes

- Set the bot to INVISIBLE when going offline.

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
