### PR TITLE
fix: Properly set timezone for `Timestamp.now/utcnow`

### DIFF
--- a/dis_snek/models/discord/timestamp.py
+++ b/dis_snek/models/discord/timestamp.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, Union
@@ -63,6 +64,23 @@ class Timestamp(datetime):
     @classmethod
     def fromordinal(cls, n: int) -> "Timestamp":
         return super().fromordinal(n).astimezone()
+
+    @classmethod
+    def now(cls, tz=None):
+        """
+        Construct a datetime from time.time() and optional time zone info.
+
+        If no timezone is provided, the time is assumed to be from the computer's
+        local timezone.
+        """
+        t = time.time()
+        return cls.fromtimestamp(t, tz)
+
+    @classmethod
+    def utcnow(cls):
+        """Construct a timezone-aware UTC datetime from time.time()."""
+        t = time.time()
+        return cls.utcfromtimestamp(t)
 
     def to_snowflake(self, high: bool = False) -> Union[str, int]:
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change (realistically, anyways)
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
`Timestamp.now/utcnow` have been broken for the longest time, as they did not provide the resulting `Timestamp` with any sort of timezone information, making them timezone-naive in a class that assumes anything in it is timezone-aware. This PR fixes that by making sure they have a timezone.


## Changes
- Added `Timestamp.now/utcnow` methods, which do the same thing as `datetime.now/utcnow` but make sure to use `Timestamp`'s classmethods instead of `datetime`'s.
  (which is to yes, yeah, this is the *exact* same code as `datetime.now/utcnow`, but Python subclassing is not fun.)


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
