### PR TITLE
Improvements to doc templates

### DIFF
--- a/docs/templates/python/material/attr_attributes.html
+++ b/docs/templates/python/material/attr_attributes.html
@@ -1,0 +1,22 @@
+{{ log.debug() }}
+<p><strong>Attr attributes:</strong></p>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for attribute in attributes %}
+      {% if 'attrs-field' in attribute.properties and (config.show_if_no_docstring or attribute.has_contents) %}
+      <tr>
+        <td><code>{{ attribute.name }}</code></td>
+          <td>{% if attribute.type %}<code>{{ attribute.type }}</code>{% endif %}</td>
+        <td>{% if attribute.docstring %}{{ attribute.docstring|convert_markdown(heading_level, html_id) }}{% endif %}</td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+  </tbody>
+</table>

--- a/docs/templates/python/material/children.html
+++ b/docs/templates/python/material/children.html
@@ -1,0 +1,101 @@
+{{ log.debug() }}
+{% if obj.children %}
+
+  <div class="doc doc-children">
+
+    {% if config.group_by_category %}
+
+      {% with %}
+
+        {% if config.show_category_heading %}
+          {% set extra_level = 1 %}
+        {% else %}
+          {% set extra_level = 0 %}
+        {% endif %}
+
+        {% if config.show_category_heading and obj.attributes|any("has_contents") and 'attrs' not in class.properties %}
+          {% filter heading(heading_level, id=html_id ~ "-attributes") %}Attributes{% endfilter %}
+        {% endif %}
+        {% with heading_level = heading_level + extra_level %}
+          {% for attribute in obj.attributes %}
+            {% if 'attrs-field' not in attribute.properties %}
+              {% include "attribute.html" with context %}
+            {% endif %}
+          {% endfor %}
+        {% endwith %}
+
+        {% if config.show_category_heading and obj.classes|any("has_contents") %}
+          {% filter heading(heading_level, id=html_id ~ "-classes") %}Classes{% endfilter %}
+        {% endif %}
+        {% with heading_level = heading_level + extra_level %}
+          {% for class in obj.classes %}
+            {% include "class.html" with context %}
+          {% endfor %}
+        {% endwith %}
+
+        {% if config.show_category_heading and obj.functions|any("has_contents") %}
+          {% filter heading(heading_level, id=html_id ~ "-functions") %}Functions{% endfilter %}
+        {% endif %}
+        {% with heading_level = heading_level + extra_level %}
+          {% for function in obj.functions %}
+            {% include "function.html" with context %}
+          {% endfor %}
+        {% endwith %}
+
+        {% if config.show_category_heading and obj.methods|any("has_contents") %}
+          {% filter heading(heading_level, id=html_id ~ "-methods") %}Methods{% endfilter %}
+        {% endif %}
+        {% with heading_level = heading_level + extra_level %}
+          {% for method in obj.methods %}
+            {% include "method.html" with context %}
+          {% endfor %}
+        {% endwith %}
+
+        {% if config.show_category_heading and obj.modules|any("has_contents") %}
+          {% filter heading(heading_level, id=html_id ~ "-modules") %}Modules{% endfilter %}
+        {% endif %}
+        {% with heading_level = heading_level + extra_level %}
+          {% for module in obj.modules %}
+            {% include "module.html" with context %}
+          {% endfor %}
+        {% endwith %}
+
+      {% endwith %}
+
+    {% else %}
+
+      {% for child in obj.children %}
+        {% if child.category == "attribute" and 'attrs-field' not in child.properties %}
+          {% with attribute = child %}
+            {% include "attribute.html" with context %}
+          {% endwith %}
+
+        {% elif child.category == "class" %}
+          {% with class = child %}
+            {% include "class.html" with context %}
+          {% endwith %}
+
+        {% elif child.category == "function" %}
+          {% with function = child %}
+            {% include "function.html" with context %}
+          {% endwith %}
+
+        {% elif child.category == "method" %}
+          {% with method = child %}
+            {% include "method.html" with context %}
+          {% endwith %}
+
+        {% elif child.category == "module" %}
+          {% with module = child %}
+            {% include "module.html" with context %}
+          {% endwith %}
+
+        {% endif %}
+
+      {% endfor %}
+
+    {% endif %}
+
+  </div>
+
+{% endif %}

