### PR TITLE
Yet another change to how application commands are processed

### DIFF
--- a/dis_snek/client.py
+++ b/dis_snek/client.py
@@ -54,6 +54,7 @@ from dis_snek.models import (
     ComponentCommand,
     to_optional_snowflake,
     Context,
+    application_commands_to_dict,
 )
 from dis_snek.models.discord_objects.components import get_components_ids, BaseComponent
 from dis_snek.models.enums import ComponentTypes, Intents, InteractionTypes, Status, ActivityType
@@ -643,78 +644,6 @@ class Snake(
         except Exception as e:
             await self.on_error("Interaction Syncing", e)
 
-    def application_commands_to_dict(self) -> dict:
-        """Convert the command list into a format that would be accepted by discord"""
-        cmd_bases = {}  # {cmd_base: [commands]}
-        """A store of commands organised by their base command"""
-        output = {}
-        """The output dictionary"""
-
-        def squash_subcommand(subcommands: List) -> Dict:
-            output_data = {}
-            groups = {}
-            sub_cmds = []
-            for subcommand in subcommands:
-                if not output_data:
-                    output_data = {
-                        "name": subcommand.name,
-                        "description": subcommand.description,
-                        "options": [],
-                        "permissions": subcommand.permissions,
-                        "default_permission": subcommand.default_permission,
-                    }
-                if subcommand.group_name:
-                    if subcommand.group_name not in groups:
-                        groups[subcommand.group_name] = {
-                            "name": subcommand.group_name,
-                            "description": subcommand.group_description,
-                            "type": OptionTypes.SUB_COMMAND_GROUP,
-                            "options": [subcommand.to_dict() | {"type": OptionTypes.SUB_COMMAND}],
-                        }
-                        continue
-                    groups[subcommand.group_name]["options"].append(
-                        subcommand.to_dict() | {"type": OptionTypes.SUB_COMMAND}
-                    )
-                else:
-                    sub_cmds.append(subcommand.to_dict() | {"type": OptionTypes.SUB_COMMAND})
-            options = [g for g in groups.values()] + sub_cmds
-            output_data["options"] = options
-            return output_data
-
-        for scope, cmds in self.interactions.items():
-            for cmd in cmds.values():
-                if cmd.name not in cmd_bases:
-                    cmd_bases[cmd.name] = [cmd]
-                    continue
-                if cmd not in cmd_bases[cmd.name]:
-                    cmd_bases[cmd.name].append(cmd)
-
-        for cmd_list in cmd_bases.values():
-            if any(c.is_subcommand for c in cmd_list):
-                # ensure all subcommands share the same scopes (discord req)
-                scopes: list[Snowflake_Type] = list(set(s for c in cmd_list for s in c.scopes))
-                permissions: dict = {k: v for c in cmd_list for k, v in c.permissions.items()}
-
-                if not all(c.description == cmd_list[0].description for c in cmd_list):
-                    log.warning(f"Conflicting descriptions found in {cmd_list[0].name} subcommands")
-                if not all(c.default_permission == cmd_list[0].default_permission for c in cmd_list):
-                    raise ValueError(f"Subcommands of {cmd_list[0].name} have conflicting `default_permission` values")
-
-                for cmd in cmd_list:
-                    cmd.scopes = list(scopes)
-                    cmd.permissions = permissions
-                cmd_data = squash_subcommand(cmd_list)
-            else:
-                scopes = cmd_list[0].scopes
-                cmd_data = cmd_list[0].to_dict()
-            for s in scopes:
-                if s not in output:
-                    output[s] = [cmd_data]
-                    continue
-                output[s].append(cmd_data)
-
-        return output
-
     async def _cache_interactions(self, warn_missing: bool = False):
         """Get all interactions used by this bot and cache them."""
         bot_scopes = set(g.id for g in self.cache.guild_cache.values())
@@ -782,7 +711,7 @@ class Snake(
 
         guild_perms = {}
 
-        cmds_json = self.application_commands_to_dict()
+        cmds_json = application_commands_to_dict(self.interactions)
 
         for cmd_scope in cmd_scopes:
             try:

--- a/dis_snek/client.py
+++ b/dis_snek/client.py
@@ -243,6 +243,17 @@ class Snake(
         """Get the activity of the bot"""
         return self._activity
 
+    @property
+    def application_commands(self):
+        """a list of all application commands registered within the bot"""
+        commands = []
+        for scope in self.interactions.keys():
+            for cmd in self.interactions[scope].values():
+                if cmd not in commands:
+                    commands.append(cmd)
+
+        return commands
+
     async def get_prefix(self, message: Message) -> str:
         """A method to get the bot's default_prefix, can be overridden to add dynamic prefixes.
 

--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -703,10 +703,10 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
         else:
             scopes = cmd_list[0].scopes
             cmd_data = cmd_list[0].to_dict()
-            for s in scopes:
-                if s not in output:
-                    output[s] = [cmd_data]
-                    continue
-                output[s].append(cmd_data)
+        for s in scopes:
+            if s not in output:
+                output[s] = [cmd_data]
+                continue
+            output[s].append(cmd_data)
 
     return output

--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import inspect
 import logging
 import re
@@ -7,7 +6,6 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, Callable, Coroutine, Dict, List, Union, Optional, Any
 
 import attr
-import deepdiff
 
 from dis_snek.const import (
     GLOBAL_SCOPE,

--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -349,6 +349,13 @@ class SlashCommand(InteractionCommand):
             if isinstance(value, list):
                 if len(value) > SLASH_CMD_MAX_OPTIONS:
                     raise ValueError(f"Slash commands can only hold {SLASH_CMD_MAX_OPTIONS} options")
+                if value != sorted(
+                    value,
+                    key=lambda x: x.required if isinstance(x, SlashCommandOption) else x["required"],
+                    reverse=True,
+                ):
+                    raise ValueError("Required options must go before optional options")
+
             else:
                 raise TypeError("Options attribute must be either None or a list of options")
 

--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -659,9 +659,8 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
                         "name": subcommand.group_name,
                         "description": subcommand.group_description,
                         "type": OptionTypes.SUB_COMMAND_GROUP,
-                        "options": [subcommand.to_dict() | {"type": OptionTypes.SUB_COMMAND}],
+                        "options": [],
                     }
-                    continue
                 groups[subcommand.group_name]["options"].append(
                     subcommand.to_dict() | {"type": OptionTypes.SUB_COMMAND}
                 )
@@ -681,7 +680,7 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
 
     for cmd_list in cmd_bases.values():
         if any(c.is_subcommand for c in cmd_list):
-            # ensure all subcommands share the same scopes (discord req)
+            # validate all commands share required attributes
             scopes: list[Snowflake_Type] = list(set(s for c in cmd_list for s in c.scopes))
             permissions: dict = {k: v for c in cmd_list for k, v in c.permissions.items()}
             base_description = next(
@@ -699,6 +698,7 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
                 cmd.scopes = list(scopes)
                 cmd.permissions = permissions
                 cmd.description = base_description
+            # end validation of attributes
             cmd_data = squash_subcommand(cmd_list)
         else:
             scopes = cmd_list[0].scopes

--- a/dis_snek/models/scale.py
+++ b/dis_snek/models/scale.py
@@ -109,6 +109,11 @@ class Scale:
         return self._commands
 
     @property
+    def listeners(self):
+        """Get the listeners from this Scale"""
+        return self._listeners
+
+    @property
     def name(self):
         return self.__name
 
@@ -122,8 +127,8 @@ class Scale:
                     self.bot._component_callbacks.pop(listener)
             elif isinstance(func, InteractionCommand):
                 for scope in func.scopes:
-                    if self.bot.interactions.get(scope) and self.bot.interactions[scope].get(func.name):
-                        self.bot.interactions[scope].pop(func.name)
+                    if self.bot.interactions.get(scope):
+                        self.bot.interactions[scope].pop(func.resolved_name, [])
             elif isinstance(func, MessageCommand):
                 if self.bot.commands[func.name]:
                     self.bot.commands.pop(func.name)

--- a/dis_snek/models/scale.py
+++ b/dis_snek/models/scale.py
@@ -4,7 +4,7 @@ import logging
 from typing import List, TYPE_CHECKING, Callable, Coroutine
 
 from dis_snek.const import logger_name
-from dis_snek.models.application_commands import InteractionCommand, ComponentCommand, SlashCommand, SubCommand
+from dis_snek.models.application_commands import InteractionCommand, ComponentCommand
 from dis_snek.models.command import MessageCommand, BaseCommand
 from dis_snek.models.listener import Listener
 from dis_snek.utils.misc_utils import wrap_partial
@@ -73,7 +73,7 @@ class Scale:
         new_cls = super().__new__(cls)
 
         for name, val in cls.__dict__.items():
-            if isinstance(val, BaseCommand) and not isinstance(val, SubCommand):
+            if isinstance(val, BaseCommand):
                 val.scale = new_cls
                 val = wrap_partial(val, new_cls)
 
@@ -120,7 +120,7 @@ class Scale:
             if isinstance(func, ComponentCommand):
                 for listener in func.listeners:
                     self.bot._component_callbacks.pop(listener)
-            elif isinstance(func, InteractionCommand) and not isinstance(func, SubCommand):
+            elif isinstance(func, InteractionCommand):
                 for scope in func.scopes:
                     if self.bot.interactions.get(scope) and self.bot.interactions[scope].get(func.name):
                         self.bot.interactions[scope].pop(func.name)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Im 90% sure this isn't breaking. 
This PR overhauls how commands are parsed and sent to Discord, in order to finally support Slash-Subcommands properly. Externally, all the same decorators will work, this is primarily an internal change. 
This PR also prevents unnecessary syncs of application commands, **including** subcommands

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- added `Snake.application_commands_to_dict()`
- Changed command storage to be done by resolved name, not name
- Hacky fix for caching interactions to detect changes
- Remove `SubCommand` and `SlashCommandMeta`
- Convert `SlashCommand` object to handle both slash and subcommands
- Add `is_subcommand` property to `SlashCommand`
- Sneaking in option order validation 
- Add `sync_needed` function to `application_commands`
- Tweaked `sync` and `cache` `interaction` methods in `Snake`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [ ] I've tested my code