### PR TITLE
updating app cmd permissions for new syntax

### DIFF
--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -692,7 +692,7 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
         if any(c.is_subcommand for c in cmd_list):
             # validate all commands share required attributes
             scopes: list[Snowflake_Type] = list(set(s for c in cmd_list for s in c.scopes))
-            permissions: dict = {k: v for c in cmd_list for k, v in c.permissions.items()}
+            permissions: list = [d for c in cmd_list for d in c.permissions]
             base_description = next(
                 (c.description for c in cmd_list if c.description is not None), "No Description Set"
             )


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
The v2 switch for perms changed permissions syntax. This is remaining code that is looking for a dict. Providing a list instead.


## Changes
- Processing of permissions from app_cmd objects


## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