--- a/docs/templates/python/material/class.html
+++ b/docs/templates/python/material/class.html
@@ -1,0 +1,84 @@
+{{ log.debug() }}
+{% if config.show_if_no_docstring or class.has_contents %}
+
+  <div class="doc doc-object doc-class">
+  {% with html_id = class.path %}
+
+    {% if not root or config.show_root_heading %}
+
+      {% if root %}
+        {% set show_full_path = config.show_root_full_path %}
+        {% set root_members = True %}
+      {% elif root_members %}
+        {% set show_full_path = config.show_root_members_full_path or config.show_object_full_path %}
+        {% set root_members = False %}
+      {% else %}
+        {% set show_full_path = config.show_object_full_path %}
+      {% endif %}
+
+      {% filter heading(heading_level,
+          role="class",
+          id=html_id,
+          class="doc doc-heading",
+          toc_label=class.name) %}
+
+        {% with properties = class.properties %}
+          {% include "properties.html" with context %}
+        {% endwith %}
+
+        <span class="doc doc-properties">
+            <small class="doc doc-property"><code>class</code></small>
+        </span>
+
+        <code>
+          {% if show_full_path %}{{ class.path }}{% else %} {{ class.name }}{% endif %}
+          {% if config.show_bases and class.bases and class.bases != ['object'] %}
+            ({% for base in class.bases -%}
+              {{ base|brief_xref() }}{% if not loop.last %}, {% endif %}
+             {% endfor %})
+          {% endif %}
+        </code>
+
+      {% endfilter %}
+
+    {% else %}
+      {% if config.show_root_toc_entry %}
+        {% filter heading(heading_level,
+            role="class",
+            id=html_id,
+            toc_label=class.path,
+            hidden=True) %}
+        {% endfilter %}
+      {% endif %}
+      {% set heading_level = heading_level - 1 %}
+    {% endif %}
+
+    <div class="doc doc-contents {% if root %}first{% endif %}">
+      {% with docstring_sections = class.docstring_sections %}
+        {% include "docstring.html" with context %}
+      {% endwith %}
+
+      {% if 'attrs' in class.properties %}
+        {% with attributes = class.attributes %}
+          {% include "attr_attributes.html" with context %}
+        {% endwith %}
+      {% endif %}
+
+      {% if config.show_source and class.source %}
+        <details class="quote">
+          <summary>Source code in <code>{{ class.relative_file_path }}</code></summary>
+          {{ class.source.code|highlight(language="python", linestart=class.source.line_start, linenums=False) }}
+        </details>
+      {% endif %}
+
+      {% with obj = class %}
+        {% set root = False %}
+        {% set heading_level = heading_level + 1 %}
+        {% include "children.html" with context %}
+      {% endwith %}
+    </div>
+
+  {% endwith %}
+  </div>
+
+{% endif %}

--- a/docs/templates/python/material/function.html
+++ b/docs/templates/python/material/function.html
@@ -26,6 +26,10 @@
           {% include "properties.html" with context %}
         {% endwith %}
 
+        <span class="doc doc-properties">
+            <small class="doc doc-property"><code>function</code></small>
+        </span>
+
         {% filter highlight(language="python", inline=True) %}
           {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
           {% with signature = function.signature %}{% include "signature.html" with context %}{% endwith %}

--- a/docs/templates/python/material/method.html
+++ b/docs/templates/python/material/method.html
@@ -26,6 +26,10 @@
           {% include "properties.html" with context %}
         {% endwith %}
 
+        <span class="doc doc-properties">
+          <small class="doc doc-property"><code>method</code></small>
+        </span>
+
         {% filter highlight(language="python", inline=True) %}
           {% if show_full_path %}{{ method.path }}{% else %}{{ method.name }}{% endif %}
           {% with signature = method.signature %}{% include "signature.html" with context %}{% endwith %}

--- a/docs/templates/python/material/signature.html
+++ b/docs/templates/python/material/signature.html
@@ -1,0 +1,31 @@
+{{ log.debug() }}
+{%- if signature -%}
+  {%- with -%}
+    {%- set ns = namespace(render_pos_only_separator=True, render_kw_only_separator=True, equal="=") -%}
+
+    {%- if config.show_signature_annotations -%}
+      {%- set ns.equal = " = " -%}
+    {%- endif -%}
+
+    ({%- for parameter in signature.parameters %}{% if parameter.kind == "POSITIONAL_ONLY" -%}
+      {%- if ns.render_pos_only_separator -%}
+        {%- set ns.render_pos_only_separator = False %}/, {% endif -%}
+      {%- elif parameter.kind == "KEYWORD_ONLY" -%}
+        {%- if ns.render_kw_only_separator -%}
+          {%- set ns.render_kw_only_separator = False %}*, {% endif -%}
+      {%- endif -%}
+      {%- if config.show_signature_annotations and "annotation" in parameter -%}
+        {%- set annotation = ": " + parameter.annotation|safe -%}
+      {%- endif -%}
+      {%- if "default" in parameter -%}
+        {%- set default = ns.equal + parameter.default|safe -%}
+      {%- endif -%}
+      {%- if parameter.kind == "VAR_POSITIONAL" %}*
+        {%- set render_kw_only_separator = False -%}
+      {%- elif parameter.kind == "VAR_KEYWORD" %}**
+      {%- endif %}{{ parameter.name }}{{ annotation }}{% if not loop.last %}, {% endif -%}
+    {%- endfor %}){% if config.show_signature_annotations and "return_annotation" in signature %} -> {{ signature.return_annotation }}
+    {%- endif -%}
+
+  {%- endwith -%}
+{%- endif -%}


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [ ] Breaking code change
- [X] Documentation change/addition 

## Description & Changes
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR:

- Changes docs templates to enable the display of attr attributes in form of the table
- Moves class properties ("attr" etc) to be prefixes instead of postfixes
- Adds "class", "function", "method" prefix to respective doc members for clarity

Works best when attr docs are specified like on the screenshot:
![image](https://user-images.githubusercontent.com/38689676/144711987-c98d19b3-ce19-4d98-a11a-6e2c2c6d9aff.png)


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [ ] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.9.x`
- [X] I've tested my code
