### PR TITLE
fix: Safer way to pop waits in Snake.dispatch()

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -638,7 +638,7 @@ class Snake(
                 if result:
                     index_to_remove.append(i)
 
-            for idx in index_to_remove:
+            for idx in sorted(index_to_remove, reverse=True):
                 _waits.pop(idx)
 
     async def wait_until_ready(self) -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [X] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
Occasionally there will be two identical waits which need to be removed upon a call to `Client.dispatch()`. I usually see this behavior after a previous call to `wait_for_component()` times out. Regardless, the list of indexes to pop from a list should be sorted in descending order to prevent `IndexErrors`


## Changes
* In `Client.dispatch()`, added `sorted(..., reverse=True)` so that indexes are always removed in descending order


## Checklist
- [X] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.10.x`
- [X] I've tested my code
