### PR TITLE
Better Differentiate Error Handling

### DIFF
--- a/dis_snek/client.py
+++ b/dis_snek/client.py
@@ -427,7 +427,9 @@ class Snake(
 
         Override this to change error handling behavior
         """
-        return await self.on_error(f"Autocomplete Callback for /{ctx.invoked_name} - Option: {ctx.focussed_option}", error, *args, **kwargs)
+        return await self.on_error(
+            f"Autocomplete Callback for /{ctx.invoked_name} - Option: {ctx.focussed_option}", error, *args, **kwargs
+        )
 
     async def on_autocomplete(self, ctx: AutocompleteContext) -> None:
         """
@@ -440,7 +442,6 @@ class Snake(
 
         symbol = "$"
         log.info(f"Autocomplete Called: {symbol}{ctx.invoked_name} with {ctx.args = } | {ctx.kwargs = }")
-
 
     @listen()
     async def _on_websocket_ready(self, event: events.RawGatewayEvent) -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [x] Documentation change/addition 

## Description
This PR separates the error and post-completion handling for interactions into their own error handlers


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `on_component`
- Add `on_component_error`
- Add `on_autocomplete`
- Add `on_autocomplete_error`
- `on_command` now only fires on commands
- `on_command_error` now only fires on command errors

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
