### PR TITLE
Add missing build requirement to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ tomli = "1.2.2"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["setuptools", "poetry-core>=1.0.0"]
+requires = ["setuptools", "poetry-core>=1.0.0", "tomli"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
When trying to install dis-snek with build isolation enabled (ie, when installing in editable mode), pip sets up a specific build environment to run setup.py.  Without tomli listed in build-requirements, this will always fail with an import error.


## Changes
Added missing requirement.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
