### PR TITLE
FEAT: add property to voice channel that returns users currently in voice chat

### DIFF
--- a/dis_snek/api/events/processors/voice_events.py
+++ b/dis_snek/api/events/processors/voice_events.py
@@ -20,4 +20,5 @@ class VoiceEvents(EventMixinTemplate):
     async def _on_raw_voice_state_update(self, event: "RawGatewayEvent") -> None:
         before = copy.copy(self.cache.get_voice_state(event.data["user_id"])) or None
         after = self.cache.place_voice_state_data(event.data)
+
         self.dispatch(events.VoiceStateUpdate(before, after))

--- a/dis_snek/api/events/processors/voice_events.py
+++ b/dis_snek/api/events/processors/voice_events.py
@@ -19,6 +19,6 @@ class VoiceEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_voice_state_update(self, event: "RawGatewayEvent") -> None:
         before = copy.copy(self.cache.get_voice_state(event.data["user_id"])) or None
-        after = self.cache.place_voice_state_data(event.data)
+        after = await self.cache.place_voice_state_data(event.data)
 
         self.dispatch(events.VoiceStateUpdate(before, after))

--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -514,7 +514,6 @@ class GlobalCache:
         Returns:
             The processed VoiceState object
         """
-
         user_id = to_snowflake(data["user_id"])
 
         # try to remove the user from the _voice_member_ids list of the old channel obj, if that exists

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -1475,10 +1475,7 @@ class VoiceChannel(GuildChannel):  # May not be needed, can be directly just Gui
 
     @property
     def voice_members(self) -> List["models.Member"]:
-        """
-        Returns a list of members that are currently in the channel
-        Note: This will not be accurate if the bot was offline while users joined the channel
-        """
+        """Returns a list of members that are currently in the channel. Note: This will not be accurate if the bot was offline while users joined the channel"""
         return [self._client.cache.member_cache.get((self.guild.id, member_id)) for member_id in self._voice_member_ids]
 
 

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -1427,6 +1427,7 @@ class VoiceChannel(GuildChannel):  # May not be needed, can be directly just Gui
     user_limit: int = attr.ib()
     rtc_region: str = attr.ib(default="auto")
     video_quality_mode: Union[VideoQualityModes, int] = attr.ib(default=VideoQualityModes.AUTO)
+    _voice_member_ids: list[Snowflake_Type] = attr.ib(factory=list)
 
     async def edit(
         self,
@@ -1470,8 +1471,15 @@ class VoiceChannel(GuildChannel):  # May not be needed, can be directly just Gui
     @property
     def members(self) -> List["models.Member"]:
         """Returns a list of members that have access to this voice channel"""
-        # todo: when we support voice states, check if user is within channel
         return [m for m in self.guild.members if Permissions.CONNECT in m.channel_permissions(self)]  # type: ignore
+
+    @property
+    def voice_members(self) -> List["models.Member"]:
+        """
+        Returns a list of members that are currently in the channel
+        Note: This will not be accurate if the bot was offline while users joined the channel
+        """
+        return [self._client.cache.member_cache.get((self.guild.id, member_id)) for member_id in self._voice_member_ids]
 
 
 @define()

--- a/dis_snek/models/discord/voice_state.py
+++ b/dis_snek/models/discord/voice_state.py
@@ -1,3 +1,4 @@
+import copy
 from typing import TYPE_CHECKING, Optional, Dict, Any
 
 from dis_snek.client.const import MISSING
@@ -43,7 +44,16 @@ class VoiceState(ClientObject):
     @property
     def channel(self) -> "TYPE_VOICE_CHANNEL":
         """The channel the user is connected to."""
-        return self._client.cache.channel_cache.get(self._channel_id)
+        channel = self._client.cache.channel_cache.get(self._channel_id)
+
+        # make sure the member is showing up as a part of the channel
+        # this is relevant for VoiceStateUpdate.before
+        if self._member_id not in channel._voice_member_ids:
+            # create a copy and add the member to that list
+            channel = copy.copy(channel)
+            channel._voice_member_ids.append(self._member_id)
+
+        return channel
 
     @property
     def member(self) -> "Member":


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->

Before there was no way to tell who is currently in a voice channel. This is not perfect, since if the bot starts when people are already in a channel, it won't get caught. Since discord does not dispatch voice members anywhere however, this is the best we can do pretty sure

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- add .voice_members property to VoiceChannel
- add / remove members from there on VoiceStateUpdate

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
