### PR TITLE
fix: Include .pyi files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/Discord-Snake-Pit/Dis-Snek",
     version=pyproject["tool"]["poetry"]["version"],
     packages=find_packages(),
-    package_data={"dis_snek": ["py.typed"]},
+    package_data={"dis_snek": ["py.typed", "*.pyi", "**/*.pyi"]},
     python_requires=">=3.10",
     install_requires=(Path(__file__).parent / "requirements.txt").read_text().splitlines(),
     classifiers=[


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
`dis_snek/utils/attr_utils.pyi` (and any future `.pyi` stubs) would not be installed when using pip or using the PyPI version. This was caused by the `setup.py` file not including them, so they were added in in this PR.


## Changes
- Edit `setup.py` to make `package_data` include `.pyi` files via a glob search.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
