### PR TITLE
fix: Allow standalone instances to use `guild.fetch_channel`

### DIFF
--- a/dis_snek/api/gateway/state.py
+++ b/dis_snek/api/gateway/state.py
@@ -39,6 +39,8 @@ class ConnectionState:
     gateway_url: str = MISSING
     """The URL that the gateway should connect to."""
 
+    gateway_started: bool = False
+
     _shard_task: asyncio.Task | None = None
 
     @property
@@ -65,6 +67,8 @@ class ConnectionState:
         log.debug(f"Starting Shard ID {self.shard_id}")
         self.start_time = datetime.now()
         self._shard_task = asyncio.create_task(self._ws_connect())
+
+        self.gateway_started = True
 
         # Historically this method didn't return until the connection closed
         # so we need to wait for the task to exit.

--- a/dis_snek/api/gateway/state.py
+++ b/dis_snek/api/gateway/state.py
@@ -39,7 +39,8 @@ class ConnectionState:
     gateway_url: str = MISSING
     """The URL that the gateway should connect to."""
 
-    gateway_started: bool = False
+    gateway_started: asyncio.Event = asyncio.Event()
+    """Event to check if the gateway has been started."""
 
     _shard_task: asyncio.Task | None = None
 
@@ -68,7 +69,7 @@ class ConnectionState:
         self.start_time = datetime.now()
         self._shard_task = asyncio.create_task(self._ws_connect())
 
-        self.gateway_started = True
+        self.gateway_started.set()
 
         # Historically this method didn't return until the connection closed
         # so we need to wait for the task to exit.
@@ -83,6 +84,8 @@ class ConnectionState:
         if self._shard_task is not None:
             await self._shard_task
             self._shard_task = None
+
+        self.gateway_started.clear()
 
     async def _ws_connect(self) -> None:
         log.info("Attempting to initially connect to gateway...")

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -295,6 +295,11 @@ class Snake(
         return self._connection_state.start_time
 
     @property
+    def gateway_started(self) -> bool:
+        """Returns if the gateway has been started."""
+        return self._connection_state.gateway_started
+
+    @property
     def intents(self) -> Intents:
         """The intents being used by this bot."""
         return self._connection_state.intents

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -297,7 +297,7 @@ class Snake(
     @property
     def gateway_started(self) -> bool:
         """Returns if the gateway has been started."""
-        return self._connection_state.gateway_started
+        return self._connection_state.gateway_started.is_set()
 
     @property
     def intents(self) -> Intents:

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -1230,13 +1230,19 @@ class Guild(BaseGuild):
 
         """
         channel_id = to_snowflake(channel_id)
-        if channel_id in self._channel_ids:
+        if channel_id in self._channel_ids or self._client.start_time is MISSING:
+            # The latter check here is to see if the bot is running with the gateway.
+            # If not, then we need to check the API since only the gateway
+            # populates the channel IDs
+
             # theoretically, this could get any channel the client can see,
             # but to make it less confusing to new programmers,
             # i intentionally check that the guild contains the channel first
             try:
-                return await self._client.fetch_channel(channel_id)
-            except NotFound:
+                channel = await self._client.fetch_channel(channel_id)
+                if channel.guild.id == self.id:
+                    return channel
+            except (NotFound, AttributeError):
                 return None
 
         return None

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -1230,7 +1230,7 @@ class Guild(BaseGuild):
 
         """
         channel_id = to_snowflake(channel_id)
-        if channel_id in self._channel_ids or self._client.start_time is MISSING:
+        if channel_id in self._channel_ids or not self._client.gateway_started:
             # The latter check here is to see if the bot is running with the gateway.
             # If not, then we need to check the API since only the gateway
             # populates the channel IDs

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -1240,7 +1240,7 @@ class Guild(BaseGuild):
             # i intentionally check that the guild contains the channel first
             try:
                 channel = await self._client.fetch_channel(channel_id)
-                if channel.guild.id == self.id:
+                if channel._guild_id == self.id:
                     return channel
             except (NotFound, AttributeError):
                 return None


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
If a standalone instance is logged in via `await client.login(token)`, running `await guild.fetch_channel(channel_id)` will always return None due to a check to see if `channel_id` is in `guild._channel_ids`. However, this attribute is only populated if you connect to the gateway, and as such, will always fail for standalone instances. 

This PR fixes this by adding an additional check to see if the gateway is started, and running an API check if it is not. This allows standalone instances to properly run `guild.fetch_channel(channel_id)`, instead of having to rely strictly on `client.fetch_channel(channel_id)`

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add extra check to allow standalone instance to use `guild.fetch_channel`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/57541873/156424122-623f8b0f-d6fd-4ac5-a799-9fbc01eaee31.png)

After:
![image](https://user-images.githubusercontent.com/57541873/156424164-c0911f9f-1594-4281-a709-d07b6451794b.png)
