### PR TITLE
Proper fix for `attr_utils.define`

### DIFF
--- a/dis_snek/utils/attr_utils.py
+++ b/dis_snek/utils/attr_utils.py
@@ -21,7 +21,7 @@ field_defaults = dict(repr=False)
 
 # have to do some TypeVar weirdness in order to make classes defined
 # with the define decorator typehint properly in VSC
-# credit to Proxy#9876 for the fix
+# credit to artem30801 for the fix
 _T = TypeVar("_T")
 
 

--- a/dis_snek/utils/attr_utils.py
+++ b/dis_snek/utils/attr_utils.py
@@ -21,8 +21,14 @@ field_defaults = dict(repr=False)
 
 # have to do some TypeVar weirdness in order to make classes defined
 # with the define decorator typehint properly in VSC
+# credit to Proxy#9876 for the fix
 _T = TypeVar("_T")
-define: Callable[[_T], _T] = partial(attr.define, **class_defaults)
+
+
+def define(cls: _T) -> _T:
+    return attr.define(cls, **class_defaults)
+
+
 field = partial(attr.field, **field_defaults)
 
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition 

## Description

As it turns out, the old fix did not work correctly with models.
Basically, for something like `dis_snek.models.context.Context`, trying to use it for typehinting in VSC would result in VSC incorrectly assuming it was of type `_T`, which does not work well with `Optional`, `Union`, or the like in `typing`.

## Changes

- Fix `attr_utils.define` by using a method @artem30801 suggested to me on Discord over using my own solution. *Probably* should have just done this.

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
