### PR TITLE
feat💥: remove request_fallback args from cache

### DIFF
--- a/dis_snek/api/events/processors/channel_events.py
+++ b/dis_snek/api/events/processors/channel_events.py
@@ -33,7 +33,7 @@ class ChannelEvents(EventMixinTemplate):
 
     @Processor.define()
     async def _on_raw_channel_update(self, event: "RawGatewayEvent") -> None:
-        before = copy.copy(await self.cache.fetch_channel(channel_id=event.data.get("id"), request_fallback=False))
+        before = copy.copy(self.cache.get_channel(event.data.get("id")))
         self.dispatch(events.ChannelUpdate(before=before or MISSING, after=self.cache.place_channel_data(event.data)))
 
     @Processor.define()

--- a/dis_snek/api/events/processors/guild_events.py
+++ b/dis_snek/api/events/processors/guild_events.py
@@ -58,7 +58,7 @@ class GuildEvents(EventMixinTemplate):
             self.dispatch(
                 events.GuildUnavailable(
                     guild_id,
-                    await self.cache.fetch_guild(guild_id, False) or MISSING,
+                    self.cache.get_guild(guild_id) or MISSING,
                 )
             )
         else:
@@ -72,7 +72,7 @@ class GuildEvents(EventMixinTemplate):
             self.dispatch(
                 events.GuildLeft(
                     guild_id,
-                    await self.cache.fetch_guild(guild_id, False) or MISSING,
+                    self.cache.get_guild(guild_id) or MISSING,
                 )
             )
 

--- a/dis_snek/api/events/processors/member_events.py
+++ b/dis_snek/api/events/processors/member_events.py
@@ -26,10 +26,10 @@ class MemberEvents(EventMixinTemplate):
     async def _on_raw_guild_member_remove(self, event: "RawGatewayEvent") -> None:
         g_id = event.data.pop("guild_id")
         user = self.cache.place_user_data(event.data["user"])
-        self.dispatch(events.MemberRemove(g_id, await self.cache.fetch_member(g_id, user.id, False) or user))
+        self.dispatch(events.MemberRemove(g_id, self.cache.get_member(g_id, user.id) or user))
 
     @Processor.define()
     async def _on_raw_guild_member_update(self, event: "RawGatewayEvent") -> None:
         g_id = event.data.pop("guild_id")
-        before = copy.copy(await self.cache.fetch_member(g_id, event.data["user"]["id"], False)) or MISSING
+        before = copy.copy(self.cache.get_member(g_id, event.data["user"]["id"])) or MISSING
         self.dispatch(events.MemberUpdate(g_id, before, self.cache.place_member_data(g_id, event.data)))

--- a/dis_snek/api/events/processors/message_events.py
+++ b/dis_snek/api/events/processors/message_events.py
@@ -51,8 +51,9 @@ class MessageEvents(EventMixinTemplate):
             event: raw message deletion event
 
         """
-        message = await self.cache.fetch_message(
-            event.data.get("channel_id"), event.data.get("id"), request_fallback=False
+        message = self.cache.get_message(
+            event.data.get("channel_id"),
+            event.data.get("id"),
         )
 
         if not message:
@@ -71,8 +72,6 @@ class MessageEvents(EventMixinTemplate):
 
         """
         # a copy is made because the cache will update the original object in memory
-        before = copy.copy(
-            await self.cache.fetch_message(event.data.get("channel_id"), event.data.get("id"), request_fallback=False)
-        )
+        before = copy.copy(self.cache.get_message(event.data.get("channel_id"), event.data.get("id")))
         after = self.cache.place_message_data(event.data)
         self.dispatch(events.MessageUpdate(before=before, after=after))

--- a/dis_snek/api/events/processors/role_events.py
+++ b/dis_snek/api/events/processors/role_events.py
@@ -31,7 +31,7 @@ class RoleEvents(EventMixinTemplate):
     async def _on_raw_guild_role_update(self, event: "RawGatewayEvent") -> None:
         g_id = int(event.data.get("guild_id"))
         r_data = event.data.get("role")
-        before = copy.copy(await self.cache.fetch_role(g_id, r_data["id"], False) or MISSING)
+        before = copy.copy(self.cache.get_role(g_id, r_data["id"]) or MISSING)
 
         after = self.cache.place_role_data(g_id, [r_data])
         after = after[int(event.data["role"]["id"])]

--- a/dis_snek/api/events/processors/user_events.py
+++ b/dis_snek/api/events/processors/user_events.py
@@ -49,8 +49,7 @@ class UserEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_presence_update(self, event: "RawGatewayEvent") -> None:
         g_id = to_snowflake(event.data["guild_id"])
-        user = await self.cache.fetch_user(event.data["user"]["id"], request_fallback=False)
-        if user:
+        if user := self.cache.get_user(event.data["user"]["id"]):
             status = Status[event.data["status"].upper()]
             activities = Activity.from_list(event.data.get("activities"))
 

--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -347,7 +347,7 @@ class GlobalCache:
         self,
         channel_id: "Snowflake_Type",
         message_id: "Snowflake_Type",
-    ) -> Optional[Message]:
+    ) -> Message:
         """
         Fetch a message from a channel based on their IDs.
 

--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -295,7 +295,7 @@ class GlobalCache:
         if guild and (user_id in guild._member_ids):
             return True
 
-        # If no such guild in cache, try to get member directly. May send requests
+        # If no such guild in cache or member not in guild cache, try to get member directly. May send requests
         try:
             member = await self.fetch_member(guild_id, user_id)
         except (NotFound, Forbidden):  # there is no such member in the guild (as per request)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description

`request_fallback` was a method back when the cache had inconsistent/no get and fetch methods - it was an argument used to make `fetch_x` function like `get_x`.

These days, get and fetch methods have been standardized, and there is no need for `request_fallback` to even be a thing - its argument can be accomplished, with certainty, by using `get_x`. However, it was kept to minimize breaking code.

Having legacy code isn't *exactly* the best idea, though. So this PR removes it entirely and adjusts cases where it was used.

## Changes

- `smart_cache.py`:
  - 💥 All `fetch_x` methods have their `request_fallback` argument removed.
  - 💥 The above methods' (typehints *and* actual functions at points) have also been changed so they no longer return `Optional[x]`, instead just returning `x`.
    - This might be controversial for `fetch_role` due to how that works.
  - 💥 Given `is_user_in_guild` and `fetch_user_guild_ids` are asynchronous functions, I decided to make them act like as if the `fallback`s they used to have were `True` and remove those arguments. These aren't methods used anywhere else in the library itself, but if this isn't a desired change, I can always fix it.
- Events and other places that used `request_fallback` have been changed so they use the appropriate get or fetch method instead.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code*
\* Due to how much this PR affects, there's a chance I might have forgotten to test something. I don't think I've missed anything, but feel free to test this out!