### PR TITLE
Add a shortcut function to clone a channel and fix a incosistent naming

### DIFF
--- a/dis_snek/client.py
+++ b/dis_snek/client.py
@@ -627,9 +627,9 @@ class Snake(
         components: Optional[
             Union[List[List[Union["BaseComponent", dict]]], List[Union["BaseComponent", dict]], "BaseComponent", dict]
         ] = None,
-        check=None,
-        timeout=None,
-    ) -> Awaitable["Future"]:
+        check: Optional[Callable] = None,
+        timeout: Optional[float] = None,
+    ) -> "Component":
         """
         Waits for a message to be sent to the bot.
 
@@ -640,8 +640,12 @@ class Snake(
             timeout: The number of seconds to wait before timing out.
 
         Returns:
-            `Component` that was invoked, or `None` if timed out. Use `.context` to get the `ComponentContext`.
+            `Component` that was invoked. Use `.context` to get the `ComponentContext`.
+
+        Raises:
+            `asyncio.TimeoutError` if timed out
         """
+
         if not (messages or components):
             raise ValueError("You must specify messages or components (or both)")
 

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -675,6 +675,7 @@ class GuildChannel(BaseChannel):
 
     _guild_id: Optional["Snowflake_Type"] = attr.ib(default=None, converter=optional_c(to_snowflake))
     _permission_overwrites: Dict["Snowflake_Type", "PermissionOverwrite"] = attr.ib(factory=list)
+    _original_permission_overwrites: List[Union["PermissionOverwrite", dict]] = attr.ib(factory=list)
 
     @property
     def guild(self) -> "Guild":
@@ -686,9 +687,10 @@ class GuildChannel(BaseChannel):
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:
-        permission_overwrites = data.get("permission_overwrites", [])
+        data["original_permission_overwrites"] = data.get("permission_overwrites", [])
         data["permission_overwrites"] = {
-            obj.id: obj for obj in (PermissionOverwrite(**permission) for permission in permission_overwrites)
+            obj.id: obj
+            for obj in (PermissionOverwrite(**permission) for permission in data["original_permission_overwrites"])
         }
         return data
 
@@ -745,6 +747,30 @@ class GuildChannel(BaseChannel):
     @property
     def members(self) -> List["Member"]:
         return [m for m in self.guild.members if Permissions.VIEW_CHANNEL in m.channel_permissions(self)]  # type: ignore
+
+    async def clone(self, name: Optional[str] = None, reason: Optional[str] = MISSING) -> "TYPE_GUILD_CHANNEL":
+        """
+        Clone this channel and create a new one.
+
+        parameters:
+            name: The name of the new channel. Defaults to the current name
+            reason: The reason for creating this channel
+
+        returns:
+            The newly created channel.
+        """
+
+        await self.guild.create_channel(
+            channel_type=self.type,
+            name=name if name else self.name,
+            topic=getattr(self, "topic", MISSING),
+            position=self.position,
+            permission_overwrites=self._original_permission_overwrites,
+            category=self.category,
+            nsfw=self.nsfw,
+            rate_limit_per_user=getattr(self, "rate_limit_per_user", 0),
+            reason=reason,
+        )
 
 
 @define()

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -759,6 +759,36 @@ class GuildCategory(GuildChannel):
         """
         return [channel for channel in self.guild.channels if channel.parent_id == self.id]
 
+    @property
+    def voice_channels(self) -> List["GuildVoice"]:
+        """
+        Get all voice channels within the category.
+
+        Returns:
+            The list of voice channels
+        """
+        return [channel for channel in self.channels if isinstance(channel, GuildVoice) and not isinstance(channel, GuildStageVoice)]
+
+    @property
+    def stage_channels(self) -> List["GuildStageVoice"]:
+        """
+        Get all stage channels within the category.
+
+        Returns:
+            The list of stage channels
+        """
+        return [channel for channel in self.channels if isinstance(channel, GuildStageVoice)]
+
+    @property
+    def text_channels(self) -> List["TYPE_MESSAGEABLE_CHANNEL"]:
+        """
+        Get all text channels within the category.
+
+        Returns:
+            The list of text channels
+        """
+        return [channel for channel in self.channels if isinstance(channel, GuildText)]
+
     async def edit(
         self,
         name: Optional[str] = MISSING,

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -767,7 +767,11 @@ class GuildCategory(GuildChannel):
         Returns:
             The list of voice channels
         """
-        return [channel for channel in self.channels if isinstance(channel, GuildVoice) and not isinstance(channel, GuildStageVoice)]
+        return [
+            channel
+            for channel in self.channels
+            if isinstance(channel, GuildVoice) and not isinstance(channel, GuildStageVoice)
+        ]
 
     @property
     def stage_channels(self) -> List["GuildStageVoice"]:

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -460,7 +460,7 @@ class Guild(BaseGuild):
         nsfw: bool = False,
         bitrate: int = 64000,
         user_limit: int = 0,
-        slowmode_delay: int = 0,
+        rate_limit_per_user: int = 0,
         reason: Optional[str] = MISSING,
     ) -> "TYPE_GUILD_CHANNEL":
         """
@@ -476,7 +476,7 @@ class Guild(BaseGuild):
             nsfw: Should this channel be marked nsfw
             bitrate: The bitrate of this channel, only for voice
             user_limit: The max users that can be in this channel, only for voice
-            slowmode_delay: The time users must wait between sending messages
+            rate_limit_per_user: The time users must wait between sending messages
             reason: The reason for creating this channel
 
         returns:
@@ -496,7 +496,7 @@ class Guild(BaseGuild):
             nsfw,
             bitrate,
             user_limit,
-            slowmode_delay,
+            rate_limit_per_user,
             reason,
         )
         return self._client.cache.place_channel_data(channel_data)
@@ -509,7 +509,7 @@ class Guild(BaseGuild):
         permission_overwrites: Optional[List[Union["PermissionOverwrite", dict]]] = MISSING,
         category: Union["Snowflake_Type", "GuildCategory"] = None,
         nsfw: bool = False,
-        slowmode_delay: int = 0,
+        rate_limit_per_user: int = 0,
         reason: Optional[str] = MISSING,
     ) -> "GuildText":
         """
@@ -522,7 +522,7 @@ class Guild(BaseGuild):
             permission_overwrites: Permission overwrites to apply to the channel
             category: The category this channel should be within
             nsfw: Should this channel be marked nsfw
-            slowmode_delay: The time users must wait between sending messages
+            rate_limit_per_user: The time users must wait between sending messages
             reason: The reason for creating this channel
 
         returns:
@@ -536,7 +536,7 @@ class Guild(BaseGuild):
             permission_overwrites=permission_overwrites,
             category=category,
             nsfw=nsfw,
-            slowmode_delay=slowmode_delay,
+            rate_limit_per_user=rate_limit_per_user,
             reason=reason,
         )
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition 

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Add a shortcut function to clone a channel and fix a incosistent naming.

Note:
GuildChannel._permission_overwrites is being saved differently to how discord dispatches the data. I added a new attribute for the original data for the time being, but would recommend clearing that up in the future. Not sure what the best action is, GuildChannel._permission_overwrite seems to be only used once, so I'd probly change that usage ( Member.channel_permissions() ).

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- add `channel.clone()`
- rename `slowmode_delay` to `rate_limit_per_user``. Now follows the discord api, previously both existed

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
