### PR TITLE
If slash_command(description=) isn't set, attempt to pull it from the coroutine's docstring

### DIFF
--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -463,7 +463,7 @@ class ComponentCommand(InteractionCommand):
 
 def slash_command(
     name: str,
-    description: str = "No Description Set",
+    description: str = MISSING,
     scopes: List["Snowflake_Type"] = MISSING,
     options: Optional[List[Union[SlashCommandOption, Dict]]] = None,
     default_permission: bool = True,
@@ -501,13 +501,17 @@ def slash_command(
         if not asyncio.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
+        _description = description
+        if _description is MISSING:
+            _description = func.__doc__ if func.__doc__ else "No Description Set"
+
         cmd = SlashCommand(
             name=name,
             group_name=group_name,
             group_description=group_description,
             sub_cmd_name=sub_cmd_name,
             sub_cmd_description=sub_cmd_description,
-            description=description,
+            description=_description,
             scopes=scopes if scopes else [GLOBAL_SCOPE],
             default_permission=default_permission,
             permissions=permissions or {},

--- a/dis_snek/models/checks.py
+++ b/dis_snek/models/checks.py
@@ -62,7 +62,7 @@ def is_owner():
     """
 
     async def check(ctx: Context) -> bool:
-        return ctx.author.id == ctx.bot.owner
+        return ctx.author.id == ctx.bot.owner.id
 
     return check
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
I find putting ~80 character strings in the decorator is worse on code readability than using a docstring to explain what a command does. 


## Changes
This PR adds support for checking the docstring before falling back to "No Description Set"


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
