### PR TITLE
Fix deadlock in `reconnect()`

### DIFF
--- a/dis_snek/gateway.py
+++ b/dis_snek/gateway.py
@@ -342,7 +342,7 @@ class WebsocketClient:
 
             case OPCODE.INVALIDATE_SESSION:
                 log.warning("Gateway has invalidated session! Reconnecting...")
-                return await self.reconnect(resume=data["d"])
+                return await self.reconnect(resume=data)
 
             case _:
                 return log.debug(f"Unhandled OPCODE: {op} = {OPCODE(op).name}")

--- a/dis_snek/gateway.py
+++ b/dis_snek/gateway.py
@@ -80,8 +80,6 @@ class WebsocketClient:
         self.ws = None
         self.shard = shard
 
-        self._zlib = zlib.decompressobj()
-
         self.rl_manager = GatewayRateLimit()
         self.chunk_cache = {}
 
@@ -116,6 +114,7 @@ class WebsocketClient:
             raise RuntimeError("An instance of 'WebsocketClient' cannot be re-used!")
 
         self._entered = True
+        self._zlib = zlib.decompressobj()
 
         self.ws = await self.state.client.http.websocket_connect(self.state.gateway_url)
         self._closed.set()
@@ -252,6 +251,7 @@ class WebsocketClient:
 
             await self.ws.close(code=code)
             self.ws = None
+            self._zlib = zlib.decompressobj()
 
             self.ws = await self.state.client.http.websocket_connect(self.state.gateway_url)
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description

It was quickly discovered that #129 had a dead-lock in `reconnect()`, this PR fixes that by adding a `force` parameter to ignore the `_closed` event. A few other bugs were picked up along the way.

## Changes

- Recreate the zlib decompressor upon reconnecting (this wasn't done originally and caused `zlib.error: Error -3 while decompressing data: invalid stored block lengths`)
- Fix one-off bug in `dispatch_opcode` when handling INVALIDATE_SESSION (`data` is the inner `d` field, not the whole message)
- Remove dead-lock in `reconnect()` (add a `force` parameter that ignores the event)

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
