### PR TITLE
fix: Asset url and get broken

### DIFF
--- a/dis_snek/models/discord/asset.py
+++ b/dis_snek/models/discord/asset.py
@@ -35,7 +35,8 @@ class Asset:
 
     @property
     def url(self) -> str:
-        return f"{self._url}?size=4096"
+        ext = ".gif" if self.animated else ".png"
+        return f"{self._url}{ext}?size=4096"
 
     @property
     def animated(self) -> bool:
@@ -62,7 +63,7 @@ class Asset:
         if not extension:
             extension = ".gif" if self.animated else ".png"
 
-        url = self.url
+        url = self._url + extension
 
         if size:
             if not ((size != 0) and (size & (size - 1) == 0)):  # if not power of 2
@@ -72,7 +73,6 @@ class Asset:
 
             url = f"{url}?size={size}"
 
-        url = url + extension
         return await self._client.http.request_cdn(url, self)
 
     async def save(


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
`Asset.url` returned a malformed URL missing the extension, and `Asset.get` used `Asset.url` instead of `Asset._url`, creating a broken mess of URLs

Thank you Polls for the sane fix

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Change `Asset.url` to include extension
- Change `Asset.get` to use `Asset._url`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
