### PR TITLE
fix: Resolve some bad variable references, and add linter to ensure they can't happen again

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,16 @@
 # top-most EditorConfig file
 root = true
 
-[*.py]
+[*.(py|md)]
 indent_style = space
 indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+extend-ignore = 
+    Q0, E501, C812, E203, W503  # These default to arguing with Black.  We might configure some of them eventually
+    F403, # F403 tells us not to use * imports.  It's correct, but it'll be work to fix.
+    ANN1, # These insist that we have Type Annotations for self and cls.
+    ANN204, ANN206, # return annotations for special methods and class methods
+    D105, D107,  # Missing Docstrings in magic method and __init__
+
+# After all of the above, we blow it away and only turn on specific settings anyway. 
+# This is a temporary measure.
+select = E9, F6, F7, F81, F82
+max-line-length=120

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,18 @@
+name: flake-action
+on: [push, pull_request]
+jobs:
+  linter_name:
+    name: runner / flake8 linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2.3.1
+        with:
+          python-version: '3.10'
+      - name: Setup flake8 annotations
+        uses: rbialon/flake8-annotations@v1
+      - name: Lint with flake8
+        run: |
+          pip install flake8 flake8-annotations flake8-bandit flake8-docstrings
+          flake8 . --show-source --statistics

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,3 @@ repos:
           - flake8-annotations~=2.0
           - flake8-bandit~=2.1
           - flake8-docstrings~=1.5
-        args: [--max-line-length=120, --ignore=ANN101 D107 ANN102 ANN206 D105 ANN204]

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -466,7 +466,7 @@ class Guild(BaseGuild):
         nsfw: bool = False,
         bitrate: int = 64000,
         user_limit: int = 0,
-        slowmode_delay: int = 0,
+        rate_limit_per_user: int = 0,
         reason: Absent[Optional[str]] = MISSING,
     ) -> "TYPE_GUILD_CHANNEL":
         """
@@ -515,7 +515,7 @@ class Guild(BaseGuild):
         permission_overwrites: Absent[Optional[List[Union["PermissionOverwrite", dict]]]] = MISSING,
         category: Union["Snowflake_Type", "GuildCategory"] = None,
         nsfw: bool = False,
-        slowmode_delay: int = 0,
+        rate_limit_per_user: int = 0,
         reason: Absent[Optional[str]] = MISSING,
     ) -> "GuildText":
         """

--- a/dis_snek/models/discord_objects/scheduled_event.py
+++ b/dis_snek/models/discord_objects/scheduled_event.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from dis_snek.models.discord_objects.guild import Guild
     from dis_snek.models.discord_objects.user import Member
     from dis_snek.models.discord_objects.user import User
-    from dis_snek.models.snowflake import Snowflake_Type
 
 
 class ScheduledEventPrivacyLevel(IntEnum):

--- a/dis_snek/models/discord_objects/webhooks.py
+++ b/dis_snek/models/discord_objects/webhooks.py
@@ -5,6 +5,7 @@ import attr
 from aiohttp import FormData
 
 from dis_snek.const import MISSING, Absent
+from dis_snek.errors import ForeignWebhookException
 from dis_snek.mixins.send import SendMixin
 from dis_snek.models.discord import DiscordObject
 from dis_snek.models.discord_objects.message import process_message_payload


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition 

## Description
In the course of 76f6d05f32fb9e445f49895cb4613368e341637a, Polls accidentally partially reintroduced the old name for `rate_limit_per_user`
I've fixed that, and added a bare-bones flake8 config and linter to ensure errors like that can't return.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
- [x] This PR can be rebased