### PR TITLE
Consolidate importing of the library to one simple import

### DIFF
--- a/dis_snek/__init__.py
+++ b/dis_snek/__init__.py
@@ -1,2 +1,16 @@
-from dis_snek.const import __version__
-from dis_snek.client import Snake
+"""
+Dis-Snek
+~~~~~~~~~~~~~~~~~~~
+A Python API wrapper for Discord
+:copyright: (c) 2021-present LordOfPolls
+:license: MIT, see LICENSE for more details.
+"""
+
+from .const import __version__
+
+from .client import Snake
+from .annotations import *
+from .models import *
+from .errors import *
+
+from . import utils, const

--- a/dis_snek/annotations/__init__.py
+++ b/dis_snek/annotations/__init__.py
@@ -1,1 +1,2 @@
-from dis_snek.annotations.argument_annotations import *
+from .argument_annotations import *
+from .slash_annotations import *

--- a/dis_snek/mixins/__init__.py
+++ b/dis_snek/mixins/__init__.py
@@ -1,0 +1,2 @@
+from .send import SendMixin
+from .serialization import DictSerializationMixin

--- a/dis_snek/models/__init__.py
+++ b/dis_snek/models/__init__.py
@@ -13,11 +13,7 @@ from .route import *
 from .scale import *
 from .snowflake import *
 from .timestamp import *
-
-# these are intentionally not imported, leaving them here so people dont think its a mistake
-# from .events import *
-# from .enums import *
-
+from .enums import Intents, ActivityType, Status
 
 from .discord_objects.activity import *
 from .discord_objects.application import *
@@ -37,3 +33,5 @@ from .discord_objects.thread import *
 from .discord_objects.user import *
 from .discord_objects.webhooks import *
 from .discord_objects.voice_state import *
+
+from . import events, enums

--- a/dis_snek/utils/__init__.py
+++ b/dis_snek/utils/__init__.py
@@ -1,0 +1,6 @@
+from .attr_utils import *
+from .cache import *
+from .converters import *
+from .input_utils import *
+from .misc_utils import *
+from .serializer import *


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change (Ideally - there *may* be some situations where that's not true.)
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
For the longest time, the library has required the use of a number of imports to be imported in order to make a single bot. For example, the bot shown in the [Getting Started](https://dis-snek.readthedocs.io/Guides/1%20Getting%20Started/) guide currently has:
```python
from dis_snek.client import Snake
from dis_snek.models.enums import Intents
from dis_snek.models.listener import listen
```
for what is a *very* simple bot.

While it might be a *bit* unfair to compare, `discord.py` allows you to do `import discord` in order to get much of everything you need - it made it *much* simpler to set up a bot, as you didn't need to hunt around for which imports you needed or hope that your IDE found it on its own.

This PR tries to replicate that ease of use for this library, making an `import dis_snek` all you need for a majority of users.

## Changes
- Adjusted `__init__.py` files of many of the folders in the program for ease of importing.
  - Obviously, the greatest effect of this is the fact that `import dis_snek` imports just about everything a normal user needs, but I did bother to go in to adjust some other imports too to make them easier to import, if an end user so desires.
  - Several imports, like the `utils`, `const`(ants), `enums`, and `events` were purposely done so that they would have their own separate namespace (IE to use something from `utils`, you need to do `dis_snek.utils.whatever_you_need`). This was done to organize things a bit and _hopefully_ address the reason why `enums` and `events` weren't imported when `dis_snek.models` was imported.
    - That being said, `Intents`, `ActivityType`, and `Status` are under the `dis_snek` namespace due to how used they are. Feel free to tell me to change that if you don't want that!
  - The main `__init__.py` now has a little docstring noting basic information about the library, because why not?

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x`
- [x] I've tested my code

~~yes i wrote too much for this simple change shhh~~