### PR TITLE
Basic Converter support

### DIFF
--- a/docs/src/Guides/3 Creating Commands.md
+++ b/docs/src/Guides/3 Creating Commands.md
@@ -350,3 +350,33 @@ client = CustomErrorSnake(...)
 ```
 
 There also is `on_command` which you can overwrite too. That fires on every interactions usage.
+
+## I need a custom parameter type
+
+If your bot is complex enough, you might find yourself wanting to use custom models in your commands.
+To do this, you'll want to use a string option, and define a converter:
+
+```python
+class DatabaseEntry():
+    name: str
+    description: str
+    score: int
+
+    @classmethod
+    def convert(cls, ctx: Context, value: str) -> DatabaseEntry:
+        """This is where the magic happens"""
+        return cls(hypothetical_database.lookup(ctx.guild.id, value))
+
+@slash_command(name="lookup", description="Gives info about a thing from the db")
+@slash_option(
+    name="thing", 
+    description="The user enters a string", 
+    required=True, 
+    opt_type=OptionTypes.STRING
+)
+async def my_command_function(ctx: InteractionContext, thing: DatabaseEntry):
+    await ctx.send(f"***{thing.name}***\n{thing.description}\nScore: {thing.score}/10")
+```
+
+As you can see, a converter can transparently convert what Discord sends you (a string, a user, etc) into something more complex (A pokemon card, a scoresheet, etc).
+This can be useful if you frequently find yourself starting commands with `thing = lookup(thing_name)`


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
This adds support for custom parameter converters.  
As mentioned in the (rather awful) description I added to the documentation, these are useful for reducing boilerplate when you need to do database lookups to actually get the data needed to do your command

## Changes

- Created a lightweight wrapper that's called from `call_callback` when preparing arguments.

As mentioned in Discord, this system should potentially be used to ensure parameters from MessageCommands are the correct types, as currently everything is passed through as a string regardless of annotations.  This PR does not do that.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
