### PR TITLE
fix/feat: ability to use asyncio.run with Snake.start and Snake.start_gateway

### DIFF
--- a/dis_snek/api/gateway/gateway.py
+++ b/dis_snek/api/gateway/gateway.py
@@ -115,10 +115,6 @@ class WebsocketClient:
         # Santity check, it is extremely important that an instance isn't reused.
         self._entered = False
 
-    @property
-    def loop(self) -> asyncio.AbstractEventLoop:
-        return self.state.client.loop
-
     async def __aenter__(self: SELF) -> SELF:
         if self._entered:
             raise RuntimeError("An instance of 'WebsocketClient' cannot be re-used!")
@@ -419,7 +415,7 @@ class WebsocketClient:
                 return self.state.client.dispatch(events.Resume())
 
             case "GUILD_MEMBERS_CHUNK":
-                return self.loop.create_task(self._process_member_chunk(data))
+                return asyncio.create_task(self._process_member_chunk(data))
 
             case _:
                 # the above events are "special", and are handled by the gateway itself, the rest can be dispatched
@@ -523,5 +519,5 @@ class WebsocketClient:
 
         guild = self.state.client.cache.guild_cache.get(to_snowflake(chunk.get("guild_id")))
         if guild:
-            return self.loop.create_task(guild.process_member_chunk(chunk))
+            return asyncio.create_task(guild.process_member_chunk(chunk))
         raise ValueError(f"No guild exists for {chunk.get('guild_id')}")

--- a/dis_snek/api/http/http_client.py
+++ b/dis_snek/api/http/http_client.py
@@ -137,7 +137,6 @@ class HTTPClient(
 ):
     """A http client for sending requests to the Discord API."""
 
-    # def __init__(self, connector: Optional[BaseConnector] = None, loop: Optional[asyncio.AbstractEventLoop] = None):
     def __init__(self, connector: Optional[BaseConnector] = None):
         self.connector: Optional[BaseConnector] = connector
         self.__session: Absent[Optional[ClientSession]] = MISSING
