### PR TITLE
feat💥: add bot argument to generate_prefixes

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -379,7 +379,7 @@ class Snake(
         if len(self.processors) == 0:
             log.warning("No Processors are loaded! This means no events will be processed!")
 
-    async def generate_prefixes(self, message: Message) -> str | Iterable[str]:
+    async def generate_prefixes(self, bot: "Snake", message: Message) -> str | Iterable[str]:
         """
         A method to get the bot's default_prefix, can be overridden to add dynamic prefixes.
 
@@ -387,6 +387,7 @@ class Snake(
             To easily override this method, simply use the `generate_prefixes` parameter when instantiating the client
 
         Args:
+            bot: A reference to the client
             message: A message to determine the prefix from.
 
         Returns:
@@ -1278,7 +1279,7 @@ class Snake(
             return
 
         if not message.author.bot:
-            prefixes = await self.generate_prefixes(message)
+            prefixes = await self.generate_prefixes(self, message)
 
             if isinstance(prefixes, str) or prefixes == MENTION_PREFIX:
                 # its easier to treat everything as if it may be an iterable


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description

~~i heard you like essays~~

### Introduction

`generate_prefixes` is a rather useful way of generating what prefixes a command may have based on certain conditions, like using a certain set of prefixes for one guild and another set for, well, another guild.
(this may be a biased view, but still)

*However*, there has been one limitation with it - there has been no **clear** way of using the bot (in this case, an instance of Snake) variable with it. This poses some downsides, which best can be explained by common usages of `dis-snek` and generated prefixes:

#### Case 1 - Bot Variables
Many bots use databases to store data relating to their operation, and many (including one of the most popular `dis-snek` bots, [Popularity Contest](https://github.com/Wolfhound905/popularity-contest/blob/40016dd5064498f9047f32222f8d1bcba75c0194/bot.py#L43)) use a bot variable to store an instance of their database, IE `bot.db = ...`.

For bots that use message commands, it is very likely that they may use the same database in order to store what prefixes a guild may have. In these cases, if they use the bot variable to access the database, they simply can't: there's no way they can access `bot.db` because, well, you only have a `Message`. Thus, they *cannot* use the database to store guild prefixes if they actually want to use them, limiting their bot.

#### Case 2 - Native Bot Functions and Attributes
Mention prefixes are technically something supported by `dis-snek` via usage of `MENTION_PREFIX`, but its usage of regex when it is unnecessary has been hotly debated. Let's ignore it from now, or at least assume that the average bot developer doesn't realize they can use `MENTION_PREFIX` in an iterable and still have it work (and honestly, it's not exactly intuitive).

If a bot developer wishes to have custom prefixes for a guild (as discussed above) and *also* have the bot always respond to mention prefixes... well, there is no way of getting the bot's user (and their ID), and so no way of generating mention prefixes (since they rely on said IDs). This makes this way *also* impossible unless you know how `dis-snek` works.

(And since this is a somewhat weak point thanks to `MENTION_PREFIX`, I'll add on the fact that users may want to be able to use the bot methods to fetch or get a function or attribute. I could totally see a bot dev making their `generate_prefixes` return an empty list if the bot isn't ready with its cache yet, preventing message commands from being run until that time.)

#### Continuation

As you can see, it is very annoying and inconvenient to not have access to the bot variable.

### Current Workarounds (and Drawbacks)

There are currently three workarounds I can think of on top of my head to get the bot instance, so let's go through each one:

#### Solution 1

Subclass `Snake`, replacing `generate_prefixes`, like so:

```python
class CustomSnake(Snake):
    async def generate_prefixes(self, msg: Message):
        # self is an instance of the bot
        ...
```

Polls himself has disagreed with this solution, stating that it is not beginning-dev-friendly in any way. Subclassing to achieve something like this is usually *not* a thing many developers think of and poking around at the "internals" usually scares newcomers off.

#### Solution 2

If the bot and `generate_prefixes` are defined in the same file, use how Python works to use the bot, like so:

```python
async def generate_prefixes(msg: Message):
    return [f"<@{bot.user.id}>", f"<@!{bot.user.id}>"] # exists because of the below

bot = Snake(..., generate_prefixes=generate_prefixes)  # in same file
```

This has two drawbacks:
- If a person comes from another programming language, or simply tries to look at this logically without knowing too much about Python, they would be used. It is *very* unorthodox to use a variable *before* it is assigned.
- If either the `generate_prefixes` or the `bot` is in a different file from each other, then this method isn't viable. That may not seem like it would happen often, but something like `when_mentioned_or`, a feature a certain Discord Python library has, would benefit from having a `bot` variable, and a bot developer may have other usages for separating the two.

#### Solution 3

Using `Message._client`, like so:
```python
async def generate_prefixes(msg: Message):
    return [f"<@{msg._client.user.id}>", f"<@!{msg._client.user.id}>"]
```

This is both unintuitive *and* encourages using "private" attributes that `dis-snek` clearly doesn't want developers using.

### Proper Solution

This PR, of course!

This PR makes `generate_prefixes` have a bot argument, like so:

```python
async def generate_prefixes(bot: Snake, msg: Message):
    ...
```

This allows using the bot variable in an easy way, though this change is breaking. The bot variable was put first largely to reflect how other libraries did it (though putting it after `Message` even ignoring that is weird, especially when `Snake` is "bigger").

## Changes
- 💥 Make `generate_prefixes` take two arguments: `bot: Snake` and `message: Message`.
  - Technically, `bot: Snake` is referring to itself, making a bit more awkward for subclassers, but I feel like that's minor enough to ignore.
- 💥 Make `_dispatch_msg_commands`, the internal handler for message commands, use the updated form, passing an instance of it`self` to do so.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
