### PR TITLE
fix: Fix Member.top_role returning incorrect roles and add some doc strings

### DIFF
--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -279,7 +279,9 @@ class Member(DiscordObject, _SendDMMixin):
 
     @property
     def top_role(self) -> "Role":
-        return self._client.cache.role_cache.get(self._role_ids[-1])
+        """The member's top most role, or None if the member has no roles."""
+        roles = self.roles
+        return max(roles, key=lambda x: x.position) if roles else None
 
     @property
     def display_name(self) -> str:

--- a/dis_snek/models/discord_objects/user.py
+++ b/dis_snek/models/discord_objects/user.py
@@ -271,10 +271,12 @@ class Member(DiscordObject, _SendDMMixin):
 
     @property
     def guild(self) -> "Guild":
+        """The guild object this member is from"""
         return self._client.cache.guild_cache.get(self._guild_id)
 
     @property
     def roles(self) -> List["Role"]:
+        """The roles this member has"""
         return [r for r in self.guild.roles if r.id in self._role_ids]
 
     @property


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition 

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Member.top_role did not actually return the topmost role. It also was not documented, among a couple of other neighboring methods.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- fixed the implementation of Member.top_role to sort by position
- added doc strings to Member.top_role, Member.guild, and Member.roles

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
