### PR TITLE
Fix `ComponentContext.values`

### DIFF
--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -251,7 +251,11 @@ class ComponentContext(InteractionContext):
         new_cls.custom_id = data["data"]["custom_id"]
         new_cls.component_type = data["data"]["component_type"]
         new_cls.message = client.cache.place_message_data(data["message"])
-        new_cls.values = data["data"]["values"]
+
+        if "values" in data["data"]:
+            new_cls.values = data["data"]["values"]
+        else:
+            new_cls.values = []
 
         return new_cls
 

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -251,11 +251,7 @@ class ComponentContext(InteractionContext):
         new_cls.custom_id = data["data"]["custom_id"]
         new_cls.component_type = data["data"]["component_type"]
         new_cls.message = client.cache.place_message_data(data["message"])
-
-        if "values" in data["data"]:
-            new_cls.values = data["data"]["values"]
-        else:
-            new_cls.values = []
+        new_cls.values = data["data"].get("values", [])
 
         return new_cls
 

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -251,7 +251,7 @@ class ComponentContext(InteractionContext):
         new_cls.custom_id = data["data"]["custom_id"]
         new_cls.component_type = data["data"]["component_type"]
         new_cls.message = client.cache.place_message_data(data["message"])
-        new_cls.values = data['data']['values']
+        new_cls.values = data["data"]["values"]
 
         return new_cls
 

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -238,7 +238,7 @@ class ComponentContext(InteractionContext):
     custom_id: str = attr.ib(default="", metadata=docs("The ID given to the component that has been pressed"))
     component_type: int = attr.ib(default=0, metadata=docs("The type of component that has been pressed"))
 
-    values: List = attr.ib(factory=list, metadata=docs("The values set"))  # todo: Polls, check this
+    values: List = attr.ib(factory=list, metadata=docs("The values set"))
 
     defer_edit_origin: bool = attr.ib(default=False, metadata=docs("Are we editing the message the component is on"))
 
@@ -251,6 +251,7 @@ class ComponentContext(InteractionContext):
         new_cls.custom_id = data["data"]["custom_id"]
         new_cls.component_type = data["data"]["component_type"]
         new_cls.message = client.cache.place_message_data(data["message"])
+        new_cls.values = data['data']['values']
 
         return new_cls
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Previously, `ComponentContext.values` would always give an empty list. Now it gives a list of the values of the options the user chose (in string form) 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- `ComponentContext.from_dict` sets `.values` to `data['data']['values']`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code