@@ -151,10 +150,6 @@ class HTTPClient(
         self.user_agent: str = (
             f"DiscordBot ({__repo_url__} {__version__} Python/{__py_version__}) aiohttp/{aiohttp.__version__}"
         )
-
-    def __del__(self):
-        if self.__session and not self.__session.closed:
-            asyncio.get_running_loop().run_until_complete(self.__session.close())
 
     def get_ratelimit(self, route: Route) -> BucketLock:
         """
@@ -335,7 +330,7 @@ class HTTPClient(
 
     async def close(self) -> None:
         """Close the session."""
-        if self.__session:
+        if self.__session and not self.__session.closed:
             await self.__session.close()
 
     async def get_gateway(self) -> str:

--- a/dis_snek/api/http/http_client.py
+++ b/dis_snek/api/http/http_client.py
@@ -137,9 +137,9 @@ class HTTPClient(
 ):
     """A http client for sending requests to the Discord API."""
 
-    def __init__(self, connector: Optional[BaseConnector] = None, loop: Optional[asyncio.AbstractEventLoop] = None):
+    # def __init__(self, connector: Optional[BaseConnector] = None, loop: Optional[asyncio.AbstractEventLoop] = None):
+    def __init__(self, connector: Optional[BaseConnector] = None):
         self.connector: Optional[BaseConnector] = connector
-        self.loop = asyncio.get_event_loop() if loop is None else loop
         self.__session: Absent[Optional[ClientSession]] = MISSING
         self.token: Optional[str] = None
         self.global_lock: GlobalLock = GlobalLock()
@@ -154,7 +154,7 @@ class HTTPClient(
 
     def __del__(self):
         if self.__session and not self.__session.closed:
-            self.loop.run_until_complete(self.__session.close())
+            asyncio.get_running_loop().run_until_complete(self.__session.close())
 
     def get_ratelimit(self, route: Route) -> BucketLock:
         """

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -590,7 +590,6 @@ class Snake(
         self._mention_reg = re.compile(rf"^(<@!?{self.user.id}*>\s)")
         self.dispatch(events.Login())
 
-
     async def astart(self, token) -> None:
         await self.login(token)
         try:

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -103,7 +103,6 @@ class Snake(
 
     Args:
         intents: Union[int, Intents]: The intents to use
-        loop: Optional[asyncio.AbstractEventLoop]: An event loop to use, normally leave this undefined
 
         default_prefix: Union[str, Iterable[str]]: The default prefix (or prefixes) to use for message commands. Defaults to your bot being mentioned.
         generate_prefixes: Callable[..., Coroutine]: A coroutine that returns a string or an iterable of strings to determine prefixes.

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -674,7 +674,7 @@ class Snake(
         if event not in self.waits:
             self.waits[event] = []
 
-        future = asyncio.get_running_loop().create_future()
+        future = asyncio.Event()
         self.waits[event].append(Wait(event, checks, future))
 
         return asyncio.wait_for(future, timeout)
@@ -696,7 +696,7 @@ class Snake(
         Returns:
             The context of the modal response
         Raises:
-           ` asyncio.TimeoutError` if no response is received that satisfies the predicate before timeout seconds have passed
+            `asyncio.TimeoutError` if no response is received that satisfies the predicate before timeout seconds have passed
 
         """
         author = to_snowflake(author) if author else None

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -591,7 +591,15 @@ class Snake(
         self._mention_reg = re.compile(rf"^(<@!?{self.user.id}*>\s)")
         self.dispatch(events.Login())
 
-    async def start(self, token) -> None:
+
+    async def astart(self, token):
+        await self.login(token)
+        try:
+            await self._connection_state.start()
+        finally:
+            await self.stop()
+
+    def start(self, token) -> None:
         """
         Start the bot.
 
@@ -602,11 +610,12 @@ class Snake(
             token str: Your bot's token
 
         """
-        await self.login(token)
         try:
-            await self._connection_state.start()
-        finally:
-            await self.stop()
+            asyncio.run(self.astart(token))
+        except KeyboardInterrupt:
+            # ignore, cus this is useless and can be misleading to the
+            # user
+            pass
 
     async def start_gateway(self) -> None:
         """Starts the gateway connection."""

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1,5 +1,4 @@
 import asyncio
-from contextlib import asynccontextmanager
 import importlib.util
 import inspect
 import json
@@ -619,6 +618,7 @@ class Snake(
     async def stop(self) -> None:
         log.debug("Stopping the bot.")
         self._ready.clear()
+        await self.http.close()
         await self._connection_state.stop()
 
     def dispatch(self, event: events.BaseEvent, *args, **kwargs) -> None:

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -592,7 +592,7 @@ class Snake(
         self.dispatch(events.Login())
 
 
-    async def astart(self, token):
+    async def astart(self, token) -> None:
         await self.login(token)
         try:
             await self._connection_state.start()

--- a/dis_snek/ext/debug_scale/__init__.py
+++ b/dis_snek/ext/debug_scale/__init__.py
@@ -1,7 +1,5 @@
-import datetime
 import logging
 import platform
-import tracemalloc
 
 from dis_snek import Scale, listen, slash_command, InteractionContext, Timestamp, TimestampStyles, Intents
 from dis_snek.client.const import logger_name, __version__, __py_version__
@@ -20,12 +18,7 @@ class DebugScale(DebugExec, DebugAppCMD, DebugScales, Scale):
     def __init__(self, bot):
         self.add_scale_check(checks.is_owner())
 
-        log.info("Debug Scale is growing! Activating memory allocation trace and asyncio debug...")
-
-        if not tracemalloc.is_tracing():
-            tracemalloc.start()
-        if not self.bot.loop.get_debug():
-            self.bot.loop.set_debug(True)
+        log.info("Debug Scale is growing!")
 
     @listen()
     async def on_startup(self) -> None:

--- a/dis_snek/ext/paginators.py
+++ b/dis_snek/ext/paginators.py
@@ -281,7 +281,7 @@ class Paginator:
 
         if self.timeout_interval > 1:
             self._timeout_task = Timeout(self)
-            self.client.loop.create_task(self._timeout_task())
+            asyncio.create_task(self._timeout_task())
 
         return self._message
 

--- a/dis_snek/models/snek/tasks/task.py
+++ b/dis_snek/models/snek/tasks/task.py
@@ -37,10 +37,6 @@ class Task:
         self.iteration = 0
 
     @property
-    def _loop(self) -> AbstractEventLoop:
-        return asyncio.get_event_loop()
-
-    @property
     def next_run(self) -> Optional[datetime]:
         """Get the next datetime this task will run."""
         if not self.task.done():
@@ -67,7 +63,7 @@ class Task:
     def _fire(self, fire_time: datetime) -> None:
         """Called when the task is being fired."""
         self.trigger.last_call_time = fire_time
-        self._loop.create_task(self())
+        asyncio.create_task(self())
         self.iteration += 1
 
     async def _task_loop(self):
@@ -88,8 +84,7 @@ class Task:
     def start(self) -> None:
         """Start this task."""
         self._stop.clear()
-        if self._loop:
-            self.task = asyncio.create_task(self._task_loop())
+        self.task = asyncio.create_task(self._task_loop())
 
     def stop(self) -> None:
         """End this task."""

--- a/dis_snek/models/snek/wait.py
+++ b/dis_snek/models/snek/wait.py
@@ -1,30 +1,29 @@
-from asyncio import Future
+from asyncio import Event
 from typing import Callable, Optional
 
 __all__ = ["Wait"]
 
 
 class Wait:
-    def __init__(self, event: str, checks: Optional[Callable[..., bool]], future: Future):
+    def __init__(self, event: str, checks: Optional[Callable[..., bool]], future: Event):
         self.event = event
         self.checks = checks
         self.future = future
 
     def __call__(self, *args, **kwargs) -> bool:
-        if self.future.cancelled():
+        if self.future.is_set():
             return True
 
         if self.checks:
             try:
                 check_result = self.checks(*args, **kwargs)
-            except Exception as exc:
-                self.future.set_exception(exc)
+            except Exception:
                 return True
         else:
             check_result = True
 
         if check_result:
-            self.future.set_result(*args, **kwargs)
+            self.future.set()
             return True
 
         return False

--- a/dis_snek/models/snek/wait.py
+++ b/dis_snek/models/snek/wait.py
@@ -15,10 +15,7 @@ class Wait:
             return True
 
         if self.checks:
-            try:
-                check_result = self.checks(*args, **kwargs)
-            except Exception as exc:
-                raise exc
+            check_result = self.checks(*args, **kwargs)
         else:
             check_result = True
 

--- a/dis_snek/models/snek/wait.py
+++ b/dis_snek/models/snek/wait.py
@@ -17,8 +17,8 @@ class Wait:
         if self.checks:
             try:
                 check_result = self.checks(*args, **kwargs)
-            except Exception:
-                return True
+            except Exception as exc:
+                raise exc
         else:
             check_result = True
 


### PR DESCRIPTION
## What type of pull request is this?

- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description

Converted `Snake.start` and `Snake.start_gateway` to async methods inorder to enforce to use if `asyncio.run`.
Additionally this PR removes the use of a loop attribute.

## Changes

Removed the `loop` attribute from the following classes:
- `Snake`
- `HTTPClient`
- `WebsocketClient`

Changed the following methods from non-async to async:
- `Snake.start`
- `Snake.start_gateway`

Removed the `loop` and `asyncio_debug` keyword arg from `Snake`
Also removed `start_gateway` keyword arg from `Snake.login`

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
