### PR TITLE
feat💥: allow for iterables of str for msg prefixes

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1283,7 +1283,7 @@ class Snake(
                     if mention:
                         prefix = mention.group()
                     else:
-                        return
+                        continue
 
                 if message.content.startswith(prefix):
                     prefix_used = prefix

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1273,7 +1273,7 @@ class Snake(
             if isinstance(prefixes, str):
                 # its easier to treat everything as if it may be an iterable
                 # rather than building a special case for strings
-                prefixes = {prefixes}
+                prefixes = (prefixes,)
 
             prefix_used = None
 

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -8,6 +8,7 @@ import sys
 import time
 import traceback
 from datetime import datetime
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, NoReturn, Optional, Type, Union
 
 import dis_snek.api.events as events
@@ -140,7 +141,7 @@ class Snake(
         self,
         intents: Union[int, Intents] = Intents.DEFAULT,
         loop: Optional[asyncio.AbstractEventLoop] = None,
-        default_prefix: str = MENTION_PREFIX,
+        default_prefix: str | Iterable[str] = MENTION_PREFIX,
         generate_prefixes: Absent[Callable[..., Coroutine]] = MISSING,
         sync_interactions: bool = False,
         delete_unused_application_cmds: bool = False,
@@ -376,7 +377,7 @@ class Snake(
         if len(self.processors) == 0:
             log.warning("No Processors are loaded! This means no events will be processed!")
 
-    async def generate_prefixes(self, message: Message) -> str:
+    async def generate_prefixes(self, message: Message) -> str | Iterable[str]:
         """
         A method to get the bot's default_prefix, can be overridden to add dynamic prefixes.
 

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -143,7 +143,7 @@ class Snake(
         loop: Optional[asyncio.AbstractEventLoop] = None,
         default_prefix: str | Iterable[str] = MENTION_PREFIX,
         generate_prefixes: Absent[Callable[..., Coroutine]] = MISSING,
-        sync_interactions: bool = False,
+        sync_interactions: bool = True,
         delete_unused_application_cmds: bool = False,
         enforce_interaction_perms: bool = True,
         fetch_members: bool = False,

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -102,8 +102,8 @@ class Snake(
         intents: Union[int, Intents]: The intents to use
         loop: Optional[asyncio.AbstractEventLoop]: An event loop to use, normally leave this undefined
 
-        default_prefix: str: The default_prefix to use for message commands, defaults to your bot being mentioned
-        get_prefix: Callable[..., Coroutine]: A coroutine that returns a string to determine prefixes
+        default_prefix: Union[str, Iterable[str]]: The default prefix (or prefixes) to use for message commands. Defaults to your bot being mentioned.
+        generate_prefixes: Callable[..., Coroutine]: A coroutine that returns a string or an iterable of strings to determine prefixes.
         status: Status: The status the bot should log in with (IE ONLINE, DND, IDLE)
         activity: Union[Activity, str]: The activity the bot should log in "playing"
 
@@ -141,7 +141,7 @@ class Snake(
         intents: Union[int, Intents] = Intents.DEFAULT,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         default_prefix: str = MENTION_PREFIX,
-        get_prefix: Absent[Callable[..., Coroutine]] = MISSING,
+        generate_prefixes: Absent[Callable[..., Coroutine]] = MISSING,
         sync_interactions: bool = False,
         delete_unused_application_cmds: bool = False,
         enforce_interaction_perms: bool = True,
@@ -180,8 +180,8 @@ class Snake(
         """Sync global commands as guild for quicker command updates during debug"""
         self.default_prefix = default_prefix
         """The default prefix to be used for message commands"""
-        self.get_prefix = get_prefix if get_prefix is not MISSING else self.get_prefix
-        """A coroutine that returns a prefix, for dynamic prefixes"""
+        self.generate_prefixes = generate_prefixes if generate_prefixes is not MISSING else self.generate_prefixes
+        """A coroutine that returns a prefix or an iterable of prefixes, for dynamic prefixes"""
         self.auto_defer = auto_defer or AutoDefer()
         """A system to automatically defer commands after a set duration"""
 
@@ -376,18 +376,18 @@ class Snake(
         if len(self.processors) == 0:
             log.warning("No Processors are loaded! This means no events will be processed!")
 
-    async def get_prefix(self, message: Message) -> str:
+    async def generate_prefixes(self, message: Message) -> str:
         """
         A method to get the bot's default_prefix, can be overridden to add dynamic prefixes.
 
         !!! note
-            To easily override this method, simply use the `get_prefix` parameter when instantiating the client
+            To easily override this method, simply use the `generate_prefixes` parameter when instantiating the client
 
         Args:
             message: A message to determine the prefix from.
 
         Returns:
-            A string to use as a prefix, by default will return `client.default_prefix`
+            A string or an iterable of strings to use as a prefix. By default, this will return `client.default_prefix`
 
         """
         return self.default_prefix
@@ -1258,22 +1258,35 @@ class Snake(
             return
 
         if not message.author.bot:
-            prefix = await self.get_prefix(message)
+            prefixes = await self.generate_prefixes(message)
 
-            if prefix == MENTION_PREFIX:
-                mention = self._mention_reg.search(message.content)
-                if mention:
-                    prefix = mention.group()
-                else:
-                    return
+            if isinstance(prefixes, str):
+                # its easier to treat everything as if it may be an iterable
+                # rather than building a special case for strings
+                prefixes = {prefixes}
 
-            if message.content.startswith(prefix):
-                invoked_name = get_first_word(message.content.removeprefix(prefix))
+            prefix_used = None
+
+            for prefix in prefixes:
+                if prefix == MENTION_PREFIX:
+                    mention = self._mention_reg.search(message.content)
+                    if mention:
+                        prefix = mention.group()
+                    else:
+                        return
+
+                if message.content.startswith(prefix):
+                    prefix_used = prefix
+                    break
+
+            if prefix_used:
+                invoked_name = get_first_word(message.content.removeprefix(prefix_used))
                 command = self.commands.get(invoked_name)
+
                 if command and command.enabled:
                     context = await self.get_context(message)
                     context.invoked_name = invoked_name
-                    context.prefix = prefix
+                    context.prefix = prefix_used
                     context.args = get_args(context.content_parameters)
                     try:
                         if self.pre_run_callback:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [x] Documentation change/addition (technically)

## Description

As of right now, message commands can have dynamic prefixes via `get_prefix`, and that is very useful. However, the problem is that `get_prefix` only allows for *one* prefix to be returned when it is used. This results in something like this happening:

```python
async def get_prefix(msg: dis_snek.Message):
    prefixes = database_handler.get_prefixes(msg.guild.id) # returns a list of prefixes
    for prefix in prefixes:
        if msg.content.startswith(prefix):
            return prefix
```

...to which `dis-snek` would check *again* if the message's content started with that prefix. Not to mention it's just not convenient at all, especially when `discord.py` didn't require this (and I know we *aren't* `discord.py`, but still).

In an ideal world, you would be able to do something like:

```python
async def generate_prefixes(msg: dis_snek.Message):
    return database_handler.get_prefixes(msg.guild.id)
```

...and let `dis-snek` handle it from there, finding out which of the prefixes were used. That's what this PR does.
(I type a lot, don't I?)

## Changes

- 💥 Change `get_prefix` to `generate_prefixes` for clarity.
  - Technically, this could be made non-breaking by leveraging `kwargs` when initing `Snake` and have it check for `get_prefix` if `generate_prefixes` is at its default. This hasn't been done before in this library, however, and I figure we're, well, in alpha, so might as well.
  - Current `dis-snek` bots will have to rename `get_prefix` to `generate_prefixes` for their init for their `Snake`s, but won't have to change much else.
- Allow for `default_prefix` to be `Iterable[str]`, and for `generate_prefixes` to return `Iterable[str]` (they both can still use `str`). You can see the implementation yourself, but at the end of the day, it's just a for loop.
- Import `collections.abc.Iterable` into `client.py` so things are typehinted correctly.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code

## Additional Notes
- Static, one-entry prefixes (aka something like "s!" passed into `default_prefix` and nothing else) may *seem* like they're being treated inefficiently, having to be added to a set of just itself and for-looped from there. However, testing revealed that this resulted in *less than a millisecond* of delay compared to just checking the prefix directly. It's not worth adding a special case to bypass the for loop.
- Ignore the weird commit history - just squash this, please! `sync_interactions` being changed to be default `True` messed things up since I was working on this for a little while.
