### PR TITLE
Make bot stop more graceful

### DIFF
--- a/dis_snek/gateway.py
+++ b/dis_snek/gateway.py
@@ -333,10 +333,12 @@ class WebsocketClient:
                 # Note that we check for a received message first, because if both completed at
                 # the same time, we don't want to discard that message.
                 msg = await receiving
+                stopping.cancel()
             else:
                 # This has to be the stopping task, which we join into the current task (even
                 # though that doesn't give any meaningful value in the return).
                 await stopping
+                receiving.cancel()
                 return
 
             op = msg.get("op")

--- a/dis_snek/gateway.py
+++ b/dis_snek/gateway.py
@@ -296,7 +296,12 @@ class WebsocketClient:
         if self.heartbeat_interval is None:
             raise RuntimeError
 
-        await asyncio.sleep(self.heartbeat_interval * random.uniform(0, 0.5))
+        try:
+            await asyncio.wait_for(self._kill_bee_gees.wait(), timeout=self.heartbeat_interval * random.uniform(0, 0.5))
+        except asyncio.TimeoutError:
+            pass
+        else:
+            return
 
         log.debug(f"Sending heartbeat every {self.heartbeat_interval} seconds")
         while not self._kill_bee_gees.is_set():

--- a/dis_snek/state.py
+++ b/dis_snek/state.py
@@ -71,7 +71,13 @@ class ConnectionState:
 
     async def stop(self) -> None:
         log.debug(f"Shutting down shard ID {self.shard_id}")
-        self._shard_task.cancel()
+        if self.gateway is not None:
+            self.gateway.close()
+            self.gateway = None
+
+        if self._shard_task is not None:
+            await self._shard_task
+            self._shard_task = None
 
     async def _ws_connect(self) -> None:
         log.info("Attempting to initially connect to gateway...")


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description

[As reported by @Wolfhound905](https://discord.com/channels/870046872864165888/921934329842634793/929492794895118376) in the [Discord server](https://discord.gg/dis-snek) the bot shutdown from `bot.stop()` can be somewhat scary because it cancels the gateway task:
```python
orjson not installed, built-in json library will be used
Im online, going to leave now
Traceback (most recent call last):
  File "D:\temp-test\venv\lib\site-packages\dis_snek\state.py", line 81, in _ws_connect
    await self.gateway.run()
  File "D:\temp-test\venv\lib\site-packages\dis_snek\gateway.py", line 321, in run
    msg = await self.receive()
  File "D:\temp-test\venv\lib\site-packages\dis_snek\gateway.py", line 209, in receive
    resp = await self.ws.receive()
  File "D:\temp-test\venv\lib\site-packages\aiohttp\client_ws.py", line 230, in receive
    msg = await self._reader.read()
  File "D:\temp-test\venv\lib\site-packages\aiohttp\streams.py", line 644, in read
    return await super().read()
  File "D:\temp-test\venv\lib\site-packages\aiohttp\streams.py", line 604, in read
    await self._waiter
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\temp-test\venv\lib\site-packages\dis_snek\client.py", line 412, in login
    await self._connection_state.start()
  File "D:\temp-test\venv\lib\site-packages\dis_snek\state.py", line 70, in start
    await self._shard_task
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\temp-test\dis-snek.py", line 38, in <module>
    bot.start("")
  File "D:\temp-test\venv\lib\site-packages\dis_snek\client.py", line 590, in start
    self.loop.run_until_complete(self.login(token))
  File "C:\Users\aiden\AppData\Local\Programs\Python\Python310\lib\asyncio\base_events.py", line 641, in run_until_complete
    return future.result()
asyncio.exceptions.CancelledError
```
Even though this is by design, and only happens on shutdown, there could be unnecessary future issues opened about it. Additionally it shows that the shutdown could be a bit too forceful.

This PR fixes that using an event that gets handled by the gateway when it has a chance to between waiting for more messages.

## Changes

- Added the `_close_gateway` event that gets handled whenever the gateway can.

### Additional changes (EDIT)

- Ensure proper shutdown of the heartbeater when exiting the gateway
- Make it possible to shutdown gateway and heartbeater before it has sent its first heartbeat

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
