### PR TITLE
fix: Use optional_timestamp_converter

### DIFF
--- a/dis_snek/models/discord/invite.py
+++ b/dis_snek/models/discord/invite.py
@@ -4,7 +4,7 @@ from attr.converters import optional as optional_c
 
 from dis_snek.client.const import MISSING
 from dis_snek.client.utils.attr_utils import define, field
-from dis_snek.client.utils.converters import timestamp_converter
+from dis_snek.client.utils.converters import optional_timestamp_converter, timestamp_converter
 from dis_snek.models.discord.application import Application
 from dis_snek.models.discord.enums import InviteTargetTypes
 from dis_snek.models.discord.guild import GuildPreview
@@ -27,7 +27,7 @@ class Invite(ClientObject):
     # metadata
     uses: int = field(default=0)
     max_uses: int = field(default=0)
-    created_at: Timestamp = field(default=MISSING, converter=optional_c(timestamp_converter))
+    created_at: Timestamp = field(default=MISSING, converter=optional_c(optional_timestamp_converter))
     expires_at: Optional[Timestamp] = field(default=None, converter=optional_c(timestamp_converter))
     temporary: bool = field(default=False)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
When the `on_invite_delete` event was sent there was no timestamp, so all I did was use the optional timestamp converter instead.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- `converter=optional_c(optional_timestamp_converter)`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
