### PR TITLE
fix: Mention prefix erroring out

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1270,9 +1270,9 @@ class Snake(
         if not message.author.bot:
             prefixes = await self.generate_prefixes(message)
 
-            if isinstance(prefixes, str):
+            if isinstance(prefixes, str) or prefixes == MENTION_PREFIX:
                 # its easier to treat everything as if it may be an iterable
-                # rather than building a special case for strings
+                # rather than building a special case for this
                 prefixes = (prefixes,)
 
             prefix_used = None


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description

Right, so `dis-snek` handles its mention prefix (the default prefix when you don't provide any to the bot) a bit weirdly, right? It's neither a list nor a string, instead being a `Sentinel` that tells `dis-snek` to do fun regex stuff.

Problem: #306 did not account for that. It naively thought the only thing that would be reasonably passed for prefixes were `Iterable[str]` or `str`, and did *not* realize `MentionPrefix` could be too.

This fixes that.

## Changes

- Edit the single item check so that it also checks if the prefixes gotten equal `MENTION_PREFIX`.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
