### PR TITLE
use int instead of string on_raw_guild_role_create

### DIFF
--- a/dis_snek/event_processors/role_events.py
+++ b/dis_snek/event_processors/role_events.py
@@ -14,7 +14,7 @@ class RoleEvents(EventMixinTemplate):
     async def _on_raw_guild_role_create(self, event: RawGatewayEvent) -> None:
         g_id = event.data.get("guild_id")
         role = self.cache.place_role_data(g_id, [event.data.get("role")])
-        self.dispatch(events.RoleCreate(g_id, role[event.data["role"]["id"]]))
+        self.dispatch(events.RoleCreate(g_id, role[int(event.data["role"]["id"])]))
 
     @listen()
     async def _on_raw_guild_role_update(self, event: RawGatewayEvent) -> None:


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description

https://github.com/Discord-Snake-Pit/Dis-Snek/blob/96611cec6ddbecec9e29b52f3dae3815ea91db5f/dis_snek/event_processors/role_events.py#L17
`event.data["role"]["id"]` is a str and when making a role you will get a `KeyError: '123456789'`
This is because it is looking for an int and not a string.

## Changes

- just slap int() around it.

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
