### PR TITLE
refactor: rename `Emoji` to `PartialEmoji`

### DIFF
--- a/dis_snek/event_processors/reaction_events.py
+++ b/dis_snek/event_processors/reaction_events.py
@@ -2,7 +2,7 @@ import logging
 
 from dis_snek.const import logger_name
 from dis_snek.event_processors._template import EventMixinTemplate, Processor
-from dis_snek.models import events, Emoji, Reaction
+from dis_snek.models import events, PartialEmoji, Reaction
 from dis_snek.models.events import RawGatewayEvent
 
 log = logging.getLogger(logger_name)
@@ -18,7 +18,7 @@ class ReactionEvents(EventMixinTemplate):
         else:
             author = await self.cache.get_user(event.data.get("user_id"))
 
-        emoji = Emoji.from_dict(event.data.get("emoji"))  # type: ignore
+        emoji = PartialEmoji.from_dict(event.data.get("emoji"))  # type: ignore
         message = await self.cache.get_message(
             event.data.get("channel_id"), event.data.get("message_id"), request_fallback=False
         )

--- a/dis_snek/http_requests/emojis.py
+++ b/dis_snek/http_requests/emojis.py
@@ -33,7 +33,7 @@ class EmojiRequests:
             emoji_id: The ID of the emoji to get
 
         Returns:
-            Emoji object
+            PartialEmoji object
 
         """
         data = await self.request(Route("GET", f"/guilds/{guild_id}/emojis/{emoji_id}"))

--- a/dis_snek/models/discord_objects/components.py
+++ b/dis_snek/models/discord_objects/components.py
@@ -12,7 +12,7 @@ from dis_snek.utils.attr_utils import str_validator
 from dis_snek.utils.serializer import export_converter
 
 if TYPE_CHECKING:
-    from dis_snek.models.discord_objects.emoji import Emoji
+    from dis_snek.models.discord_objects.emoji import PartialEmoji
     from dis_snek.models.discord_objects.message import Message
 
 
@@ -62,7 +62,7 @@ class Button(InteractiveComponent):
     Attributes:
         style optional[ButtonStyles, int]: Buttons come in a variety of styles to convey different types of actions.
         label optional[str]: The text that appears on the button, max 80 characters.
-        emoji optional[Union[Emoji, dict, str]]: The emoji that appears on the button.
+        emoji optional[Union[PartialEmoji, dict, str]]: The emoji that appears on the button.
         custom_id Optional[str]: A developer-defined identifier for the button, max 100 characters.
         url Optional[str]: A url for link-style buttons.
         disabled bool: Disable the button and make it not interactable, default false.
@@ -71,7 +71,7 @@ class Button(InteractiveComponent):
 
     style: Union[ButtonStyles, int] = attr.ib()
     label: Optional[str] = attr.ib(default=None)
-    emoji: Optional[Union["Emoji", dict, str]] = attr.ib(default=None, metadata=export_converter(process_emoji))
+    emoji: Optional[Union["PartialEmoji", dict, str]] = attr.ib(default=None, metadata=export_converter(process_emoji))
     custom_id: Optional[str] = attr.ib(default=MISSING, validator=str_validator)
     url: Optional[str] = attr.ib(default=None)
     disabled: bool = attr.ib(default=False)
@@ -113,7 +113,7 @@ class SelectOption(BaseComponent):
         label str: The label (max 80 characters)
         value str: The value of the select, this is whats sent to your bot
         description Optional[str]: A description of this option
-        emoji Optional[Union[Emoji, dict, str]: An emoji to show in this select option
+        emoji Optional[Union[PartialEmoji, dict, str]: An emoji to show in this select option
         default bool: Is this option selected by default
 
     """
@@ -121,7 +121,7 @@ class SelectOption(BaseComponent):
     label: str = attr.ib(validator=str_validator)
     value: str = attr.ib(validator=str_validator)
     description: Optional[str] = attr.ib(default=None)
-    emoji: Optional[Union["Emoji", dict, str]] = attr.ib(default=None, metadata=export_converter(process_emoji))
+    emoji: Optional[Union["PartialEmoji", dict, str]] = attr.ib(default=None, metadata=export_converter(process_emoji))
     default: bool = attr.ib(default=False)
 
     @label.validator

--- a/dis_snek/models/discord_objects/emoji.py
+++ b/dis_snek/models/discord_objects/emoji.py
@@ -21,8 +21,8 @@ emoji_regex = re.compile(r"<?(a)?:(\w*):(\d*)>?")
 
 
 @define()
