### PR TITLE
feat: Add support for Annotated[]

### DIFF
--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -403,13 +403,12 @@ class SlashCommand(InteractionCommand):
                 for ann in typing.get_args(val.annotation):
                     if isinstance(ann, SlashCommandOption):
                         annotation = ann
-            
+
             if annotation:
                 if not self.options:
                     self.options = []
                 ann.name = name
                 self.options.append(ann)
-
 
         if self.callback is not None:
             if hasattr(self.callback, "options"):

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import re
 from enum import IntEnum
-from typing import TYPE_CHECKING, Callable, Coroutine, Dict, List, Union, Optional, Any
+from typing import TYPE_CHECKING, Annotated, Callable, Coroutine, Dict, List, Union, Optional, Any
 import typing
 
 import attr
@@ -399,7 +399,7 @@ class SlashCommand(InteractionCommand):
             annotation = None
             if val.annotation and isinstance(val.annotation, SlashCommandOption):
                 annotation = val.annotation
-            elif typing.get_origin(val.annotation) is typing.Annotated:
+            elif typing.get_origin(val.annotation) is Annotated:
                 for ann in typing.get_args(val.annotation):
                     if isinstance(ann, SlashCommandOption):
                         annotation = ann

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -4,6 +4,7 @@ import logging
 import re
 from enum import IntEnum
 from typing import TYPE_CHECKING, Callable, Coroutine, Dict, List, Union, Optional, Any
+import typing
 
 import attr
 
@@ -395,12 +396,20 @@ class SlashCommand(InteractionCommand):
     def __attrs_post_init__(self) -> None:
         params = get_parameters(self.callback)
         for name, val in params.items():
+            annotation = None
             if val.annotation and isinstance(val.annotation, SlashCommandOption):
-
+                annotation = val.annotation
+            elif typing.get_origin(val.annotation) is typing.Annotated:
+                for ann in typing.get_args(val.annotation):
+                    if isinstance(ann, SlashCommandOption):
+                        annotation = ann
+            
+            if annotation:
                 if not self.options:
                     self.options = []
-                val.annotation.name = name
-                self.options.append(val.annotation)
+                ann.name = name
+                self.options.append(ann)
+
 
         if self.callback is not None:
             if hasattr(self.callback, "options"):


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
As recently mentioned in #lib-discussion, there's currently not way to use parameter annotations and also correctly type hint your functions.  Thankfully, [PEP-593](https://www.python.org/dev/peps/pep-0593/) was made for this exact situation, and introduces `typing.Annotated` as a way to include both.

Annotated is a generic annotation, where the first parameter is a type hint, and any subsequent parameters are metadata that can be used by other code.

Here's an example of a message command using `CMD_BODY` with and without type hints:

```python
@message_command()
async def untyped(ctx, body: CMD_BODY):
    ...

@message_command()
async def typed(ctx, body: Annotated[str, CMD_BODY]):
    ...
```

(The same also works with `slash_str_option` and friends, over in slash commands)
```python
@slash_command('sample')
async def my_command_function(ctx: InteractionContext, integer_option: Annotated[int, slash_int_option("Integer Option")]):
    ...
```



## Changes
- Added support for Annotated[] to message_command annotations
- Added support for Annotated[] to slash command options

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
