### PR TITLE
feat: Update debug_exec.py

### DIFF
--- a/dis_snek/ext/debug_scale/debug_exec.py
+++ b/dis_snek/ext/debug_scale/debug_exec.py
@@ -81,13 +81,13 @@ class DebugExec(Scale):
 
         if isinstance(result, Paginator):
             return await result.send(ctx)
-        
+
         if not isinstance(result, str):
             result = repr(result)
 
         # prevent token leak
-        result = result.replace(self.bot.http.token, '[REDACTED TOKEN]')
-            
+        result = result.replace(self.bot.http.token, "[REDACTED TOKEN]")
+
         if len(result) <= 2000:
             return await ctx.message.reply(f"```py\n{result}```")
 

--- a/dis_snek/ext/debug_scale/debug_exec.py
+++ b/dis_snek/ext/debug_scale/debug_exec.py
@@ -79,11 +79,17 @@ class DebugExec(Scale):
         if isinstance(result, File):
             return await ctx.message.reply(file=result)
 
+        if isinstance(result, Paginator):
+            return await result.send(ctx)
+        
         if not isinstance(result, str):
             result = repr(result)
 
+        # prevent token leak
+        result = result.replace(self.bot.http.token, '[REDACTED TOKEN]')
+            
         if len(result) <= 2000:
-            return await ctx.message.reply(f"```py\n{result.replace(self.bot.http.token, '[REDACTED TOKEN]')}```")
+            return await ctx.message.reply(f"```py\n{result}```")
 
         else:
             paginator = Paginator.create_from_string(self.bot, result, prefix="```py", suffix="```", page_size=4000)


### PR DESCRIPTION
- if `exec` returns a `Paginator` the Paginator will be send
- the token will *always* be replaced if a str was returned


## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition


## Description

It adds more functionality (handling `Paginator` in `result`) to the `exec`-command and secures the bot-token more than it is now.


## Changes

- move the token-replacement outside an `if`-statement
- add instance-check to `result` (if is `Paginator` it will be send as one)


## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
