### PR TITLE
refactor!: ChannelUpdate now has before and after args just like all other events

### DIFF
--- a/dis_snek/api/events/discord.py
+++ b/dis_snek/api/events/discord.py
@@ -66,8 +66,13 @@ class ChannelCreate(BaseEvent):
 
 
 @attr.s(slots=True)
-class ChannelUpdate(ChannelCreate):
+class ChannelUpdate(BaseEvent):
     """Dispatched when a channel is updated."""
+
+    before: "BaseChannel" = attr.ib()
+    """Channel before this event. MISSING if it was not cached before"""
+    after: "BaseChannel" = attr.ib()
+    """Channel after this event"""
 
 
 @attr.s(slots=True)

--- a/dis_snek/api/events/processors/channel_events.py
+++ b/dis_snek/api/events/processors/channel_events.py
@@ -1,9 +1,10 @@
+import copy
 import logging
 from typing import TYPE_CHECKING
 
 import dis_snek.api.events as events
 from dis_snek.models.discord.invite import Invite
-from dis_snek.client.const import logger_name
+from dis_snek.client.const import MISSING, logger_name
 from ._template import EventMixinTemplate, Processor
 from dis_snek.client.utils.converters import timestamp_converter
 
@@ -33,8 +34,8 @@ class ChannelEvents(EventMixinTemplate):
 
     @Processor.define()
     async def _on_raw_channel_update(self, event: "RawGatewayEvent") -> None:
-        channel = self.cache.place_channel_data(event.data)
-        self.dispatch(events.ChannelUpdate(channel))
+        before = copy.copy(await self.cache.get_channel(channel_id=event.data.get("id"), request_fallback=False))
+        self.dispatch(events.ChannelUpdate(before=before or MISSING, after=self.cache.place_channel_data(event.data)))
 
     @Processor.define()
     async def _on_raw_channel_pins_update(self, event: "RawGatewayEvent") -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
ChannelUpdate was inconsistent to all other events

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- add before and after args to ChannelUpdate

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
