### PR TITLE
Fix wrong .send() file parameters

### DIFF
--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -208,7 +208,7 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
         stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        file: Optional[Union[str, "Path"]] = None,
+        file: Optional[Union["File", "IOBase", "Path", str]] = None,
         tts: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
         ephemeral: bool = False,
@@ -223,7 +223,7 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
             stickers: IDs of up to 3 stickers in the server to send in the message.
             allowed_mentions: Allowed mentions for the message.
             reply_to: Message to reference, must be from the same channel.
-            filepath: Location of file to send, defaults to None.
+            file: Location of file to send, the bytes or the File() instance, defaults to None.
             tts: Should this message use Text To Speech.
             flags: Message flags to apply.
             ephemeral bool: Should this message be sent as ephemeral (hidden)

--- a/dis_snek/models/discord_objects/webhooks.py
+++ b/dis_snek/models/discord_objects/webhooks.py
@@ -125,7 +125,7 @@ class Webhook(DiscordObject, SendMixin):
         stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        file: Optional[Union["IOBase", "Path", str]] = None,
+        file: Optional[Union["File", "IOBase", "Path", str]] = None,
         tts: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
         username: str = None,
@@ -141,7 +141,7 @@ class Webhook(DiscordObject, SendMixin):
             stickers: IDs of up to 3 stickers in the server to send in the message.
             allowed_mentions: Allowed mentions for the message.
             reply_to: Message to reference, must be from the same channel.
-            filepath: Location of file to send, defaults to None.
+            file: Location of file to send, the bytes or the File() instance, defaults to None.
             tts: Should this message use Text To Speech.
             flags: Message flags to apply.
             username: The username to use


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition 

## Description

Allow `File` as an option for the `file` parameter where it was missing before. Hopefully I didn't miss any more

## Changes

- Fix wrong .send() file parameters

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [ ] I've tested my code
