### PR TITLE
Ratelimit commands when holding lock and RESUME more

### DIFF
--- a/dis_snek/api/gateway/gateway.py
+++ b/dis_snek/api/gateway/gateway.py
@@ -225,7 +225,7 @@ class WebsocketClient:
                 if force:
                     raise RuntimeError("Discord unexpectedly wants to close the WebSocket during force receive!")
 
-                await self.reconnect(code=1000)
+                await self.reconnect(code=resp.data, resume=resp.data != 1000)
                 continue
 
             elif resp.type is WSMsgType.CLOSED:
@@ -241,7 +241,7 @@ class WebsocketClient:
                     # This is an odd corner-case where the underlying socket connection was closed
                     # unexpectedly without communicating the WebSocket closing handshake. We'll have
                     # to reconnect ourselves.
-                    await self.reconnect()
+                    await self.reconnect(resume=True)
 
             elif resp.type is WSMsgType.CLOSING:
                 if force:

--- a/dis_snek/api/gateway/gateway.py
+++ b/dis_snek/api/gateway/gateway.py
@@ -174,13 +174,12 @@ class WebsocketClient:
             bypass: Should the rate limit be ignored for this send (used for heartbeats)
 
         """
-        if not bypass:
-            await self.rl_manager.rate_limit()
-
         log.debug(f"Sending data to gateway: {data}")
         async with self._race_lock:
             if self.ws is None:
                 raise RuntimeError
+            if not bypass:
+                await self.rl_manager.rate_limit()
 
             await self.ws.send_str(data)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description

The gateway used to ratelimit commands before waiting for the lock, this has now been moved into the context manager when holding the lock.

Additionally, there were a few places where `self.reconnect()` was used without specifying `resume` which lead to using the default of IDENTIFYing.

## Changes

- Move gateway command ratelimiting into the context manager where the lock is held
- RESUME in more reconnection cases

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
