### PR TITLE
Use Python 3.10 support for `black` in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,10 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 21.12b0
     hooks:
       - id: black
-        args: [--line-length=120]
+        args: [--target-version, py310, --line-length=120]
 
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.2


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
Adjust pre-commit to properly support Python 3.10 for `black`, since that's the minimum version for this library now.


## Changes
- Bump `black` version in pre-commit to `21.12b0`, the latest version as of right now.
- Added arguments to target version Python 3.10 for `black`.
  - I know the `args` are a *slight* hack with `--target-version, py310`, but putting them together doesn't work for some reason. Seems like `black` or `pre-commit` accidentally passes the entire `--target-version py310` string instead of separating the two properly.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.9.x` (okay, I *actually* tested on 3.10, but you know)
- [x] I've tested my code
