### PR TITLE
featfactor: client methods for command execution

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1176,6 +1176,14 @@ class Snake(
 
         return cls
 
+    async def _run_slash_command(self, command: SlashCommand, ctx: InteractionContext) -> Any:
+        """Overrideable method that executes slash commands, can be used to wrap callback execution"""
+        return await command(ctx, **ctx.kwargs)
+
+    async def _run_message_command(self, command: MessageCommand, ctx: MessageContext) -> Any:
+        """Overrideable method that executes message commands, can be used to wrap callback execution"""
+        return await command(ctx)
+
     @processors.Processor.define("raw_interaction_create")
     async def _dispatch_interaction(self, event: RawGatewayEvent) -> None:
         """
@@ -1221,7 +1229,7 @@ class Snake(
                         await auto_defer(ctx)
                         if self.pre_run_callback:
                             await self.pre_run_callback(ctx, **ctx.kwargs)
-                        await command(ctx, **ctx.kwargs)
+                        await self._run_slash_command(command, ctx)
                         if self.post_run_callback:
                             await self.post_run_callback(ctx, **ctx.kwargs)
                     except Exception as e:
@@ -1301,7 +1309,7 @@ class Snake(
                     try:
                         if self.pre_run_callback:
                             await self.pre_run_callback(context)
-                        await command(context)
+                        await self._run_message_command(command, context)
                         if self.post_run_callback:
                             await self.post_run_callback(context)
                     except Exception as e:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [X] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Added methods that literally just run command callbacks so it could be easily overridden in client subclass to make wrapping around command callbacks much cleaner. This may be used for statistics collection, execution time measurements, load and clean-up of resources, etc.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- added `_run_slash_command` client method
- added `_run_message_command` client method

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [X] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.10.x`
- [X] I've tested my code
<!-- - [X] I hate your easter eggs, Wolfhound  -->
