### PR TITLE
timeout support for guild members

### DIFF
--- a/dis_snek/http_requests/members.py
+++ b/dis_snek/http_requests/members.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from dis_snek.const import MISSING
 from dis_snek.models.route import Route
@@ -65,7 +65,7 @@ class MemberRequests:
         mute: bool = MISSING,
         deaf: bool = MISSING,
         channel_id: "Snowflake_Type" = MISSING,
-        communication_disabled_until: Optional["Timestamp"] = MISSING,
+        communication_disabled_until: Union["Timestamp", None] = MISSING,
         reason: str = MISSING,
     ) -> Dict:
         """

--- a/dis_snek/http_requests/members.py
+++ b/dis_snek/http_requests/members.py
@@ -65,7 +65,7 @@ class MemberRequests:
         mute: bool = MISSING,
         deaf: bool = MISSING,
         channel_id: "Snowflake_Type" = MISSING,
-        communication_disabled_until: Union["Timestamp", None] = MISSING,
+        communication_disabled_until: Union[Timestamp, None] = MISSING,
         reason: str = MISSING,
     ) -> Dict:
         """

--- a/dis_snek/http_requests/members.py
+++ b/dis_snek/http_requests/members.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from dis_snek.const import MISSING
 from dis_snek.models.route import Route
+from dis_snek.models.timestamp import Timestamp
 from dis_snek.utils.serializer import dict_filter_missing
 
 if TYPE_CHECKING:
@@ -64,6 +65,7 @@ class MemberRequests:
         mute: bool = MISSING,
         deaf: bool = MISSING,
         channel_id: "Snowflake_Type" = MISSING,
+        communication_disabled_until: Optional["Timestamp"] = MISSING,
         reason: str = MISSING,
     ) -> Dict:
         """
@@ -81,9 +83,22 @@ class MemberRequests:
         returns:
             The updated member object
         """
+        if communication_disabled_until is not MISSING:
+            if isinstance(communication_disabled_until, Timestamp):
+                communication_disabled_until = communication_disabled_until.isoformat()
+
         return await self.request(
             Route("PATCH", f"/guilds/{guild_id}/members/{user_id}"),
-            data=dict_filter_missing(dict(nick=nickname, roles=roles, mute=mute, deaf=deaf, channel_id=channel_id)),
+            data=dict_filter_missing(
+                dict(
+                    nick=nickname,
+                    roles=roles,
+                    mute=mute,
+                    deaf=deaf,
+                    channel_id=channel_id,
+                    communication_disabled_until=communication_disabled_until,
+                )
+            ),
             reason=reason,
         )
 

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING, Any, Set, Dict, List, Optional, Union
 import attr
 from attr.converters import optional as optional_c
 
+
+from datetime import datetime, timedelta
+
 from dis_snek.const import MISSING, logger_name
 from dis_snek.errors import HTTPException, TooManyChanges
 from dis_snek.mixins.send import SendMixin
@@ -191,6 +194,11 @@ class Member(DiscordObject, _SendDMMixin):
         default=None, metadata=docs("Whether the user has **not** passed guild's membership screening requirements")
     )
     guild_avatar: "Asset" = field(default=None, metadata=docs("The user's guild avatar"))
