### PR TITLE
Support Timestamp in get_messages()

### DIFF
--- a/dis_snek/http_client.py
+++ b/dis_snek/http_client.py
@@ -28,6 +28,7 @@ from dis_snek.http_requests import (
     ThreadRequests,
     UserRequests,
     WebhookRequests,
+    ScheduledEventsRequests,
 )
 from dis_snek.models import CooldownSystem
 from dis_snek.models.route import Route
@@ -63,6 +64,7 @@ class HTTPClient(
     ThreadRequests,
     UserRequests,
     WebhookRequests,
+    ScheduledEventsRequests,
 ):
     """A http client for sending requests to the Discord API."""
 

--- a/dis_snek/http_requests/__init__.py
+++ b/dis_snek/http_requests/__init__.py
@@ -10,3 +10,4 @@ from dis_snek.http_requests.stickers import StickerRequests  # noqa
 from dis_snek.http_requests.threads import ThreadRequests  # noqa
 from dis_snek.http_requests.users import UserRequests  # noqa
 from dis_snek.http_requests.webhooks import WebhookRequests  # noqa
+from dis_snek.http_requests.scheduled_events import ScheduledEventsRequests  # noqa

--- a/dis_snek/http_requests/scheduled_events.py
+++ b/dis_snek/http_requests/scheduled_events.py
@@ -1,0 +1,133 @@
+from typing import Any
+from dis_snek.const import MISSING
+from dis_snek.models.route import Route
+from dis_snek.models.snowflake import Snowflake_Type
+from urllib.parse import urlencode
+
+
+class ScheduledEventsRequests:
+    request: Any
+
+    async def list_schedules_events(self, guild_id: "Snowflake_Type", with_user_count: bool = False) -> list[dict]:
+        """
+        Get the scheduled events for a guild.
+
+        parameters:
+            guild_id: The guild to get scheduled events from
+            with_user_count: Whether to include the user count in the response
+        returns:
+            List of Scheduled Events or None
+        """
+        return await self.request(
+            Route("GET", f"/guilds/{guild_id}/scheduled-events?with_user_count={with_user_count}")
+        )
+
+    async def get_scheduled_event(
+        self, guild_id: "Snowflake_Type", scheduled_event_id: "Snowflake_Type", with_user_count: bool = False
+    ) -> dict:
+        """
+        Get a scheduled event for a guild.
+
+        parameters:
+            guild_id: The guild to get scheduled event from
+            with_user_count: Whether to include the user count in the response
+        returns:
+            Scheduled Event or None
+        """
+        return await self.request(
+            Route("GET", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}?with_user_count={with_user_count}")
+        )
+
+    async def create_scheduled_event(
+        self,
+        guild_id: "Snowflake_Type",
+        payload: dict,
+        reason: str = MISSING,
+    ) -> dict:
+        """
+        Create a scheduled event for a guild.
+
+        parameters:
+            guild_id: The guild to create scheduled event from
+            payload: The scheduled event payload
+            reason: The reason to be displayed in audit logs
+        returns:
+            Scheduled Event or None
+        """
+        return await self.request(Route("POST", f"/guilds/{guild_id}/scheduled-events"), data=payload, reason=reason)
+
+    async def modify_scheduled_event(
+        self,
+        guild_id: "Snowflake_Type",
+        scheduled_event_id: "Snowflake_Type",
+        payload: dict,
+        reason: str = MISSING,
+    ) -> dict:
+        """
+        Modify a scheduled event for a guild.
+
+        parameters:
+            guild_id: The guild to modify scheduled event from
+            scheduled_event_id: The scheduled event to modify
+            payload: The payload to modify the scheduled event with
+            reason: The reason to be displayed in audit logs
+        returns:
+            Scheduled Event or None
+        """
+        return await self.request(
+            Route("PATCH", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}"), data=payload, reason=reason
+        )
+
+    async def delete_scheduled_event(
+        self,
+        guild_id: "Snowflake_Type",
+        scheduled_event_id: "Snowflake_Type",
+        reason: str = MISSING,
+    ) -> dict:
+        """
+        Delete a scheduled event for a guild.
+
+        parameters:
+            guild_id: The guild to delete scheduled event from
+            scheduled_event_id: The scheduled event to delete
+            reason: The reason to be displayed in audit logs
+        returns:
+            Scheduled Event or None
+        """
+        return await self.request(
+            Route("DELETE", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}", reason=reason)
+        )
+
+    async def get_scheduled_event_users(
+        self,
+        guild_id: "Snowflake_Type",
+        scheduled_event_id: "Snowflake_Type",
+        limit: int = 100,
+        with_member: bool = False,
+        before: "Snowflake_Type" = MISSING,
+        after: "Snowflake_Type" = MISSING,
+    ) -> list[dict]:
+        """
+        Get the users for a scheduled event.
+
+        parameters:
+            guild_id: The guild to get scheduled event users from
+            scheduled_event_id: The scheduled event to get users from
+            with_count: Whether to include the user count in the response
+        returns:
+            List of Scheduled Event Users or None
+        """
+        query_params = urlencode(
+            {
+                "limit": limit,
+                "with_memeber": with_member,
+                "before": before,
+                "after": after,
+            }
+        )
+        return await self.request(
+            Route(
+                "GET",
+                f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}/users{query_params}",
+            )
+        )

