### PR TITLE
fix: Return None if the cache.get_channel's fallback request errors

### DIFF
--- a/dis_snek/smart_cache.py
+++ b/dis_snek/smart_cache.py
@@ -313,7 +313,10 @@ class GlobalCache:
         channel_id = to_snowflake(channel_id)
         channel = self.channel_cache.get(channel_id)
         if request_fallback and channel is None:
-            data = await self._client.http.get_channel(channel_id)
+            try:
+                data = await self._client.http.get_channel(channel_id)
+            except (NotFound, Forbidden):
+                return None
             channel = self.place_channel_data(data)
         return channel
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
`cache.get_channel` was already marked as Optional, and if called with `request_fallback=False`, would return None instead of throwing an error.
This PR adds consistency when called with `request_fallback=True` on a channel that is hidden from the bot. 
Most notably, this fixes an error that would happen when generating an InteractionContext in a channel/guild without the bot user.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
