### PR TITLE
refactor: Make all gets non-async, all fetches async

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1422,9 +1422,9 @@ class Snake(
 
         # todo: maybe add an ability to revert to the previous version if unable to load the new one
 
-    async def get_guild(self, guild_id: "Snowflake_Type") -> Optional[Guild]:
+    async def fetch_guild(self, guild_id: "Snowflake_Type") -> Optional[Guild]:
         """
-        Get a guild.
+        Fetch a guild.
 
         Note:
             This method is an alias for the cache which will either return a cached object, or query discord for the object
@@ -1439,6 +1439,25 @@ class Snake(
         """
         try:
             return await self.cache.fetch_guild(guild_id)
+        except NotFound:
+            return None
+
+    def get_guild(self, guild_id: "Snowflake_Type") -> Optional[Guild]:
+        """
+        Get a guild.
+
+        Note:
+            This method is an alias for the cache which will return a cached object.
+
+        Args:
+            guild_id: The ID of the guild to get
+
+        Returns:
+            Guild Object if found, otherwise None
+
+        """
+        try:
+            return self.cache.get_guild(guild_id)
         except NotFound:
             return None
 
@@ -1465,9 +1484,9 @@ class Snake(
         guild_data = await self.http.create_guild_from_guild_template(template_code, name, icon)
         return Guild.from_dict(guild_data, self)
 
-    async def get_channel(self, channel_id: "Snowflake_Type") -> Optional["TYPE_ALL_CHANNEL"]:
+    async def fetch_channel(self, channel_id: "Snowflake_Type") -> Optional["TYPE_ALL_CHANNEL"]:
         """
-        Get a channel.
+        Fetch a channel.
 
         Note:
             This method is an alias for the cache which will either return a cached object, or query discord for the object
@@ -1485,9 +1504,27 @@ class Snake(
         except NotFound:
             return None
 
-    async def get_user(self, user_id: "Snowflake_Type") -> Optional[User]:
+    def get_channel(self, channel_id: "Snowflake_Type") -> Optional["TYPE_ALL_CHANNEL"]:
         """
-        Get a user.
+        Get a channel.
+
+        Note:
+            This method is an alias for the cache which will return a cached object.
+
+        Args:
+            channel_id: The ID of the channel to get
+
+        Returns:
+            Channel Object if found, otherwise None
+        """
+        try:
+            return self.cache.get_channel(channel_id)
+        except NotFound:
+            return None
+
+    async def fetch_user(self, user_id: "Snowflake_Type") -> Optional[User]:
+        """
+        Fetch a user.
 
         Note:
             This method is an alias for the cache which will either return a cached object, or query discord for the object
@@ -1505,9 +1542,28 @@ class Snake(
         except NotFound:
             return None
 
-    async def get_member(self, user_id: "Snowflake_Type", guild_id: "Snowflake_Type") -> Optional[Member]:
+    def get_user(self, user_id: "Snowflake_Type") -> Optional[User]:
         """
-        Get a member from a guild.
+        Get a user.
+
+        Note:
+            This method is an alias for the cache which will return a cached object.
+
+        Args:
+            user_id: The ID of the user to get
+
+        Returns:
+            User Object if found, otherwise None
+
+        """
+        try:
+            return self.cache.get_user(user_id)
+        except NotFound:
+            return None
+
+    async def fetch_member(self, user_id: "Snowflake_Type", guild_id: "Snowflake_Type") -> Optional[Member]:
+        """
+        Fetch a member from a guild.
 
         Note:
             This method is an alias for the cache which will either return a cached object, or query discord for the object
@@ -1526,11 +1582,31 @@ class Snake(
         except NotFound:
             return None
 
-    async def get_scheduled_event(
+    def get_member(self, user_id: "Snowflake_Type", guild_id: "Snowflake_Type") -> Optional[Member]:
+        """
+        Get a member from a guild.
+
+        Note:
+            This method is an alias for the cache which will return a cached object.
+
+        Args:
+            user_id: The ID of the member
+            guild_id: The ID of the guild to get the member from
+
+        Returns:
+            Member object if found, otherwise None
+
+        """
+        try:
+            return self.cache.get_member(guild_id, user_id)
+        except NotFound:
+            return None
+
+    async def fetch_scheduled_event(
         self, guild_id: "Snowflake_Type", scheduled_event_id: "Snowflake_Type", with_user_count: bool = False
     ) -> Optional["ScheduledEvent"]:
         """
-        Get a scheduled event by id.
+        Fetch a scheduled event by id.
 
         parameters:
             event_id: The id of the scheduled event.
@@ -1545,9 +1621,9 @@ class Snake(
         except NotFound:
             return None
 
-    async def get_sticker(self, sticker_id: "Snowflake_Type") -> Optional[Sticker]:
+    async def fetch_sticker(self, sticker_id: "Snowflake_Type") -> Optional[Sticker]:
         """
-        Get a sticker by ID.
+        Fetch a sticker by ID.
 
         Args:
             sticker_id: The ID of the sticker.
@@ -1562,7 +1638,7 @@ class Snake(
         except NotFound:
             return None
 
-    async def get_nitro_packs(self) -> Optional[List["StickerPack"]]:
+    async def fetch_nitro_packs(self) -> Optional[List["StickerPack"]]:
         """
         List the sticker packs available to Nitro subscribers.
 

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1456,10 +1456,7 @@ class Snake(
             Guild Object if found, otherwise None
 
         """
-        try:
-            return self.cache.get_guild(guild_id)
-        except NotFound:
-            return None
+        return self.cache.get_guild(guild_id)
 
     async def create_guild_from_guild_template(
         self, template_code: str, name: str, icon: Absent[Optional[Union[str, "Path", "IOBase"]]] = MISSING
@@ -1517,10 +1514,7 @@ class Snake(
         Returns:
             Channel Object if found, otherwise None
         """
-        try:
-            return self.cache.get_channel(channel_id)
-        except NotFound:
-            return None
+        return self.cache.get_channel(channel_id)
 
     async def fetch_user(self, user_id: "Snowflake_Type") -> Optional[User]:
         """
@@ -1556,10 +1550,7 @@ class Snake(
             User Object if found, otherwise None
 
         """
-        try:
-            return self.cache.get_user(user_id)
-        except NotFound:
-            return None
+        return self.cache.get_user(user_id)
 
     async def fetch_member(self, user_id: "Snowflake_Type", guild_id: "Snowflake_Type") -> Optional[Member]:
         """
@@ -1597,10 +1588,7 @@ class Snake(
             Member object if found, otherwise None
 
         """
-        try:
-            return self.cache.get_member(guild_id, user_id)
-        except NotFound:
-            return None
+        return self.cache.get_member(guild_id, user_id)
 
     async def fetch_scheduled_event(
         self, guild_id: "Snowflake_Type", scheduled_event_id: "Snowflake_Type", with_user_count: bool = False

--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -631,7 +631,7 @@ class GlobalCache:
 
     def get_role(self, role_id: "Snowflake_Type") -> Optional[Role]:
         """
-        Get a role based on the guild and its own ID.
+        Get a role based on the role ID.
 
         Args:
             role_id: The ID of the role
@@ -787,7 +787,7 @@ class GlobalCache:
 
     def get_emoji(self, emoji_id: "Snowflake_Type") -> Optional["CustomEmoji"]:
         """
-        Get an emoji based on the guild and its own ID.
+        Get an emoji based on the emoji ID.
 
         This cache is disabled by default, start your bot with `Snake(enable_emoji_cache=True)` to enable it.
 

--- a/dis_snek/models/discord/asset.py
+++ b/dis_snek/models/discord/asset.py
@@ -47,9 +47,9 @@ class Asset:
             return None
         return self.hash.startswith("a_")
 
-    async def get(self, extension: Optional[str] = None, size: Optional[int] = None) -> bytes:
+    async def fetch(self, extension: Optional[str] = None, size: Optional[int] = None) -> bytes:
         """
-        Get the asset from the Discord CDN.
+        Fetch the asset from the Discord CDN.
 
         Args:
             extension: File extension

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -101,11 +101,11 @@ class ChannelHistory(AsyncIterator):
             if not self.last:
                 self.last = namedtuple("temp", "id")
                 self.last.id = self.after
-            messages = await self.channel.get_messages(limit=self.get_limit, after=self.last.id)
+            messages = await self.channel.fetch_messages(limit=self.get_limit, after=self.last.id)
             messages.sort(key=lambda x: x.id)
 
         elif self.around:
-            messages = await self.channel.get_messages(limit=self.get_limit, around=self.around)
+            messages = await self.channel.fetch_messages(limit=self.get_limit, around=self.around)
             # todo: decide how getting *more* messages from `around` would work
             self._limit = 1  # stops history from getting more messages
 
@@ -147,7 +147,7 @@ class MessageableMixin(SendMixin):
     async def _send_http_request(self, message_payload: Union[dict, "FormData"]) -> dict:
         return await self._client.http.create_message(message_payload, self.id)
 
-    async def get_message(self, message_id: Snowflake_Type) -> "models.Message":
+    async def fetch_message(self, message_id: Snowflake_Type) -> "models.Message":
         """
         Fetch a message from the channel.
 
@@ -156,10 +156,23 @@ class MessageableMixin(SendMixin):
 
         Returns:
             The message object fetched.
-
         """
         message_id = to_snowflake(message_id)
         message: "models.Message" = await self._client.cache.fetch_message(self.id, message_id)
+        return message
+
+    def get_message(self, message_id: Snowflake_Type) -> "models.Message":
+        """
+        Get a message from the channel.
+
+        Args:
+            message_id: ID of message to retrieve.
+
+        Returns:
+            The message object fetched.
+        """
+        message_id = to_snowflake(message_id)
+        message: "models.Message" = self._client.cache.get_message(self.id, message_id)
         return message
 
     def history(
@@ -199,7 +212,7 @@ class MessageableMixin(SendMixin):
         """
         return ChannelHistory(self, limit, before, after, around)
 
-    async def get_messages(
+    async def fetch_messages(
         self,
         limit: int = 50,
         around: Snowflake_Type = MISSING,
@@ -235,7 +248,7 @@ class MessageableMixin(SendMixin):
 
         return [self._client.cache.place_message_data(m) for m in messages_data]
 
-    async def get_pinned_messages(self) -> List["models.Message"]:
+    async def fetch_pinned_messages(self) -> List["models.Message"]:
         """
         Fetch pinned messages from the channel.
 
@@ -401,8 +414,8 @@ class InvitableMixin:
         )
         return models.Invite.from_dict(invite_data, self._client)
 
-    async def get_invites(self) -> List["models.Invite"]:
-        """Gets all invites (with invite metadata) for the channel."""
+    async def fetch_invites(self) -> List["models.Invite"]:
+        """Fetches all invites (with invite metadata) for the channel."""
         invites_data = await self._client.http.get_channel_invites(self.id)
         return models.Invite.from_list(invites_data, self._client)
 
@@ -468,7 +481,7 @@ class ThreadableMixin:
         )
         return self._client.cache.place_channel_data(thread_data)
 
-    async def get_public_archived_threads(
+    async def fetch_public_archived_threads(
         self, limit: int = None, before: Optional["models.Timestamp"] = None
     ) -> "models.ThreadList":
         """
@@ -485,7 +498,7 @@ class ThreadableMixin:
         threads_data["id"] = self.id
         return models.ThreadList.from_dict(threads_data, self._client)
 
-    async def get_private_archived_threads(
+    async def fetch_private_archived_threads(
         self, limit: int = None, before: Optional["models.Timestamp"] = None
     ) -> "models.ThreadList":
         """
@@ -502,7 +515,7 @@ class ThreadableMixin:
         threads_data["id"] = self.id
         return models.ThreadList.from_dict(threads_data, self._client)
 
-    async def get_archived_threads(
+    async def fetch_archived_threads(
         self, limit: int = None, before: Optional["models.Timestamp"] = None
     ) -> "models.ThreadList":
         """
@@ -522,7 +535,7 @@ class ThreadableMixin:
         threads_data["id"] = self.id
         return models.ThreadList.from_dict(threads_data, self._client)
 
-    async def get_joined_private_archived_threads(
+    async def fetch_joined_private_archived_threads(
         self, limit: int = None, before: Optional["models.Timestamp"] = None
     ) -> "models.ThreadList":
         """
@@ -538,7 +551,7 @@ class ThreadableMixin:
         threads_data["id"] = self.id
         return models.ThreadList.from_dict(threads_data, self._client)
 
-    async def get_active_threads(self) -> "models.ThreadList":
+    async def fetch_active_threads(self) -> "models.ThreadList":
         """Returns all active threads in the channel, including public and private threads."""
         threads_data = await self._client.http.list_active_threads(guild_id=self._guild_id)
 
@@ -561,7 +574,7 @@ class ThreadableMixin:
 
         return models.ThreadList.from_dict(threads_data, self._client)
 
-    async def get_all_threads(self) -> "models.ThreadList":
+    async def fetch_all_threads(self) -> "models.ThreadList":
         """Returns all threads in the channel. Active and archived, including public and private threads."""
         threads = await self.get_active_threads()
 
@@ -600,9 +613,9 @@ class WebhookMixin:
         """
         return await webhook.delete()
 
-    async def get_webhooks(self) -> List["models.Webhook"]:
+    async def fetch_webhooks(self) -> List["models.Webhook"]:
         """
-        Get all the webhooks for this channel.
+        Fetches all the webhooks for this channel.
 
         Returns:
             List of webhooks
@@ -722,9 +735,13 @@ class DMGroup(DMChannel):
     application_id: Optional[Snowflake_Type] = attr.ib(default=None)
     recipients: List["models.User"] = field(factory=list)
 
-    async def get_owner(self) -> "models.User":
-        """Get the owner of this DM group"""
+    async def fetch_owner(self) -> "models.User":
+        """Fetch the owner of this DM group"""
         return await self._client.cache.fetch_user(self.owner_id)
+
+    def get_owner(self) -> "models.User":
+        """Get the owner of this DM group"""
+        return self._client.cache.get_user(self.owner_id)
 
     async def add_recipient(
         self, user: Union["models.User", Snowflake_Type], access_token: str, nickname: Absent[Optional[str]] = MISSING
@@ -1309,7 +1326,7 @@ class ThreadChannel(GuildChannel, MessageableMixin, WebhookMixin):
         """Returns a string that would mention this thread."""
         return f"<#{self.id}>"
 
-    async def get_members(self) -> List["models.ThreadMember"]:
+    async def fetch_members(self) -> List["models.ThreadMember"]:
         """Get the members that have access to this thread."""
         members_data = await self._client.http.list_thread_members(self.id)
         members = []
@@ -1495,9 +1512,9 @@ class GuildStageVoice(GuildVoice):
 
     # todo: Listeners and speakers properties (needs voice state caching)
 
-    async def get_stage_instance(self) -> "models.StageInstance":
+    async def fetch_stage_instance(self) -> "models.StageInstance":
         """
-        Gets the stage instance associated with this channel.
+        Fetches the stage instance associated with this channel.
 
         If no stage is live, will return None.
 

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -642,7 +642,7 @@ class Guild(BaseGuild):
 
         """
         emoji = self._client.cache.get_emoji(emoji_id)
-        if emoji._guild_id == self.id:
+        if emoji and emoji._guild_id == self.id:
             return emoji
         return None
 

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -641,7 +641,10 @@ class Guild(BaseGuild):
             The custom emoji object.
 
         """
-        return self._client.cache.get_emoji(self.id, emoji_id)
+        emoji = self._client.cache.get_emoji(emoji_id)
+        if emoji._guild_id != self.id:
+            return None
+        return emoji
 
     async def create_channel(
         self,
@@ -1065,7 +1068,10 @@ class Guild(BaseGuild):
             A role object or None if the role is not found.
 
         """
-        return self._client.cache.get_role(self.id, role_id)
+        role = self._client.cache.get_role(role_id)
+        if role._guild_id != self.id:
+            return None
+        return role
 
     async def create_role(
         self,

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -642,9 +642,9 @@ class Guild(BaseGuild):
 
         """
         emoji = self._client.cache.get_emoji(emoji_id)
-        if emoji._guild_id != self.id:
-            return None
-        return emoji
+        if emoji._guild_id == self.id:
+            return emoji
+        return None
 
     async def create_channel(
         self,
@@ -1068,10 +1068,10 @@ class Guild(BaseGuild):
             A role object or None if the role is not found.
 
         """
-        role = self._client.cache.get_role(role_id)
-        if role._guild_id != self.id:
-            return None
-        return role
+        role_id = to_snowflake(role_id)
+        if role_id in self._role_ids:
+            return self._client.cache.get_role(role_id)
+        return None
 
     async def create_role(
         self,

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -641,6 +641,7 @@ class Guild(BaseGuild):
             The custom emoji object.
 
         """
+        emoji_id = to_snowflake(emoji_id)
         emoji = self._client.cache.get_emoji(emoji_id)
         if emoji and emoji._guild_id == self.id:
             return emoji

--- a/dis_snek/models/discord/message.py
+++ b/dis_snek/models/discord/message.py
@@ -236,9 +236,9 @@ class Message(BaseMessage):
         for r_id in self._mention_roles:
             yield await self._client.cache.fetch_role(self._guild_id, r_id)
 
-    async def get_referenced_message(self) -> Optional["Message"]:
+    async def fetch_referenced_message(self) -> Optional["Message"]:
         """
-        Get the message this message is referencing, if any.
+        Fetch the message this message is referencing, if any.
 
         Returns:
             The referenced message, if found
@@ -247,6 +247,17 @@ class Message(BaseMessage):
         if self._referenced_message_id is None:
             return None
         return await self._client.cache.fetch_message(self._channel_id, self._referenced_message_id)
+
+    def get_referenced_message(self) -> Optional["Message"]:
+        """
+        Get the message this message is referencing, if any.
+
+        Returns:
+            The referenced message, if found
+        """
+        if self._referenced_message_id is None:
+            return None
+        return self._client.cache.get_message(self._channel_id, self._referenced_message_id)
 
     @classmethod
     def _process_dict(cls, data: dict, client: "Snake") -> dict:
@@ -452,9 +463,9 @@ class Message(BaseMessage):
         )
         return self._client.cache.place_channel_data(thread_data)
 
-    async def get_reaction(self, emoji: Union["models.PartialEmoji", dict, str]) -> List["models.User"]:
+    async def fetch_reaction(self, emoji: Union["models.PartialEmoji", dict, str]) -> List["models.User"]:
         """
-        Get reactions of a specific emoji from this message.
+        Fetches reactions of a specific emoji from this message.
 
         Args:
             emoji: The emoji to get

--- a/dis_snek/models/discord/role.py
+++ b/dis_snek/models/discord/role.py
@@ -67,7 +67,19 @@ class Role(DiscordObject):
 
         return data
 
-    async def get_bot(self) -> Optional["Member"]:
+    async def fetch_bot(self) -> Optional["Member"]:
+        """
+        Fetch the bot associated with this role if any.
+
+        Returns:
+            Member object if any
+
+        """
+        if self._bot_id is None:
+            return None
+        return await self._client.cache.fetch_member(self._guild_id, self._bot_id)
+
+    def get_bot(self) -> Optional["Member"]:
         """
         Get the bot associated with this role if any.
 
@@ -77,7 +89,7 @@ class Role(DiscordObject):
         """
         if self._bot_id is None:
             return None
-        return await self._client.cache.fetch_member(self._guild_id, self._bot_id)
+        return self._client.cache.get_member(self._guild_id, self._bot_id)
 
     @property
     def guild(self) -> "Guild":

--- a/dis_snek/models/discord/scheduled_event.py
+++ b/dis_snek/models/discord/scheduled_event.py
@@ -93,14 +93,21 @@ class ScheduledEvent(DiscordObject):
             return self.entity_metadata["location"]
         return None
 
-    async def get_channel(self) -> Optional[Union["GuildVoice", "GuildStageVoice"]]:
+    async def fetch_channel(self) -> Optional[Union["GuildVoice", "GuildStageVoice"]]:
         """Returns the channel this event is scheduled in if it is scheduled in a channel."""
         if self._channel_id:
-            channel = await self._client.get_channel(self._channel_id)
+            channel = await self._client.cache.fetch_channel(self._channel_id)
             return channel
         return None
 
-    async def get_event_users(
+    def get_channel(self) -> Optional[Union["GuildVoice", "GuildStageVoice"]]:
+        """Returns the channel this event is scheduled in if it is scheduled in a channel."""
+        if self._channel_id:
+            channel = self._client.cache.get_channel(self._channel_id)
+            return channel
+        return None
+
+    async def fetch_event_users(
         self,
         limit: Optional[int] = 100,
         with_member_data: bool = False,
@@ -108,7 +115,7 @@ class ScheduledEvent(DiscordObject):
         after: Absent[Optional["Snowflake_Type"]] = MISSING,
     ) -> List[Union["Member", "User"]]:
         """
-        Get event users.
+        Fetch event users.
 
         Args:
             limit: Discord defualts to 100

--- a/dis_snek/models/discord/sticker.py
+++ b/dis_snek/models/discord/sticker.py
@@ -63,9 +63,9 @@ class Sticker(StickerItem):
     _user_id: Optional["Snowflake_Type"] = attr.ib(default=None, converter=optional(to_snowflake))
     _guild_id: Optional["Snowflake_Type"] = attr.ib(default=None, converter=optional(to_snowflake))
 
-    async def get_creator(self) -> "User":
+    async def fetch_creator(self) -> "User":
         """
-        Get the user who created this emoji.
+        Fetch the user who created this emoji.
 
         Returns:
             User object
@@ -73,7 +73,27 @@ class Sticker(StickerItem):
         """
         return await self._client.cache.fetch_user(self._user_id)
 
-    async def get_guild(self) -> "Guild":
+    def get_creator(self) -> "User":
+        """
+        Get the user who created this emoji.
+
+        Returns:
+            User object
+
+        """
+        return self._client.cache.get_user(self._user_id)
+
+    async def fetch_guild(self) -> "Guild":
+        """
+        Fetch the guild associated with this emoji.
+
+        Returns:
+            Guild object
+
+        """
+        return await self._client.cache.fetch_guild(self._guild_id)
+
+    def get_guild(self) -> "Guild":
         """
         Get the guild associated with this emoji.
 
@@ -81,7 +101,7 @@ class Sticker(StickerItem):
             Guild object
 
         """
-        return await self._client.cache.fetch_guild(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     async def edit(
         self,

--- a/dis_snek/models/discord/thread.py
+++ b/dis_snek/models/discord/thread.py
@@ -30,17 +30,37 @@ class ThreadMember(DiscordObject, SendMixin):
 
     _user_id: "Snowflake_Type" = field(converter=optional(to_snowflake))
 
-    async def get_thread(self) -> "TYPE_THREAD_CHANNEL":
+    async def fetch_thread(self) -> "TYPE_THREAD_CHANNEL":
         """
-        Gets the thread associated with with this member.
+        Fetches the thread associated with with this member.
 
         Returns:
             The thread in question
 
         """
-        return await self._client.get_channel(self.id)
+        return await self._client.cache.fetch_channel(self.id)
 
-    async def get_user(self) -> "User":
+    def get_thread(self) -> "TYPE_THREAD_CHANNEL":
+        """
+        Gets the thread associated with with this member.
+
+        Returns:
+        The thread in question
+
+        """
+        return self._client.cache.get_channel(self.id)
+
+    async def fetch_user(self) -> "User":
+        """
+        Fetch the user associated with this thread member.
+
+        Returns:
+        The user object
+
+        """
+        return await self._client.cache.fetch_user(self._user_id)
+
+    def get_user(self) -> "User":
         """
         Get the user associated with this thread member.
 
@@ -48,7 +68,7 @@ class ThreadMember(DiscordObject, SendMixin):
             The user object
 
         """
-        return await self._client.get_user(self._user_id)
+        return self._client.cache.get_user(self._user_id)
 
     async def _send_http_request(self, message_payload: Union[dict, "FormData"]) -> dict:
         dm_id = await self._client.cache.fetch_dm_channel_id(self._user_id)

--- a/dis_snek/models/discord/thread.py
+++ b/dis_snek/models/discord/thread.py
@@ -45,7 +45,7 @@ class ThreadMember(DiscordObject, SendMixin):
         Gets the thread associated with with this member.
 
         Returns:
-        The thread in question
+            The thread in question
 
         """
         return self._client.cache.get_channel(self.id)
@@ -55,7 +55,7 @@ class ThreadMember(DiscordObject, SendMixin):
         Fetch the user associated with this thread member.
 
         Returns:
-        The user object
+            The user object
 
         """
         return await self._client.cache.fetch_user(self._user_id)

--- a/dis_snek/models/discord/user.py
+++ b/dis_snek/models/discord/user.py
@@ -75,9 +75,13 @@ class BaseUser(DiscordObject, _SendDMMixin):
         """The users display name, will return nickname if one is set, otherwise will return username."""
         return self.username  # for duck-typing compatibility with Member
 
-    async def get_dm(self) -> "DM":
-        """Get the DM channel associated with this user."""
+    async def fetch_dm(self) -> "DM":
+        """Fetch the DM channel associated with this user."""
         return await self._client.cache.fetch_channel(self.id)  # noqa
+
+    def get_dm(self) -> "DM":
+        """Get the DM channel associated with this user."""
+        return self._client.cache.get_channel(self.id)  # noqa
 
     @property
     def mutual_guilds(self) -> List["Guild"]:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Creates naming convention parity between the cache and all Discord models. Currently, many functions with `get_*` are async, when in reality they should be called `fetch_*`. This PR renames all of these, as well as adding non-async `get_*` where applicable.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Fix all `get_*` functions in `dis_snek.models.discord`
- Fix all `get_*` functions in `dis_snek.client`
- Add async `fetch_*` and non-async `get_*` methods where applicable

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
