### PR TITLE
feat: Defer the unpacking of guild channel and members

### DIFF
--- a/dis_snek/event_processors/channel_events.py
+++ b/dis_snek/event_processors/channel_events.py
@@ -36,7 +36,6 @@ class ChannelEvents(EventMixinTemplate):
     async def _on_raw_channel_pins_update(self, event: RawGatewayEvent) -> None:
         channel = await self.cache.get_channel(event.data.get("channel_id"))
         channel.last_pin_timestamp = timestamp_converter(event.data.get("last_pin_timestamp"))
-        self.cache.channel_cache[channel.id] = channel
         self.dispatch(events.ChannelPinsUpdate(channel, channel.last_pin_timestamp))
 
     @Processor.define()

--- a/dis_snek/gateway.py
+++ b/dis_snek/gateway.py
@@ -498,7 +498,7 @@ class WebsocketClient:
             start_time = time.perf_counter()
 
             for i, member in enumerate(members):
-                self.state.client.cache.place_member_data(g_id, member)
+                self.state.client.cache.place_member_data(g_id, member, deferred=True)
                 if (time.monotonic() - s) > 0.05:
                     # look, i get this *could* be a thread, but because it needs to modify data in the main thread,
                     # it is still blocking. So by periodically yielding to the event loop, we can avoid blocking, and still

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -174,9 +174,7 @@ class _BaseInteractionContext(Context):
                 match option["type"]:
                     case OptionTypes.USER:
                         value = (
-                            self._client.cache.get_cached_member(
-                                (to_snowflake(data.get("guild_id", 0)), to_snowflake(value))
-                            )
+                            self._client.cache.get_cached_member(to_snowflake(data.get("guild_id", 0)), to_snowflake(value))
                             or self._client.cache.user_cache.get(to_snowflake(value))
                         ) or value
 
@@ -188,7 +186,7 @@ class _BaseInteractionContext(Context):
 
                     case OptionTypes.MENTIONABLE:
                         snow = to_snowflake(value)
