### PR TITLE
feat: add `reply` to `MessageContext`

### DIFF
--- a/dis_snek/models/snek/context.py
+++ b/dis_snek/models/snek/context.py
@@ -604,5 +604,15 @@ class MessageContext(Context, SendMixin):
     def content_parameters(self) -> str:
         return self.message.content.removeprefix(f"{self.prefix}{self.invoked_name}").strip()
 
+    async def reply(
+        self,
+        content: Optional[str] = None,
+        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embed: Optional[Union["Embed", dict]] = None,
+        **kwargs,
+    ) -> "Message":
+        """Reply to this message, takes all the same attributes as `send`."""
+        return await self.send(content=content, reply_to=self.message, embeds=embeds or embed, **kwargs)
+
     async def _send_http_request(self, message_payload: Union[dict, "FormData"]) -> dict:
         return await self._client.http.create_message(message_payload, self.channel.id)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description

Going to make this short - to reply to a message when using message commands, you used to have to do `ctx.message.reply`, which was a *bit* annoying when you consider replying to a message command makes a lot of sense and so should be done frequently.
This PR, of course, makes it easier to do so by allowing `ctx.reply`.


## Changes

- Add `reply` to `MessageContext`.
  - This functions the same as `dis_snek.Message.reply`, and thus has the same docstrings and arguments.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
