### PR TITLE
fix: Adjust typehinting for project packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
 include LICENSE
 include requirements.txt
+include dis_snek/py.typed
 recursive-include dis_snek *.pyi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include LICENSE
+include requirements.txt
+recursive-include dis_snek *.pyi

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/Discord-Snake-Pit/Dis-Snek",
     version=pyproject["tool"]["poetry"]["version"],
     packages=find_packages(),
-    package_data={"dis_snek": ["py.typed", "*.pyi", "**/*.pyi"]},
+    include_package_data=True,
     python_requires=">=3.10",
     install_requires=(Path(__file__).parent / "requirements.txt").read_text().splitlines(),
     classifiers=[


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
#174 was wrongly thought to make sure `.pyi` files were being included when installing `Dis-Snek` from PIP. To an extent, it *did*, as using `pip install .` in the `Dis-Snek` project itself would work but installing it from a wheel or using PyPI would not include these files.

This PR fixes that, making sure those files are included while building the package.

EDIT: as per request, `py.typed` has also been fixed.


## Changes

- Remove `package_data` from `setup.py` and use `include_package_data` instead.
  - Globbing was *not* the way and it seems like `setup.py` ignored it.
- Create `MANIFEST.in` for `include_package_data` and make it include `.pyi` files (and some other basic files).
- EDIT: Move `py.typed` to the correct spot and add it to `MANIFEST.in`.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code

## Additional Note

EDIT: The below note has been adjusted for in this PR now, as per request.

While doing this PR, I found out we *technically* don't have a `py.typed`, which is why it's not included in `MANIFEST.in`. That *probably* needs to be added in a separate PR, though I can add it here if needed.