### PR TITLE
refactor: Move processing of color from to_dict to a separate method.

### DIFF
--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -11,7 +11,6 @@ from dis_snek.client.mixins.serialization import DictSerializationMixin
 from dis_snek.client.utils.attr_utils import define, field
 from dis_snek.client.utils.converters import optional as optional_c
 from dis_snek.client.utils.converters import timestamp_converter
-from dis_snek.client.utils.input_utils import _bytes_to_base64_data
 from dis_snek.client.utils.serializer import to_dict, to_image_data
 from dis_snek.models.discord.base import DiscordObject
 from dis_snek.models.discord.snowflake import Snowflake_Type, to_snowflake, to_optional_snowflake, SnowflakeObject

--- a/dis_snek/models/discord/color.py
+++ b/dis_snek/models/discord/color.py
@@ -1,7 +1,7 @@
 import colorsys
 import re
 from enum import Enum
-from typing import Tuple
+from typing import Tuple, Union
 
 import attr
 
@@ -10,10 +10,12 @@ __all__ = [
     "BrandColors",
     "MaterialColors",
     "FlatUIColors",
+    "process_color",
     "Colour",
     "BrandColours",
     "MaterialColours",
     "FlatUIColours",
+    "process_colour",
 ]
 
 
@@ -193,8 +195,22 @@ class FlatUIColors(Color, Enum):
     ASBESTOS = "#7F8C8D"
 
 
+def process_color(color: Union[Color, tuple, list, str, int]) -> int:
+    if not color:
+        return color
+    elif isinstance(color, Color):
+        return color.value
+    elif isinstance(color, dict):
+        return color["value"]
+    elif isinstance(color, (tuple, list, str, int)):
+        return Color(color).value
+
+    raise ValueError(f"Invalid color: {type(color)}")
+
+
 # aliases
 Colour = Color
 BrandColours = BrandColors
 MaterialColours = MaterialColors
 FlatUIColours = FlatUIColors
+process_colour = process_color

--- a/dis_snek/models/discord/color.py
+++ b/dis_snek/models/discord/color.py
@@ -1,7 +1,7 @@
 import colorsys
 import re
 from enum import Enum
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 import attr
 
@@ -195,7 +195,7 @@ class FlatUIColors(Color, Enum):
     ASBESTOS = "#7F8C8D"
 
 
-def process_color(color: Union[Color, dict, tuple, list, str, int]) -> int:
+def process_color(color: Optional[Union[Color, dict, tuple, list, str, int]]) -> Optional[int]:
     if not color:
         return color
     elif isinstance(color, Color):

--- a/dis_snek/models/discord/color.py
+++ b/dis_snek/models/discord/color.py
@@ -195,7 +195,7 @@ class FlatUIColors(Color, Enum):
     ASBESTOS = "#7F8C8D"
 
 
-def process_color(color: Union[Color, tuple, list, str, int]) -> int:
+def process_color(color: Union[Color, dict, tuple, list, str, int]) -> int:
     if not color:
         return color
     elif isinstance(color, Color):

--- a/dis_snek/models/discord/embed.py
+++ b/dis_snek/models/discord/embed.py
@@ -165,7 +165,7 @@ class Embed(DictSerializationMixin):
     """The title of the embed"""
     description: Optional[str] = field(default=None, repr=True)
     """The description of the embed"""
-    color: Optional[Union[Color, tuple, list, str, int]] = field(
+    color: Optional[Union[Color, dict, tuple, list, str, int]] = field(
         default=None, repr=True, metadata=export_converter(process_color)
     )
     """The colour of the embed"""

--- a/dis_snek/models/discord/embed.py
+++ b/dis_snek/models/discord/embed.py
@@ -17,8 +17,8 @@ from dis_snek.client.mixins.serialization import DictSerializationMixin
 from dis_snek.client.utils.attr_utils import field
 from dis_snek.client.utils.converters import list_converter, timestamp_converter
 from dis_snek.client.utils.converters import optional as c_optional
-from dis_snek.client.utils.serializer import no_export_meta
-from dis_snek.models.discord.color import Color
+from dis_snek.client.utils.serializer import no_export_meta, export_converter
+from dis_snek.models.discord.color import Color, process_color
 from dis_snek.models.discord.timestamp import Timestamp
 
 __all__ = [
@@ -165,7 +165,9 @@ class Embed(DictSerializationMixin):
     """The title of the embed"""
     description: Optional[str] = field(default=None, repr=True)
     """The description of the embed"""
-    color: Optional[Union[str, int, Color]] = field(default=None, repr=True)
+    color: Optional[Union[Color, tuple, list, str, int]] = field(
+        default=None, repr=True, metadata=export_converter(process_color)
+    )
     """The colour of the embed"""
     url: Optional[str] = field(default=None, validator=v_optional(instance_of(str)), repr=True)
     """The url the embed should direct to when clicked"""
@@ -232,16 +234,6 @@ class Embed(DictSerializationMixin):
             raise ValueError(
                 "Your embed is too large, more info at https://discord.com/developers/docs/resources/channel#embed-limits"
             )
-
-    def to_dict(self) -> Dict[str, Any]:
-        data = super().to_dict()
-        if color := data.get("color"):
-            if isinstance(color, dict):
-                color = color["value"]
-            elif not isinstance(color, int):
-                color = Color(color).value
-            data["color"] = color
-        return data or None
 
     def __len__(self):
         # yes i know there are far more optimal ways to write this


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
* Add a new `process_color` method.
* Embed color use export converter to `process_color` instead of overriding `to_dict`.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
