### PR TITLE
fix: Do not set read-only message properties.

### DIFF
--- a/dis_snek/api/events/processors/message_events.py
+++ b/dis_snek/api/events/processors/message_events.py
@@ -30,14 +30,12 @@ class MessageEvents(EventMixinTemplate):
 
         if not msg.author:
             # sometimes discord will only send an author ID, not the author. this catches that
-            msg.channel = (
-                await self.cache.get_channel(to_snowflake(msg._channel_id)) if not msg.channel else msg.channel
-            )
+            await self.cache.get_channel(to_snowflake(msg._channel_id)) if not msg.channel else msg.channel
             if msg._guild_id:
-                msg.guild = await self.cache.get_guild(msg._guild_id) if not msg.guild else msg.guild
-                msg.author = await self.cache.get_member(msg._guild_id, msg._author_id)
+                await self.cache.get_guild(msg._guild_id) if not msg.guild else msg.guild
+                await self.cache.get_member(msg._guild_id, msg._author_id)
             else:
-                msg.author = await self.cache.get_user(to_snowflake(msg._author_id))
+                await self.cache.get_user(to_snowflake(msg._author_id))
 
         self.dispatch(events.MessageCreate(msg))
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->

The way the properties are set will cause error, since it's read-only. Mainly the point is to load them into cache, so just not setting the properties should be fine.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [ ] I've tested my code