-class Emoji(SnowflakeObject, DictSerializationMixin):
-    """Represent a basic emoji used in discord."""
+class PartialEmoji(SnowflakeObject, DictSerializationMixin):
+    """Represent a basic ("partial") emoji used in discord."""
 
     id: Optional["Snowflake_Type"] = attr.ib(
         default=None, converter=optional(to_snowflake)
@@ -34,9 +34,9 @@ class Emoji(SnowflakeObject, DictSerializationMixin):
     """Whether this emoji is animated"""
 
     @classmethod
-    def from_str(cls, emoji_str: str) -> "Emoji":
+    def from_str(cls, emoji_str: str) -> "PartialEmoji":
         """
-        Generate an Emoji from a discord Emoji string representation, or unicode emoji.
+        Generate a PartialEmoji from a discord Emoji string representation, or unicode emoji.
 
         Handles:
             <:emoji_name:emoji_id>
@@ -48,7 +48,7 @@ class Emoji(SnowflakeObject, DictSerializationMixin):
             emoji_str: The string representation an emoji
 
         Returns:
-            An Emoji object
+            A PartialEmoji object
 
         Raises:
             ValueError if the string cannot be parsed
@@ -81,7 +81,7 @@ class Emoji(SnowflakeObject, DictSerializationMixin):
 
 
 @define()
-class CustomEmoji(Emoji):
+class CustomEmoji(PartialEmoji):
     """Represent a custom emoji in a guild with all its properties."""
 
     _client: "Snake" = field(metadata=no_export_meta)
@@ -198,23 +198,23 @@ class CustomEmoji(Emoji):
         await self._client.http.delete_guild_emoji(self._guild_id, self.id, reason=reason)
 
 
-def process_emoji_req_format(emoji: Optional[Union[Emoji, dict, str]]) -> Optional[str]:
+def process_emoji_req_format(emoji: Optional[Union[PartialEmoji, dict, str]]) -> Optional[str]:
     if not emoji:
         return emoji
 
     if isinstance(emoji, str):
-        emoji = Emoji.from_str(emoji)
+        emoji = PartialEmoji.from_str(emoji)
 
     if isinstance(emoji, dict):
-        emoji = Emoji.from_dict(emoji)
+        emoji = PartialEmoji.from_dict(emoji)
 
-    if isinstance(emoji, Emoji):
+    if isinstance(emoji, PartialEmoji):
         return emoji.req_format
 
     raise ValueError(f"Invalid emoji: {emoji}")
 
 
-def process_emoji(emoji: Optional[Union[Emoji, dict, str]]) -> Optional[dict]:
+def process_emoji(emoji: Optional[Union[PartialEmoji, dict, str]]) -> Optional[dict]:
     if not emoji:
         return emoji
 
@@ -222,9 +222,9 @@ def process_emoji(emoji: Optional[Union[Emoji, dict, str]]) -> Optional[dict]:
         return emoji
 
     if isinstance(emoji, str):
-        emoji = Emoji.from_str(emoji)
+        emoji = PartialEmoji.from_str(emoji)
 
-    if isinstance(emoji, Emoji):
+    if isinstance(emoji, PartialEmoji):
         return emoji.to_dict()
 
     raise ValueError(f"Invalid emoji: {emoji}")

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -13,7 +13,7 @@ from dis_snek.models.color import Color
 from dis_snek.models.discord import DiscordObject, ClientObject
 from dis_snek.models.discord_objects.application import Application
 from dis_snek.models.discord_objects.asset import Asset
-from dis_snek.models.discord_objects.emoji import CustomEmoji, Emoji
+from dis_snek.models.discord_objects.emoji import CustomEmoji, PartialEmoji
 from dis_snek.models.discord_objects.scheduled_event import (
     ScheduledEvent,
     ScheduledEventPrivacyLevel,
@@ -94,7 +94,7 @@ class GuildWelcome(ClientObject):
 
 @define()
 class GuildPreview(BaseGuild):
-    emoji: list[Emoji] = attr.ib(factory=list)
+    emoji: list[PartialEmoji] = attr.ib(factory=list)
     """A list of custom emoji from this guild"""
     approximate_member_count: int = attr.ib(default=0)
     """Approximate number of members in this guild"""

--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -15,7 +15,7 @@ from dis_snek.models.discord import DiscordObject
 
 from dis_snek.models.discord_objects.components import BaseComponent, process_components
 from dis_snek.models.discord_objects.embed import Embed, process_embeds
-from dis_snek.models.discord_objects.emoji import Emoji, process_emoji_req_format
+from dis_snek.models.discord_objects.emoji import PartialEmoji, process_emoji_req_format
 from dis_snek.models.discord_objects.reaction import Reaction
 from dis_snek.models.discord_objects.sticker import StickerItem
 from dis_snek.models.enums import (
@@ -443,7 +443,7 @@ class Message(BaseMessage):
         )
         return self._client.cache.place_channel_data(thread_data)
 
-    async def get_reaction(self, emoji: Union["Emoji", dict, str]) -> List["User"]:
+    async def get_reaction(self, emoji: Union["PartialEmoji", dict, str]) -> List["User"]:
         """
         Get reactions of a specific emoji from this message.
 
@@ -457,7 +457,7 @@ class Message(BaseMessage):
         reaction_data = await self._client.http.get_reactions(self._channel_id, self.id, emoji)
         return [self._client.cache.place_user_data(user_data) for user_data in reaction_data]
 
-    async def add_reaction(self, emoji: Union["Emoji", dict, str]):
+    async def add_reaction(self, emoji: Union["PartialEmoji", dict, str]):
         """
         Add a reaction to this message.
 
@@ -469,7 +469,9 @@ class Message(BaseMessage):
         await self._client.http.create_reaction(self._channel_id, self.id, emoji)
 
     async def remove_reaction(
-        self, emoji: Union["Emoji", dict, str], member: Optional[Union["Member", "User", "Snowflake_Type"]] = MISSING
+        self,
+        emoji: Union["PartialEmoji", dict, str],
+        member: Optional[Union["Member", "User", "Snowflake_Type"]] = MISSING,
     ):
         """
         Remove a specific reaction that a user reacted with.
@@ -485,7 +487,7 @@ class Message(BaseMessage):
         user_id = to_snowflake(member)
         await self._client.http.remove_user_reaction(self._channel_id, self.id, emoji_str, user_id)
 
-    async def clear_reactions(self, emoji: Union["Emoji", dict, str]) -> None:
+    async def clear_reactions(self, emoji: Union["PartialEmoji", dict, str]) -> None:
         # TODO Should we combine this with clear_all_reactions?
         """
         Clear a specific reaction from message.

--- a/dis_snek/models/discord_objects/reaction.py
+++ b/dis_snek/models/discord_objects/reaction.py
@@ -7,7 +7,7 @@ import attr
 
 from dis_snek.const import MISSING
 from dis_snek.models.discord import ClientObject
-from dis_snek.models.discord_objects.emoji import Emoji
+from dis_snek.models.discord_objects.emoji import PartialEmoji
 from dis_snek.models.iterator import AsyncIterator
 from dis_snek.models.snowflake import to_snowflake
 from dis_snek.utils.attr_utils import define
@@ -62,7 +62,7 @@ class ReactionUsers(AsyncIterator):
 class Reaction(ClientObject):
     count: int = attr.ib()
     me: bool = attr.ib(default=False)
-    emoji: "Emoji" = attr.ib(converter=Emoji.from_dict)
+    emoji: "PartialEmoji" = attr.ib(converter=PartialEmoji.from_dict)
 
     _channel_id: "Snowflake_Type" = attr.ib(converter=to_snowflake)
     _message_id: "Snowflake_Type" = attr.ib(converter=to_snowflake)

--- a/dis_snek/models/events/discord.py
+++ b/dis_snek/models/events/discord.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from dis_snek.models.discord_objects.user import Member, User, BaseUser
     from dis_snek.models.snowflake import Snowflake_Type
     from dis_snek.models.discord_objects.activity import Activity
-    from dis_snek.models.discord_objects.emoji import Emoji
+    from dis_snek.models.discord_objects.emoji import PartialEmoji
     from dis_snek.models.discord_objects.role import Role
     from dis_snek.models.discord_objects.sticker import Sticker
     from dis_snek.models.discord_objects.voice_state import VoiceState
@@ -198,9 +198,9 @@ class BanRemove(BanCreate):
 class GuildEmojisUpdate(BaseEvent, GuildEvent):
     """Dispatched when a guild's emojis are updated."""
 
-    before: List["Emoji"] = attr.ib(factory=list)
+    before: List["PartialEmoji"] = attr.ib(factory=list)
     """List of emoji before this event"""
-    after: List["Emoji"] = attr.ib(factory=list)
+    after: List["PartialEmoji"] = attr.ib(factory=list)
     """List of emoji after this event"""
 
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [x] Documentation change/addition (technically)

## Description
The original name for the class changed in this PR, `Emoji`, was awfully vague for most users, and many didn't understand the difference between it and `CustomEmoji`. Some people thought that `Emoji` was used for unicode emojis and `CustomEmoji` for guild emojis, when in reality, `Emoji` could *also* be used for guild emojis.

`PartialEmoji` hopefully makes it much clearer what it *actually* is - simply a basic emoji object without some of the extra features `CustomEmoji` has.

### Note

`CustomEmoji` was left as-is right now, as a discussion on the Discord server pointed out how having a class called `Emoji` would be too vague for developers, too. However, I could easily rename that too and include it in this PR if needed.

## Changes

- Rename `Emoji` to `PartialEmoji`.
  - Make sure to account for every instance where `Emoji` was used, replacing it with `PartialEmoji`.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