--- a/dis_snek/models/__init__.py
+++ b/dis_snek/models/__init__.py
@@ -37,3 +37,4 @@ from .discord_objects.thread import *
 from .discord_objects.user import *
 from .discord_objects.webhooks import *
 from .discord_objects.voice_state import *
+from .discord_objects.scheduled_event import *

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -177,10 +177,10 @@ class MessageableMixin(SendMixin):
         Fetch multiple messages from the channel. 
 
         Args:
-            limit: Max number of messages to return, default `50`, 1 request for every 100 messages
-            around: Will get limit/2 in each direction from given `Snowflake`
-            before: Message to get messages before
-            after: Message to get messages after
+            limit: Max number of messages to return, default `50`
+            around: Snowflake | Timestamp to get messages around
+            before: Snowflake | Timestamp to get messages before
+            after: Snowflake | Timestamp to get messages after
 
         Returns:
             A list of messages fetched.

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -1,5 +1,3 @@
-from logging import log
-import logging
 import time
 from collections import namedtuple
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Callable
@@ -42,9 +40,6 @@ if TYPE_CHECKING:
     from dis_snek.models.discord_objects.message import Message
     from dis_snek.models.discord_objects.user import User, Member
     from dis_snek.models.snowflake import Snowflake_Type
-from dis_snek.const import logger_name
-
-log = logging.getLogger(logger_name)
 
 
 class ChannelHistory(AsyncIterator):

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -168,7 +168,7 @@ class MessageableMixin(SendMixin):
 
     async def get_messages(
         self,
-        limit: int = MISSING,
+        limit: int = 50,
         around: Union["Timestamp", "Snowflake_Type"] = MISSING,
         before: Union["Timestamp", "Snowflake_Type"] = MISSING,
         after: Union["Timestamp", "Snowflake_Type"] = MISSING,
@@ -202,110 +202,7 @@ class MessageableMixin(SendMixin):
             else:
                 after = to_snowflake(after)
 
-        if around and before or around and after:
-            raise ValueError("Around may not be used with Before or After")
-
-        if before and after:
-            if limit != MISSING:
-                log.warning("Limit ignored when using Before/After search")
-            before_time = round(Timestamp.from_snowflake(before).timestamp() * 1000)
-            after_time = round(Timestamp.from_snowflake(after).timestamp() * 1000)
-            if before_time < after_time:
-                raise ValueError("Before must precede After. Did you accidentally swap them?")
-
-            before_id = await self._client.http.get_channel_messages(
-                self.id, limit=1, before=MISSING, after=MISSING, around=before
-            )
-            if len(before_id) == 0:
-                raise ValueError("Before message not found")
-            before_id = before_id[0].get("id")
-            messages_data = await self._client.http.get_channel_messages(
-                self.id, limit=100, before=MISSING, after=after, around=MISSING
-            )
-            while before_id not in [m.get("id") for m in messages_data]:
-                next_messages_data = await self._client.http.get_channel_messages(
-                    self.id, limit=100, before=MISSING, after=messages_data[-1].get("id"), around=MISSING
-                )
-                messages_data.extend(next_messages_data)
-
-            messages_data = messages_data[
-                messages_data.index(next(m for m in messages_data if m.get("id") == before_id)) :
-            ]  # chops off out of range messages
-
-        elif limit > 100:
-            messages_data = await self._client.http.get_channel_messages(
-                self.id, limit=100, before=before, after=after, around=around
-            )
-            if after or before:
-                if after:
-                    messages_data = messages_data[::-1]
-                for i in range(0, limit, 100):
-                    if before:
-                        before = messages_data[-1].get("id")
-                    elif after:
-                        after = messages_data[-1].get("id")
-                    new_limit = min(limit - i, 100)
-                    next_messages_data = await self._client.http.get_channel_messages(
-                        self.id, limit=new_limit, before=before, after=after, around=around
-                    )
-                    if after:
-                        next_messages_data = next_messages_data[::-1]
-                    messages_data.extend(next_messages_data)
-                    if len(next_messages_data) < 100:
-                        break
-            elif around:
-                shared_limit = limit - len(messages_data)
-                if (shared_limit % 2) == 0:
-                    before_total = shared_limit // 2
-                    after_total = before_total
-                else:
-                    div_odd = lambda n: (n // 2, n // 2 + 1)
-                    before_total, after_total = div_odd(shared_limit)
-
-                if before_total <= 100:
-                    next_messages_data = await self._client.http.get_channel_messages(
-                        self.id, limit=before_total, before=messages_data[-1].get("id"), after=MISSING, around=MISSING
-                    )
-                    messages_data.extend(next_messages_data)
-                else:
-                    next_messages_data = await self._client.http.get_channel_messages(
-                        self.id, limit=100, before=before, after=MISSING, around=MISSING
-                    )
-                    for i in range(0, before_total, 100):
-                        before = messages_data[-1].get("id")
-                        new_limit = min(before_total - i, 100)
-                        next_messages_data = await self._client.http.get_channel_messages(
-                            self.id, limit=new_limit, before=before, after=MISSING, around=MISSING
-                        )
-                        messages_data.extend(next_messages_data)
-                        if len(next_messages_data) < 100:
-                            break
-
-                if after_total <= 100:
-                    next_messages_data = await self._client.http.get_channel_messages(
-                        self.id, limit=after_total, before=MISSING, after=messages_data[0].get("id"), around=MISSING
-                    )
-                    messages_data = next_messages_data + messages_data
-                else:
-                    next_messages_data = await self._client.http.get_channel_messages(
-                        self.id, limit=100, before=MISSING, after=after, around=MISSING
-                    )
-                    messages_data = messages_data[::-1]
-                    for i in range(0, after_total, 100):
-                        after = messages_data[-1].get("id")
-                        new_limit = min(after_total - i, 100)
-                        next_messages_data = await self._client.http.get_channel_messages(
-                            self.id, limit=new_limit, before=MISSING, after=after, around=MISSING
-                        )
-                        next_messages_data = next_messages_data[::-1]
-                        messages_data.extend(next_messages_data)
-                        if len(next_messages_data) < 100:
-                            break
-
-        else:
-            if limit == MISSING:
-                limit = 50
-            messages_data = await self._client.http.get_channel_messages(self.id, limit, around, before, after)
+        messages_data = await self._client.http.get_channel_messages(self.id, limit, around, before, after)
         return [self._client.cache.place_message_data(message_data) for message_data in messages_data]
 
     async def get_pinned_messages(self) -> List["Message"]:

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -174,7 +174,7 @@ class MessageableMixin(SendMixin):
         after: Union["Timestamp", "Snowflake_Type"] = MISSING,
     ) -> List["Message"]:
         """
-        Fetch multiple messages from the channel. 
+        Fetch multiple messages from the channel.
 
         Args:
             limit: Max number of messages to return, default `50`

--- a/dis_snek/models/discord_objects/scheduled_event.py
+++ b/dis_snek/models/discord_objects/scheduled_event.py
@@ -1,0 +1,146 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+import attr
+from attr.converters import optional
+from dis_snek.const import MISSING
+from dis_snek.models.discord import DiscordObject
+
+from dis_snek.models.snowflake import Snowflake_Type, to_snowflake
+from dis_snek.models.timestamp import Timestamp
+from dis_snek.utils.attr_utils import define
+from dis_snek.utils.converters import timestamp_converter
+
+
+from enum import IntEnum
+
+if TYPE_CHECKING:
+    from dis_snek.client import Snake
+    from dis_snek.models.discord_objects.channel import GuildStageVoice, GuildVoice
+    from dis_snek.models.discord_objects.user import User
+    from dis_snek.models.snowflake import Snowflake_Type
+
+
+class ScheduledEventPrivacyLevel(IntEnum):
+    """The privacy level of the scheduled event."""
+
+    # Discord only has one at the momment.
+    GUILD_ONLY = 2
+
+
+class ScheduledEventEntityType(IntEnum):
+    """The type of entity that the scheduled event is attached to."""
+
+    STAGE_INSTANCE = 1
+    """ Stage Channel """
+    VOICE = 2
+    """ Voice Channel """
+    EXTERNAL = 3
+    """ External URL """
+
+
+class ScheduledEventStatus(IntEnum):
+    """The status of the scheduled event."""
+
+    # Discord only has one at the momment.
+    SCHEDULED = 1
+    ACTIVE = 2
+    COMPLETED = 3
+    CANCELED = 4
+
+
+@define()
+class ScheduledEvent(DiscordObject):
+    name: str = attr.ib()
+    description: str = attr.ib(default=MISSING)
+    entity_type: Union[ScheduledEventEntityType, int] = attr.ib(converter=ScheduledEventEntityType)
+    """	the type of the scheduled event"""
+    scheduled_start_time: Timestamp = attr.ib(converter=timestamp_converter)
+    """ a Timestamp object representing the scheduled start time of the event """
+    scheduled_end_time: Optional[Timestamp] = attr.ib(default=MISSING, converter=optional(timestamp_converter))
+    """	optinal Timstamp object representing the scheduled end time, required if entity_type is EXTERNAL"""
+    privacy_level: Union[ScheduledEventPrivacyLevel, int] = attr.ib(converter=ScheduledEventPrivacyLevel)
+    """the privacy level of the scheduled event"""
+    status: Union[ScheduledEventStatus, int] = attr.ib(converter=ScheduledEventStatus)
+    """	the status of the scheduled event"""
+    entity_id: Optional["Snowflake_Type"] = attr.ib(default=MISSING, converter=optional(to_snowflake))
+    """the id of an entity associated with a guild scheduled event"""
+    entity_metadata: Optional[Dict[str, Any]] = attr.ib(default=MISSING)
+    """the metadata associated with the entity_type"""
+    user_count: int = attr.ib(default=MISSING)
+    """	the number of users subscribed to the scheduled event"""
+
+    _creator: Optional["User"] = attr.ib(default=MISSING)
+    _creator_id: Optional["Snowflake_Type"] = attr.ib(default=MISSING, converter=optional(to_snowflake))
+    _channel_id: Optional["Snowflake_Type"] = attr.ib(default=None, converter=optional(to_snowflake))
+    _guild_id: Optional["Snowflake_Type"] = attr.ib(default=None, converter=optional(to_snowflake))
+
+    @property
+    async def creator(self) -> Optional["User"]:
+        """Returns the user who created this event
+
+        !!! note:
+            Events made before October 25th, 2021 will not have a creator.
+        """
+        return await self._client.cache.get_user(self._creator_id) if self._creator_id else None
+
+    @classmethod
+    def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:
+        if data.get("creator"):
+            data["creator"] = client.cache.place_user_data(data["creator"])
+        data = super()._process_dict(data, client)
+        return data
+
+    @property
+    def external_url(self) -> Optional[str]:
+        """Returns the external url of this event"""
+        if self.entity_type == ScheduledEventEntityType.EXTERNAL:
+            return self.entity_metadata["location"]
+        return None
+
+    async def get_channel(self) -> Optional[Union["GuildVoice", "GuildStageVoice"]]:
+        """Returns the channel this event is scheduled in if it is scheduled in a channel"""
+        return self._client.cache.channel_cache.get(self._channel_id) if self._channel_id else None
+
+    async def delete(self, reason: str = MISSING) -> None:
+        """Deletes this event"""
+        await self._client.http.delete_scheduled_event(self._guild_id, self.id, reason)
+
+    async def edit(
+        self,
+        name: str = MISSING,
+        description: str = MISSING,
+        channel_id: Optional["Snowflake_Type"] = MISSING,
+        entity_type: ScheduledEventEntityType = MISSING,
+        start_time: "Timestamp" = MISSING,
+        end_time: "Timestamp" = MISSING,
+        status: ScheduledEventStatus = MISSING,
+        entity_metadata: dict = MISSING,
+        privacy_level: ScheduledEventPrivacyLevel = MISSING,
+        reason: str = MISSING,
+    ):
+        """Edits this event
+
+        Parameters:
+            name: The name of the event
+            description: The description of the event
+            channel_id: The channel id of the event
+            entity_type: The type of the event
+            start_time: The scheduled start time of the event
+            end_time: The scheduled end time of the event
+            status: The status of the event
+            entity_metadata: The metadata of the event
+            privacy_level: The privacy level of the event
+            reason: The reason for editing the event
+        """
+        payload = dict(
+            name=name,
+            description=description,
+            channel_id=channel_id,
+            entity_type=entity_type,
+            scheduled_start_time=start_time.isoformat(),
+            scheduled_end_time=end_time.isoformat(),
+            status=status,
+            entity_metadata=entity_metadata,
+            privacy_level=privacy_level,
+        )
+        await self._client.http.modify_scheduled_event(self._guild_id, self.id, payload, reason)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
You can now give search params a [Timestamp](https://dis-snek.readthedocs.io/API%20Reference/models/Internal%20Models/timestamp/#dis_snek.models.timestamp.Timestamp)
```py
tc: GuildText = await bot.get_channel(780435741650059268)
messages = await tc.get_messages(after=Timestamp(2021, 12, 14))
```


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->

- Support for [Timestamp](https://dis-snek.readthedocs.io/API%20Reference/models/Internal%20Models/timestamp/#dis_snek.models.timestamp.Timestamp) in `around`, `before` and `after`


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
