### PR TITLE
fix: Keep local member model in sync when we add or remove roles

### DIFF
--- a/dis_snek/models/discord/user.py
+++ b/dis_snek/models/discord/user.py
@@ -399,7 +399,7 @@ class Member(DiscordObject, _SendDMMixin):
         """
         return await self._client.http.modify_guild_member(self._guild_id, self.id, nickname=new_nickname)
 
-    async def add_role(self, role: Union[Snowflake_Type, Role], reason: Absent[str] = MISSING) -> dict:
+    async def add_role(self, role: Union[Snowflake_Type, Role], reason: Absent[str] = MISSING) -> None:
         """
         Add a role to this member.
 
@@ -409,7 +409,8 @@ class Member(DiscordObject, _SendDMMixin):
 
         """
         role = to_snowflake(role)
-        return await self._client.http.add_guild_member_role(self._guild_id, self.id, role, reason=reason)
+        await self._client.http.add_guild_member_role(self._guild_id, self.id, role, reason=reason)
+        self._role_ids.append(role)
 
     async def remove_role(self, role: Union[Snowflake_Type, Role], reason: Absent[str] = MISSING) -> None:
         """
@@ -422,7 +423,8 @@ class Member(DiscordObject, _SendDMMixin):
         """
         if isinstance(role, Role):
             role = role.id
-        return await self._client.http.remove_guild_member_role(self._guild_id, self.id, role, reason=reason)
+        await self._client.http.remove_guild_member_role(self._guild_id, self.id, role, reason=reason)
+        self._role_ids.remove(role)
 
     def has_role(self, *roles: Union[Snowflake_Type, Role]) -> bool:
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
When adding or removing roles to a user, we need to keep the cached user in sync with what the user actually looks like.

## Changes
- functions now add and removes role_ids as appropriate
- Removed redundant Return Nones
- Fixed type hint on add_role


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
