### PR TITLE
Allow value to be Any type

### DIFF
--- a/dis_snek/models/discord_objects/embed.py
+++ b/dis_snek/models/discord_objects/embed.py
@@ -253,7 +253,7 @@ class Embed(DictSerializationMixin):
         """
         self.footer = EmbedFooter(text=text, icon_url=icon_url)
 
-    def add_field(self, name: str, value: str, inline: bool = False) -> None:
+    def add_field(self, name: str, value: Any, inline: bool = False) -> None:
         """
         Add a field to the embed.
 
@@ -262,7 +262,7 @@ class Embed(DictSerializationMixin):
             value: The value in this field
             inline: Should this field be inline with other fields?
         """
-        self.fields.append(EmbedField(name, value, inline))
+        self.fields.append(EmbedField(name, str(value), inline))
         self._fields_validation("fields", self.fields)
 
 


### PR DESCRIPTION
Allows Embed value to be Any type as to avoid having to type cast each value.

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [X] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
Currently, if Embed values are anything besides a str unless you type cast the value, it will fail. Example:

>e.add_field("test", 1)
>TypeError: object of type 'int' has no len()  

Discord requires `value` to be `str`; changing value to Any resolves the issue and idiot proofs it.


## Changes
-  From `def add_field(self, name: str, value: str, inline: bool = False) -> None:`  to  `def add_field(self, name: str, value: Any, inline: bool = False) -> None:`
- From `self.fields.append(EmbedField(name, value, inline))` to `self.fields.append(EmbedField(name, str(value), inline))`




## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [ ] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.9.x`
- [X] I've tested my code
