### PR TITLE
Add `Role.members` and make `Member.has_role` synchronous

### DIFF
--- a/dis_snek/models/application_commands.py
+++ b/dis_snek/models/application_commands.py
@@ -178,7 +178,7 @@ class InteractionCommand(BaseCommand):
         # I wish this wasn't needed, but unfortunately Discord permissions cant be trusted to actually prevent usage
         for perm in self.permissions:
             if perm.type == PermissionTypes.ROLE:
-                if await ctx.author.has_role(perm.id):
+                if ctx.author.has_role(perm.id):
                     if perm.permission is True:
                         return True
                     elif self.default_permission is True:

--- a/dis_snek/models/checks.py
+++ b/dis_snek/models/checks.py
@@ -16,7 +16,7 @@ def has_role(role: Union[Snowflake_Type, Role]):
     async def check(ctx: Context) -> bool:
         if ctx.guild is None:
             return False
-        return await ctx.author.has_role(role)
+        return ctx.author.has_role(role)
 
     return check
 

--- a/dis_snek/models/discord_objects/role.py
+++ b/dis_snek/models/discord_objects/role.py
@@ -79,6 +79,10 @@ class Role(DiscordObject):
         """Is this role owned/managed by a integration"""
         return self.tags.integration_id is not None
 
+    @property
+    def members(self) -> list["Member"]:
+        return [member for member in self.guild.members if member.has_role(self)]
+
     async def is_assignable(self) -> bool:
         """Can this role be assigned or removed by this bot?
         !!! note:

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -406,7 +406,7 @@ class Member(DiscordObject, _SendDMMixin):
             role = role.id
         return await self._client.http.remove_guild_member_role(self._guild_id, self.id, role, reason=reason)
 
-    async def has_role(self, *roles: Union[Snowflake_Type, Role]) -> bool:
+    def has_role(self, *roles: Union[Snowflake_Type, Role]) -> bool:
         """
         Checks if the user has the given role(s)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition 

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Turn `Member.has_role` into a synchronous function, and add the `Role.members` property
This pr is breaking because devs who used `Member.has_role` will have to remove the preceding `await`. Because of that, this pr should probably only be merged once a new major version is about to be published

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Turned Member.has_role into a synchronous function
- Changed all uses of the above to reflect changes (except for the one that wasn't awaited)
- add the `Role.members` property, which iterates over the members in a guild to check if they have a role

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
