### PR TITLE
fix: behaviour of role add and delete events

### DIFF
--- a/dis_snek/api/events/discord.py
+++ b/dis_snek/api/events/discord.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, List, Union, Optional
 import attr
 
 import dis_snek.models
-from dis_snek.client.const import MISSING
+from dis_snek.client.const import MISSING, Absent
 from dis_snek.client.utils.attr_utils import docs
 from .internal import BaseEvent, GuildEvent
 
@@ -258,7 +258,7 @@ class RoleCreate(BaseEvent, GuildEvent):
 class RoleUpdate(BaseEvent, GuildEvent):
     """Dispatched when a role is updated."""
 
-    before: "Role" = attr.ib()
+    before: Absent["Role"] = attr.ib()
     """The role before this event"""
     after: "Role" = attr.ib()
     """The role after this event"""
@@ -268,8 +268,10 @@ class RoleUpdate(BaseEvent, GuildEvent):
 class RoleDelete(BaseEvent, GuildEvent):
     """Dispatched when a guild role is deleted."""
 
-    role_id: "Snowflake_Type" = attr.ib()
+    id: "Snowflake_Type" = attr.ib()
     """The ID of the deleted role"""
+    role: Absent["Role"] = attr.ib()
+    """The deleted role"""
 
 
 # todo implementation missing

--- a/dis_snek/api/events/processors/role_events.py
+++ b/dis_snek/api/events/processors/role_events.py
@@ -18,13 +18,18 @@ log = logging.getLogger(logger_name)
 class RoleEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_guild_role_create(self, event: "RawGatewayEvent") -> None:
-        g_id = event.data.get("guild_id")
-        role = self.cache.place_role_data(g_id, [event.data.get("role")])
-        self.dispatch(events.RoleCreate(g_id, role[int(event.data["role"]["id"])]))
+        g_id = int(event.data.get("guild_id"))
+        r_id = int(event.data["role"]["id"])
+
+        guild = self.cache.guild_cache.get(g_id)
+        guild._role_ids.add(r_id)
+
+        role = self.cache.place_role_data(g_id, [event.data.get("role")])[r_id]
+        self.dispatch(events.RoleCreate(g_id, role))
 
     @Processor.define()
     async def _on_raw_guild_role_update(self, event: "RawGatewayEvent") -> None:
-        g_id = event.data.get("guild_id")
+        g_id = int(event.data.get("guild_id"))
         r_data = event.data.get("role")
         before = copy.copy(await self.cache.get_role(g_id, r_data["id"], False) or MISSING)
 
@@ -35,4 +40,16 @@ class RoleEvents(EventMixinTemplate):
 
     @Processor.define()
     async def _on_raw_guild_role_delete(self, event: "RawGatewayEvent") -> None:
-        self.dispatch(events.RoleDelete(event.data.get("guild_id"), event.data.get("role_id")))
+        g_id = int(event.data.get("guild_id"))
+        r_id = int(event.data.get("role_id"))
+
+        guild = self.cache.guild_cache.get(g_id)
+        role = self.cache.role_cache.pop(r_id, MISSING)
+
+        guild._role_ids.discard(r_id)
+
+        role_members = (member for member in guild.members if member.has_role(r_id))
+        for member in role_members:
+            member._role_ids.remove(r_id)
+
+        self.dispatch(events.RoleDelete(g_id, r_id, role))


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [X] Breaking code change
- [ ] Documentation change/addition

## Description
Reworked role add and delete events so they update all caches/related sets properly

## Changes

- role_create event now adds role id to guild._role_ids
- role_delete event now removes role id from global cache, guild._role_ids, member._role_ids
- RoleUpdate.before is now Absent["Role"] (fixed typehint)
- 💥RoleDelete.role_id renamed to RoleDelete.id
- Added role: Absent["Role"] to RoleDelete


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [X] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.10.x`
- [X] I've tested my code
