### PR TITLE
fix: Reverse byte order on color

### DIFF
--- a/dis_snek/models/discord/color.py
+++ b/dis_snek/models/discord/color.py
@@ -60,7 +60,7 @@ class Color:
 
     @property
     def r(self) -> int:
-        return self._get_byte(0)
+        return self._get_byte(2)
 
     @property
     def g(self) -> int:
@@ -68,11 +68,11 @@ class Color:
 
     @property
     def b(self) -> int:
-        return self._get_byte(2)
+        return self._get_byte(0)
 
     @property
     def rgb(self) -> Tuple[int, int, int]:
-        return self._get_byte(0), self._get_byte(1), self._get_byte(2)
+        return self._get_byte(2), self._get_byte(1), self._get_byte(0)
 
     @property
     def rgb_float(self) -> Tuple[float, float, float]:

--- a/dis_snek/models/discord/color.py
+++ b/dis_snek/models/discord/color.py
@@ -72,7 +72,7 @@ class Color:
 
     @property
     def rgb(self) -> Tuple[int, int, int]:
-        return self._get_byte(2), self._get_byte(1), self._get_byte(0)
+        return self.r, self.g, self.b
 
     @property
     def rgb_float(self) -> Tuple[float, float, float]:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
This closes #245 by correcting the byte order in `Color` to fix an issue with colors being represented in BGR format instead of RGB


## Changes
- Reverse byte order in `Color`


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
