### PR TITLE
Properly typehint `attr_utils.py`

### DIFF
--- a/dis_snek/utils/attr_utils.py
+++ b/dis_snek/utils/attr_utils.py
@@ -20,7 +20,7 @@ field_defaults = dict(repr=False)
 
 
 define = partial(attr.define, **class_defaults)  # type: ignore
-field = partial(attr.field, **field_defaults)
+field = partial(attr.field, **field_defaults)  # type: ignore
 
 
 def copy_converter(value):

--- a/dis_snek/utils/attr_utils.pyi
+++ b/dis_snek/utils/attr_utils.pyi
@@ -1,10 +1,11 @@
 import attr
-from typing import Any, TypeVar, Callable, Tuple, Union
+import logging
+from typing import Any, TypeVar, Callable, Tuple, Union, Optional
 
 # this took way too lonk to solve
 # but this solution is based on https://www.attrs.org/en/stable/extending.html
 # or, well, more specifically, the pyright section
-# doing this in the actual file itself causes the function to return as a nonetype
+# doing this in the actual file itself causes the fucntion to return as a nonetype
 
 _T = TypeVar("_T")
 
@@ -15,5 +16,14 @@ def __dataclass_transform__(
     kw_only_default: bool = False,
     field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
 ) -> Callable[[_T], _T]: ...
+
+log: logging.Logger
+
+class_defaults: dict[str, bool | list[Callable]]
+field_defaults: dict[str, bool]
+
 @__dataclass_transform__(field_descriptors=(attr.attrib, attr.field))
-def define(**kwargs): ...
+def define(f: Optional[Callable] = None, **kwargs): ...
+def field(**kwargs) -> Any: ...
+def docs(doc_string: str) -> dict[str, str]: ...
+def str_validator(self, attribute: attr.Attribute, value: Any) -> None: ...

--- a/dis_snek/utils/attr_utils.pyi
+++ b/dis_snek/utils/attr_utils.pyi
@@ -5,7 +5,7 @@ from typing import Any, TypeVar, Callable, Tuple, Union, Optional
 # this took way too lonk to solve
 # but this solution is based on https://www.attrs.org/en/stable/extending.html
 # or, well, more specifically, the pyright section
-# doing this in the actual file itself causes the fucntion to return as a nonetype
+# doing this in the actual file itself causes the function to return as a nonetype
 
 _T = TypeVar("_T")
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

Introducing `attr_utils.pyi` broke typehinting, so this is a fix to that.

## Changes

- Typehinted everything from `attr_utils.py` into `attr_utils.pyi`
- Added `# type: ignore` to field in `attr_utils.py` to make PyCharm not complain.

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