+    communication_disabled_until: Optional[Timestamp] = field(
+        default=None,
+        converter=optional_c(timestamp_converter),
+        metadata=docs("wWen a member's timeout will expire, `None` or a time in the past if the user is not timed out"),
+    )
 
     _guild_id: "Snowflake_Type" = field(repr=True, metadata=docs("The ID of the guild"))
     _role_ids: List["Snowflake_Type"] = field(
@@ -422,6 +430,28 @@ class Member(DiscordObject, _SendDMMixin):
             if role_id not in self._role_ids:
                 return False
         return True
+
+    async def timeout(self, communication_disabled_until: Union[Timestamp, datetime] = MISSING, reason: str = MISSING):
+        """
+        Disable a members communication for a given time.
+
+        Args:
+            communication_disabled_until: The time until the user can communicate again (default 1 minute)
+        """
+        if communication_disabled_until is MISSING:
+            communication_disabled_until = Timestamp.now() + timedelta(minutes=1)
+
+        if isinstance(communication_disabled_until, datetime):
+            communication_disabled_until = Timestamp.fromdatetime(communication_disabled_until)
+
+        self.communication_disabled_until = communication_disabled_until
+
+        return await self._client.http.modify_guild_member(
+            self._guild_id,
+            self.id,
+            communication_disabled_until=communication_disabled_until,
+            reason=reason,
+        )
 
     async def kick(self, reason: str = MISSING):
         """

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -431,16 +431,14 @@ class Member(DiscordObject, _SendDMMixin):
                 return False
         return True
 
-    async def timeout(self, communication_disabled_until: Union[Timestamp, datetime] = MISSING, reason: str = MISSING):
+    async def timeout(self, communication_disabled_until: Union[Timestamp, datetime, None], reason: str = MISSING):
         """
         Disable a members communication for a given time.
 
         Args:
-            communication_disabled_until: The time until the user can communicate again (default 1 minute)
+            communication_disabled_until: The time until the user can communicate again
+            reson: The reason for this timeout
         """
-        if communication_disabled_until is MISSING:
-            communication_disabled_until = Timestamp.now() + timedelta(minutes=1)
-
         if isinstance(communication_disabled_until, datetime):
             communication_disabled_until = Timestamp.fromdatetime(communication_disabled_until)
 

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -18,7 +18,6 @@ from dis_snek.models.discord_objects.role import Role
 from dis_snek.models.enums import Permissions, PremiumTypes, UserFlags
 from dis_snek.models.snowflake import Snowflake_Type
 from dis_snek.models.snowflake import to_snowflake
-from dis_snek.models.timestamp import Timestamp
 from dis_snek.utils.attr_utils import define, field, class_defaults, docs
 from dis_snek.utils.converters import list_converter
 from dis_snek.utils.converters import timestamp_converter
@@ -28,6 +27,7 @@ if TYPE_CHECKING:
     from aiohttp import FormData
 
     from dis_snek.client import Snake
+    from dis_snek.models.timestamp import Timestamp
     from dis_snek.models.discord_objects.channel import TYPE_GUILD_CHANNEL, DM
 
 log = logging.getLogger(logger_name)
@@ -194,7 +194,7 @@ class Member(DiscordObject, _SendDMMixin):
         default=None, metadata=docs("Whether the user has **not** passed guild's membership screening requirements")
     )
     guild_avatar: "Asset" = field(default=None, metadata=docs("The user's guild avatar"))
-    communication_disabled_until: Optional[Timestamp] = field(
+    communication_disabled_until: Optional["Timestamp"] = field(
         default=None,
         converter=optional_c(timestamp_converter),
         metadata=docs("wWen a member's timeout will expire, `None` or a time in the past if the user is not timed out"),
@@ -431,7 +431,7 @@ class Member(DiscordObject, _SendDMMixin):
                 return False
         return True
 
-    async def timeout(self, communication_disabled_until: Union[Timestamp, datetime, None], reason: str = MISSING):
+    async def timeout(self, communication_disabled_until: Union["Timestamp", datetime, int, float, str, None], reason: str = MISSING):
         """
         Disable a members communication for a given time.
 
@@ -439,8 +439,8 @@ class Member(DiscordObject, _SendDMMixin):
             communication_disabled_until: The time until the user can communicate again
             reson: The reason for this timeout
         """
-        if isinstance(communication_disabled_until, datetime):
-            communication_disabled_until = Timestamp.fromdatetime(communication_disabled_until)
+        if isinstance(communication_disabled_until, (datetime, int, float, str)):
+            communication_disabled_until = timestamp_converter(communication_disabled_until)
 
         self.communication_disabled_until = communication_disabled_until
 

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -431,7 +431,9 @@ class Member(DiscordObject, _SendDMMixin):
                 return False
         return True
 
-    async def timeout(self, communication_disabled_until: Union["Timestamp", datetime, int, float, str, None], reason: str = MISSING):
+    async def timeout(
+        self, communication_disabled_until: Union["Timestamp", datetime, int, float, str, None], reason: str = MISSING
+    ):
         """
         Disable a members communication for a given time.
 

--- a/dis_snek/models/enums.py
+++ b/dis_snek/models/enums.py
@@ -318,6 +318,9 @@ class Permissions(DiscordIntFlag):  # type: ignore
     USE_PUBLIC_THREADS = 1 << 35
     USE_PRIVATE_THREADS = 1 << 36
     USE_EXTERNAL_STICKERS = 1 << 37
+    SEND_MESSAGES_IN_THREADS = 1 << 38
+    START_EMBEDDED_ACTIVITIES = 1 << 39
+    MODERATE_MEMBERS = 1 << 40
 
     # Shortcuts/grouping/aliases
     REQUIRES_MFA = (


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Added a function to timeout a member and added communication_disabled_until to the Member class
Example of features:
```py
@slash_command("timeout", "mute someone", scopes=[780435741650059264])
@slash_option("member", "person", opt_type=OptionTypes.USER)
@slash_option("unix_timestamp", "unixtimestamp.com", opt_type=OptionTypes.INTEGER)
async def mute(ctx: InteractionContext, member: Member, unix_timestamp: int):
    await member.timeout(unix_timestamp)
    await ctx.send(
        f"{member.mention} will be able to chat again {member.communication_disabled_until.format(TimestampStyles.RelativeTime)}"
    )

```


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Timeout support


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
