### PR TITLE
FIX: bitrate_limit was set too high since some batman added two number

### DIFF
--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -273,7 +273,7 @@ class Guild(BaseGuild):
     @property
     def bitrate_limit(self) -> int:
         """The maximum bitrate for this guild."""
-        base = 128000 if "VIP_REGIONS" in self.features else 9600024
+        base = 128000 if "VIP_REGIONS" in self.features else 96000
         return max(base, PREMIUM_GUILD_LIMITS[self.premium_tier]["bitrate"])
 
     @property


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
`9600024` is too high of a bitrate_limit

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- set bitrate_limit to `96000`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
