### PR TITLE
fix: Modify the correct member's nickname

### DIFF
--- a/dis_snek/models/discord/user.py
+++ b/dis_snek/models/discord/user.py
@@ -432,7 +432,10 @@ class Member(DiscordObject, _SendDMMixin):
             Leave `new_nickname` empty to clean user's nickname
 
         """
-        await self._client.http.modify_current_member(self._guild_id, nickname=new_nickname, reason=reason)
+        if self.id == self._client.user.id:
+            await self._client.http.modify_current_member(self._guild_id, nickname=new_nickname, reason=reason)
+        else:
+            await self._client.http.modify_guild_member(self._guild_id, self.id, nickname=new_nickname, reason=reason)
 
     async def add_role(self, role: Union[Snowflake_Type, Role], reason: Absent[str] = MISSING) -> None:
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
`Member.edit_nickname` was bugged and only edits the current bot, regardless of the member.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
