### PR TITLE
fix spread_to_rows()

### DIFF
--- a/dis_snek/models/discord_objects/components.py
+++ b/dis_snek/models/discord_objects/components.py
@@ -321,7 +321,7 @@ def spread_to_rows(*components: Union[ActionRow, Button, Select], max_in_row=5) 
     # todo: incorrect format errors
     if not components or len(components) > 25:
         raise ValueError("Number of components should be between 1 and 25.")
-    if not 1 < max_in_row < 5:
+    if not 1 <= max_in_row <= 5:
         raise ValueError("max_in_row should be between 1 and 5.")
 
     rows = []


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

```py
Ignoring exception in cmd /`play`:
Traceback (most recent call last):
  File "C:\Users\user\Desktop\Coding\Python\snekk\venv\lib\site-packages\dis_snek\client.py", line 743, in _dispatch_interaction
    await command(ctx, **ctx.kwargs)
  File "C:\Users\user\Desktop\Coding\Python\snekk\venv\lib\site-packages\dis_snek\models\command.py", line 84, in __call__
    await self.callback(context, *args, **kwargs)
  File "C:\Users\user\Desktop\Coding\Python\snekk\scales\game.py", line 19, in play
    await ctx.send("click", components=spread_to_rows(*buttons, max_in_row=5))
  File "C:\Users\user\Desktop\Coding\Python\snekk\venv\lib\site-packages\dis_snek\models\discord_objects\components.py", line 325, in spread_to_rows
    raise ValueError("max_in_row should be between 1 and 5.")
ValueError: max_in_row should be between 1 and 5.
```

Used to be `if not 1 < max_in_row < 5:`
now `if not 1 <= max_in_row <= 5:`

## Changes

- `if not 1 < max_in_row < 5:` -> `if not 1 <= max_in_row <= 5:`

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
