### PR TITLE
fix: Don't throw KeyError if a non-cached member leaves a guild 

### DIFF
--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -232,7 +232,7 @@ class GlobalCache:
         user_id = to_snowflake(user_id)
         guild_id = to_snowflake(guild_id)
 
-        self.member_cache.pop((guild_id, user_id))
+        self.member_cache.pop((guild_id, user_id), None)
         self.delete_user_guild(user_id, guild_id)
 
     def place_user_guild(self, user_id: "Snowflake_Type", guild_id: "Snowflake_Type") -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Fixes a bug I noticed when one of my bots received a `guild_delete` event.


## Changes
- Changes `cache.delete_member` to not throw an error when the member isn't in the cache.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [ ] I've tested my code
