### PR TITLE
fix: Paginator always trying to create SelectMenu

### DIFF
--- a/dis_snek/ext/paginators.py
+++ b/dis_snek/ext/paginators.py
@@ -108,7 +108,7 @@ class Paginator:
             ComponentCommand(
                 name=f"Paginator:{self._uuid}",
                 callback=self._on_button,
-                listeners=list(get_components_ids(self.create_components(all=True))),
+                listeners=list(get_components_ids(self.create_components())),
             )
         )
 


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
Paginator was always trying to create SelectMenu which caused any Paginator that had over 25 pages to crash.

## Changes
fix: Removed `all` from call to create_components

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
