### PR TITLE
fix: Remove `to_dict` calls in `list_converter`

### DIFF
--- a/dis_snek/client/utils/converters.py
+++ b/dis_snek/client/utils/converters.py
@@ -21,10 +21,7 @@ def timestamp_converter(value: Union[datetime, int, float, str]) -> Timestamp:
 
 def list_converter(converter) -> Callable[[list], list]:
     def convert_action(value: list) -> list:
-        return [
-            converter(element) if not hasattr(element, "to_dict") else converter(**element.to_dict())
-            for element in value
-        ]
+        return [converter(element) for element in value]
 
     return convert_action
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
list_converter is used to convert things into an object, so `to_dict` call doesn't make sense.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [ ] I've tested my code