-                        if user := self._client.cache.get_cached_member(snow) or self._client.cache.user_cache.get(
+                        if user := self._client.cache.get_cached_member(to_snowflake(data.get("guild_id", 0)), snow) or self._client.cache.user_cache.get(
                             snow
                         ):
                             value = user

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -188,7 +188,9 @@ class _BaseInteractionContext(Context):
 
                     case OptionTypes.MENTIONABLE:
                         snow = to_snowflake(value)
-                        if user := self._client.cache.get_cached_member(snow) or self._client.cache.user_cache.get(snow):
+                        if user := self._client.cache.get_cached_member(snow) or self._client.cache.user_cache.get(
+                            snow
+                        ):
                             value = user
                         elif role := self._client.cache.role_cache.get(snow):
                             value = role

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -174,7 +174,9 @@ class _BaseInteractionContext(Context):
                 match option["type"]:
                     case OptionTypes.USER:
                         value = (
-                            self._client.cache.get_cached_member(to_snowflake(data.get("guild_id", 0)), to_snowflake(value))
+                            self._client.cache.get_cached_member(
+                                to_snowflake(data.get("guild_id", 0)), to_snowflake(value)
+                            )
                             or self._client.cache.user_cache.get(to_snowflake(value))
                         ) or value
 
@@ -186,9 +188,9 @@ class _BaseInteractionContext(Context):
 
                     case OptionTypes.MENTIONABLE:
                         snow = to_snowflake(value)
-                        if user := self._client.cache.get_cached_member(to_snowflake(data.get("guild_id", 0)), snow) or self._client.cache.user_cache.get(
-                            snow
-                        ):
+                        if user := self._client.cache.get_cached_member(
+                            to_snowflake(data.get("guild_id", 0)), snow
+                        ) or self._client.cache.user_cache.get(snow):
                             value = user
                         elif role := self._client.cache.role_cache.get(snow):
                             value = role

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -140,10 +140,10 @@ class _BaseInteractionContext(Context):
         if new_cls.guild_id:
             new_cls.author = client.cache.place_member_data(new_cls.guild_id, data["member"].copy())
             client.cache.place_user_data(data["member"]["user"])
-            new_cls.channel = client.cache.channel_cache.get(to_snowflake(data["channel_id"]))
+            new_cls.channel = client.cache.get_cached_channel(to_snowflake(data["channel_id"]))
         else:
             new_cls.author = client.cache.place_user_data(data["user"])
-            new_cls.channel = client.cache.channel_cache.get(new_cls.author.id)
+            new_cls.channel = client.cache.get_cached_channel(new_cls.author.id)
 
         new_cls.target_id = data["data"].get("target_id")
 
@@ -174,21 +174,21 @@ class _BaseInteractionContext(Context):
                 match option["type"]:
                     case OptionTypes.USER:
                         value = (
-                            self._client.cache.member_cache.get(
+                            self._client.cache.get_cached_member(
                                 (to_snowflake(data.get("guild_id", 0)), to_snowflake(value))
                             )
                             or self._client.cache.user_cache.get(to_snowflake(value))
                         ) or value
 
                     case OptionTypes.CHANNEL:
-                        value = self._client.cache.channel_cache.get(to_snowflake(value)) or value
+                        value = self._client.cache.get_cached_channel(to_snowflake(value)) or value
 
                     case OptionTypes.ROLE:
                         value = self._client.cache.role_cache.get(to_snowflake(value)) or value
 
                     case OptionTypes.MENTIONABLE:
                         snow = to_snowflake(value)
-                        if user := self._client.cache.member_cache.get(snow) or self._client.cache.user_cache.get(snow):
+                        if user := self._client.cache._member_cache.get(snow) or self._client.cache.user_cache.get(snow):
                             value = user
                         elif role := self._client.cache.role_cache.get(snow):
                             value = role

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -188,9 +188,7 @@ class _BaseInteractionContext(Context):
 
                     case OptionTypes.MENTIONABLE:
                         snow = to_snowflake(value)
-                        if user := self._client.cache._member_cache.get(snow) or self._client.cache.user_cache.get(
-                            snow
-                        ):
+                        if user := self._client.cache.get_cached_member(snow) or self._client.cache.user_cache.get(snow):
                             value = user
                         elif role := self._client.cache.role_cache.get(snow):
                             value = role

--- a/dis_snek/models/context.py
+++ b/dis_snek/models/context.py
@@ -188,7 +188,9 @@ class _BaseInteractionContext(Context):
 
                     case OptionTypes.MENTIONABLE:
                         snow = to_snowflake(value)
-                        if user := self._client.cache._member_cache.get(snow) or self._client.cache.user_cache.get(snow):
+                        if user := self._client.cache._member_cache.get(snow) or self._client.cache.user_cache.get(
+                            snow
+                        ):
                             value = user
                         elif role := self._client.cache.role_cache.get(snow):
                             value = role

--- a/dis_snek/models/discord_objects/channel.py
+++ b/dis_snek/models/discord_objects/channel.py
@@ -738,7 +738,7 @@ class GuildChannel(BaseChannel):
     @property
     def category(self) -> Optional["GuildCategory"]:
         """The parent category of this channel."""
-        return self._client.cache.channel_cache.get(self.parent_id)
+        return self._client.cache.get_cached_channel(self.parent_id)
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:
@@ -1106,7 +1106,7 @@ class ThreadChannel(GuildChannel, MessageableMixin, WebhookMixin):
     @property
     def parent_channel(self) -> GuildText:
         """The channel this thread is a child of."""
-        return self._client.cache.channel_cache.get(self.parent_id)
+        return self._client.cache.get_cached_channel(self.parent_id)
 
     @property
     def mention(self) -> str:

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -217,17 +217,17 @@ class Guild(BaseGuild):
     @property
     def channels(self) -> List["TYPE_GUILD_CHANNEL"]:
         """Returns a list of channels associated with this guild."""
-        return [self._client.cache.channel_cache.get(c_id) for c_id in self._channel_ids]
+        return [self._client.cache.get_cached_channel(c_id) for c_id in self._channel_ids]
 
     @property
     def threads(self) -> List["TYPE_THREAD_CHANNEL"]:
         """Returns a list of threads associated with this guild."""
-        return [self._client.cache.channel_cache.get(t_id) for t_id in self._thread_ids]
+        return [self._client.cache.get_cached_channel(t_id) for t_id in self._thread_ids]
 
     @property
     def members(self) -> List["Member"]:
         """A generator that yields all members of this guild."""
-        return [self._client.cache.member_cache.get((self.id, m_id)) for m_id in self._member_ids]
+        return [self._client.cache.get_cached_member((self.id, m_id)) for m_id in self._member_ids]
 
     @property
     def premium_subscribers(self) -> List["Member"]:
@@ -252,22 +252,22 @@ class Guild(BaseGuild):
     @property
     def me(self) -> "Member":
         """Returns this bots member object within this guild."""
-        return self._client.cache.member_cache.get((self.id, self._client.user.id))
+        return self._client.cache.get_cached_member((self.id, self._client.user.id))
 
     @property
     def system_channel(self) -> Optional["GuildText"]:
         """Returns the channel this guild uses for system messages."""
-        return self._client.cache.channel_cache.get(self.system_channel_id)
+        return self._client.cache.get_cached_channel(self.system_channel_id)
 
     @property
     def rules_channel(self) -> Optional["GuildText"]:
         """Returns the channel declared as a rules channel."""
-        return self._client.cache.channel_cache.get(self.rules_channel_id)
+        return self._client.cache.get_cached_channel(self.rules_channel_id)
 
     @property
     def public_updates_channel(self) -> Optional["GuildText"]:
         """Returns the channel where server staff receive notices from Discord."""
-        return self._client.cache.channel_cache.get(self.public_updates_channel_id)
+        return self._client.cache.get_cached_channel(self.public_updates_channel_id)
 
     @property
     def emoji_limit(self) -> int:
@@ -971,7 +971,7 @@ class Guild(BaseGuild):
             # theoretically, this could get any channel the client can see,
             # but to make it less confusing to new programmers,
             # i intentionally check that the guild contains the channel first
-            return self._client.cache.channel_cache.get(to_snowflake(channel_id))
+            return self._client.cache.get_cached_channel(to_snowflake(channel_id))
         return None
 
     async def fetch_channel(

--- a/dis_snek/models/discord_objects/guild.py
+++ b/dis_snek/models/discord_objects/guild.py
@@ -227,7 +227,7 @@ class Guild(BaseGuild):
     @property
     def members(self) -> List["Member"]:
         """A generator that yields all members of this guild."""
-        return [self._client.cache.get_cached_member((self.id, m_id)) for m_id in self._member_ids]
+        return [self._client.cache.get_cached_member(self.id, m_id) for m_id in self._member_ids]
 
     @property
     def premium_subscribers(self) -> List["Member"]:
@@ -252,7 +252,7 @@ class Guild(BaseGuild):
     @property
     def me(self) -> "Member":
         """Returns this bots member object within this guild."""
-        return self._client.cache.get_cached_member((self.id, self._client.user.id))
+        return self._client.cache.get_cached_member(self.id, self._client.user.id)
 
     @property
     def system_channel(self) -> Optional["GuildText"]:

--- a/dis_snek/models/discord_objects/invite.py
+++ b/dis_snek/models/discord_objects/invite.py
@@ -48,7 +48,7 @@ class Invite(ClientObject):
     @property
     def channel(self) -> "TYPE_GUILD_CHANNEL":
         """The channel the invite is for."""
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_cached_channel(self._channel_id)
 
     def inviter(self) -> "Member":
         """The user that created the invite."""

--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -186,7 +186,7 @@ class BaseMessage(DiscordObject):
         if self._author_id:
             member = None
             if self._guild_id:
-                member = self._client.cache.get_cached_member((self._guild_id, self._author_id))
+                member = self._client.cache.get_cached_member(self._guild_id, self._author_id)
             return member or self._client.cache.user_cache.get(self._author_id)
         return MISSING
 

--- a/dis_snek/models/discord_objects/message.py
+++ b/dis_snek/models/discord_objects/message.py
@@ -175,18 +175,18 @@ class BaseMessage(DiscordObject):
 
     @property
     def channel(self) -> "TYPE_MESSAGEABLE_CHANNEL":
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_cached_channel(self._channel_id)
 
     @property
     def thread(self) -> "TYPE_THREAD_CHANNEL":
-        return self._client.cache.channel_cache.get(self._thread_channel_id)
+        return self._client.cache.get_cached_channel(self._thread_channel_id)
 
     @property
     def author(self) -> Union["Member", "User"]:
         if self._author_id:
             member = None
             if self._guild_id:
-                member = self._client.cache.member_cache.get((self._guild_id, self._author_id))
+                member = self._client.cache.get_cached_member((self._guild_id, self._author_id))
             return member or self._client.cache.user_cache.get(self._author_id)
         return MISSING
 

--- a/dis_snek/models/discord_objects/reaction.py
+++ b/dis_snek/models/discord_objects/reaction.py
@@ -76,7 +76,7 @@ class Reaction(ClientObject):
 
     @property
     def channel(self) -> "TYPE_ALL_CHANNEL":
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_cached_channel(self._channel_id)
 
     async def remove(self) -> None:
         """Remove all this emoji's reactions from the message."""

--- a/dis_snek/models/discord_objects/scheduled_event.py
+++ b/dis_snek/models/discord_objects/scheduled_event.py
@@ -98,7 +98,7 @@ class ScheduledEvent(DiscordObject):
             data["creator"] = client.cache.place_user_data(data["creator"])
 
         if data.get("channel_id"):
-            data["channel"] = client.cache.channel_cache.get(data["channel_id"])
+            data["channel"] = client.cache.get_cached_channel(data["channel_id"])
 
         data["start_time"] = data.get("scheduled_start_time")
 

--- a/dis_snek/models/discord_objects/stage_instance.py
+++ b/dis_snek/models/discord_objects/stage_instance.py
@@ -27,7 +27,7 @@ class StageInstance(DiscordObject):
 
     @property
     def channel(self) -> "GuildStageVoice":
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_cached_channel(self._channel_id)
 
     async def delete(self, reason: Absent[Optional[str]] = MISSING) -> None:
         """

--- a/dis_snek/models/discord_objects/voice_state.py
+++ b/dis_snek/models/discord_objects/voice_state.py
@@ -47,7 +47,7 @@ class VoiceState(ClientObject):
     @property
     def member(self) -> "Member":
         """The member this voice state is for."""
-        return self._client.cache.get_cached_member((self._guild_id, self._member_id)) if self._guild_id else None
+        return self._client.cache.get_cached_member(self._guild_id, self._member_id) if self._guild_id else None
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:

--- a/dis_snek/models/discord_objects/voice_state.py
+++ b/dis_snek/models/discord_objects/voice_state.py
@@ -42,12 +42,12 @@ class VoiceState(ClientObject):
     @property
     def channel(self) -> "TYPE_VOICE_CHANNEL":
         """The channel the user is connected to."""
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_cached_channel(self._channel_id)
 
     @property
     def member(self) -> "Member":
         """The member this voice state is for."""
-        return self._client.cache.member_cache.get((self._guild_id, self._member_id)) if self._guild_id else None
+        return self._client.cache.get_cached_member((self._guild_id, self._member_id)) if self._guild_id else None
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:

--- a/dis_snek/smart_cache.py
+++ b/dis_snek/smart_cache.py
@@ -136,7 +136,7 @@ class GlobalCache:
         """
         guild_id = to_snowflake(guild_id)
         user_id = to_snowflake(user_id)
-        member = self._member_cache.get((guild_id, user_id))
+        member = self._member_cache.get(guild_id, user_id)
         if isinstance(member, Deferred):
             member = self.place_member_data(guild_id, member.data)
         return member

--- a/dis_snek/smart_cache.py
+++ b/dis_snek/smart_cache.py
@@ -136,7 +136,7 @@ class GlobalCache:
         """
         guild_id = to_snowflake(guild_id)
         user_id = to_snowflake(user_id)
-        member = self._member_cache.get(guild_id, user_id)
+        member = self._member_cache.get((guild_id, user_id))
         if isinstance(member, Deferred):
             member = self.place_member_data(guild_id, member.data)
         return member
@@ -179,12 +179,13 @@ class GlobalCache:
 
         member = self._member_cache.get((guild_id, user_id))
         if member is None or isinstance(member, Deferred):
-            if deferred:
-                member = self._member_cache[(guild_id, user_id)] = Deferred(data, user_id)
-                return member
             member_extra = {"guild_id": guild_id}
             member = data["member"] if is_user else data
             member.update(member_extra)
+
+            if deferred:
+                member = self._member_cache[(guild_id, user_id)] = Deferred(data, user_id)
+                return member
 
             member = Member.from_dict(data, self._client)
             self._member_cache[(guild_id, user_id)] = member

--- a/dis_snek/smart_cache.py
+++ b/dis_snek/smart_cache.py
@@ -323,7 +323,7 @@ class GlobalCache:
 
     # Channel cache methods
 
-    async def get_cached_channel(self, channel_id: "Snowflake_Type") -> Optional["TYPE_ALL_CHANNEL"]:
+    def get_cached_channel(self, channel_id: "Snowflake_Type") -> Optional["TYPE_ALL_CHANNEL"]:
         """
         Get a channel based on it's ID.
 

--- a/dis_snek/smart_cache.py
+++ b/dis_snek/smart_cache.py
@@ -61,7 +61,7 @@ class GlobalCache:
     # Non expiring discord objects cache
     user_cache: dict[int, User] = field(factory=dict)  # key: user_id
     _member_cache: dict[Tuple[int, int], Member | Deferred] = field(factory=dict)  # key: (guild_id, user_id)
-    _channel_cache: dict[Tuple[int, int], "TYPE_ALL_CHANNEL" | Deferred] = field(factory=dict)  # key: channel_id
+    _channel_cache: dict[Tuple[int, int], Union["TYPE_ALL_CHANNEL", Deferred]] = field(factory=dict)  # key: channel_id
     guild_cache: dict = field(factory=dict)  # key: guild_id
 
     # Expiring discord objects cache

--- a/dis_snek/smart_cache.py
+++ b/dis_snek/smart_cache.py
@@ -61,7 +61,7 @@ class GlobalCache:
     # Non expiring discord objects cache
     user_cache: dict[int, User] = field(factory=dict)  # key: user_id
     _member_cache: dict[Tuple[int, int], Member | Deferred] = field(factory=dict)  # key: (guild_id, user_id)
-    _channel_cache: dict[Tuple[int, int], TYPE_ALL_CHANNEL | Deferred] = field(factory=dict)  # key: channel_id
+    _channel_cache: dict[Tuple[int, int], "TYPE_ALL_CHANNEL" | Deferred] = field(factory=dict)  # key: channel_id
     guild_cache: dict = field(factory=dict)  # key: guild_id
 
     # Expiring discord objects cache

--- a/dis_snek/smart_cache.py
+++ b/dis_snek/smart_cache.py
@@ -122,9 +122,7 @@ class GlobalCache:
 
     # Member cache methods
 
-    def get_cached_member(
-        self, guild_id: "Snowflake_Type", user_id: "Snowflake_Type"
-    ) -> Optional[Member]:
+    def get_cached_member(self, guild_id: "Snowflake_Type", user_id: "Snowflake_Type") -> Optional[Member]:
         """
         Synchronously get a member by their guild and user IDs. Will not request data from Discord if it's not cached locally.
 
@@ -325,9 +323,7 @@ class GlobalCache:
 
     # Channel cache methods
 
-    async def get_cached_channel(
-        self, channel_id: "Snowflake_Type"
-    ) -> Optional["TYPE_ALL_CHANNEL"]:
+    async def get_cached_channel(self, channel_id: "Snowflake_Type") -> Optional["TYPE_ALL_CHANNEL"]:
         """
         Get a channel based on it's ID.
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
Makes Guild instantiation much lighter by throwing Channels and Members into the cache as deferred dicts (that get inflated when first pulled from the cache)

This is non-breaking, with the exception of people bypassing GlobalCache's methods to access the underlying dicts directly

Things I thought about doing, but have not done:
- Background task that slowly inflates deferred stuff while it's idle in the cache.  Discarded because it didn't feel needed.
- Deferring Roles.  The speedup from Members and Channels alone was good enough in my benchmarks.

## Changes
- Members and Channels can be optionally cached as Deferred dicts, rather than being constructed upon storage.
- The Guild constructor uses this to speed up initial load times
- The cache objects for `member_cache` and `channel_cache` are now private.
- Synchronous functions to access these caches have been added (Though I'm not 100% happy with the names)

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
