### PR TITLE
refactor: Use smart_cache get methods

### DIFF
--- a/dis_snek/api/events/internal.py
+++ b/dis_snek/api/events/internal.py
@@ -58,7 +58,7 @@ class GuildEvent:
     @property
     def guild(self) -> "Guild":
         """Guild related to event"""
-        return self.bot.cache.guild_cache.get(self.guild_id)
+        return self.bot.cache.get_guild(self.guild_id)
 
 
 @define(kw_only=False)

--- a/dis_snek/api/events/processors/channel_events.py
+++ b/dis_snek/api/events/processors/channel_events.py
@@ -40,7 +40,6 @@ class ChannelEvents(EventMixinTemplate):
     async def _on_raw_channel_pins_update(self, event: "RawGatewayEvent") -> None:
         channel = await self.cache.fetch_channel(event.data.get("channel_id"))
         channel.last_pin_timestamp = event.data.get("last_pin_timestamp")
-        self.cache.channel_cache[channel.id] = channel
         self.dispatch(events.ChannelPinsUpdate(channel, channel.last_pin_timestamp))
 
     @Processor.define()

--- a/dis_snek/api/events/processors/reaction_events.py
+++ b/dis_snek/api/events/processors/reaction_events.py
@@ -53,7 +53,6 @@ class ReactionEvents(EventMixinTemplate):
                     )
                 )
 
-            self.cache.message_cache[(message._channel_id, message.id)] = message
         else:
             message = await self.cache.fetch_message(event.data.get("channel_id"), event.data.get("message_id"))
 

--- a/dis_snek/api/events/processors/role_events.py
+++ b/dis_snek/api/events/processors/role_events.py
@@ -21,7 +21,7 @@ class RoleEvents(EventMixinTemplate):
         g_id = int(event.data.get("guild_id"))
         r_id = int(event.data["role"]["id"])
 
-        guild = self.cache.guild_cache.get(g_id)
+        guild = self.cache.get_guild(g_id)
         guild._role_ids.add(r_id)
 
         role = self.cache.place_role_data(g_id, [event.data.get("role")])[r_id]
@@ -43,10 +43,10 @@ class RoleEvents(EventMixinTemplate):
         g_id = int(event.data.get("guild_id"))
         r_id = int(event.data.get("role_id"))
 
-        guild = self.cache.guild_cache.get(g_id)
-        role = self.cache.role_cache.pop(r_id, MISSING)
+        guild = self.cache.get_guild(g_id)
+        role = self.cache.get_role(r_id)
 
-        guild._role_ids.discard(r_id)
+        self.cache.delete_role(r_id)
 
         role_members = (member for member in guild.members if member.has_role(r_id))
         for member in role_members:

--- a/dis_snek/api/gateway/gateway.py
+++ b/dis_snek/api/gateway/gateway.py
@@ -517,7 +517,7 @@ class WebsocketClient:
 
     async def _process_member_chunk(self, chunk: dict):
 
-        guild = self.state.client.cache.guild_cache.get(to_snowflake(chunk.get("guild_id")))
+        guild = self.state.client.cache.get_guild(to_snowflake(chunk.get("guild_id")))
         if guild:
             return asyncio.create_task(guild.process_member_chunk(chunk))
         raise ValueError(f"No guild exists for {chunk.get('guild_id')}")

--- a/dis_snek/models/discord/application.py
+++ b/dis_snek/models/discord/application.py
@@ -76,4 +76,4 @@ class Application(DiscordObject):
 
     @property
     def owner(self) -> "User":
-        return self._client.cache.user_cache.get(self.owner_id)
+        return self._client.cache.get_user(self.owner_id)

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -836,12 +836,12 @@ class GuildChannel(BaseChannel):
     @property
     def guild(self) -> "models.Guild":
         """The guild this channel belongs to."""
-        return self._client.cache.guild_cache.get(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     @property
     def category(self) -> Optional["GuildCategory"]:
         """The parent category of this channel."""
-        return self._client.cache.channel_cache.get(self.parent_id)
+        return self._client.cache.get_channel(self.parent_id)
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:
@@ -1525,7 +1525,7 @@ class ThreadChannel(GuildChannel, MessageableMixin, WebhookMixin):
     @property
     def parent_channel(self) -> GuildText:
         """The channel this thread is a child of."""
-        return self._client.cache.channel_cache.get(self.parent_id)
+        return self._client.cache.get_channel(self.parent_id)
 
     @property
     def mention(self) -> str:
@@ -1749,7 +1749,7 @@ class VoiceChannel(GuildChannel):  # May not be needed, can be directly just Gui
     def voice_members(self) -> List["models.Member"]:
         """Returns a list of members that are currently in the channel. Note: This will not be accurate if the bot was offline while users joined the channel"""
         return [
-            self._client.cache.member_cache.get((self._guild_id, member_id)) for member_id in self._voice_member_ids
+            self._client.cache.get_member(self._guild_id, member_id) for member_id in self._voice_member_ids
         ]
 
 

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -1748,9 +1748,7 @@ class VoiceChannel(GuildChannel):  # May not be needed, can be directly just Gui
     @property
     def voice_members(self) -> List["models.Member"]:
         """Returns a list of members that are currently in the channel. Note: This will not be accurate if the bot was offline while users joined the channel"""
-        return [
-            self._client.cache.get_member(self._guild_id, member_id) for member_id in self._voice_member_ids
-        ]
+        return [self._client.cache.get_member(self._guild_id, member_id) for member_id in self._voice_member_ids]
 
 
 @define()

--- a/dis_snek/models/discord/emoji.py
+++ b/dis_snek/models/discord/emoji.py
@@ -118,19 +118,17 @@ class CustomEmoji(PartialEmoji):
     @property
     def guild(self) -> "Guild":
         """The guild this emoji belongs to."""
-        return self._client.cache.guild_cache.get(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     @property
     def creator(self) -> Optional[Union["Member", "User"]]:
         """The member that created this emoji."""
-        return self._client.cache.member_cache.get(
-            (self._creator_id, self._guild_id)
-        ) or self._client.cache.user_cache.get(self._creator_id)
+        return self._client.cache.get_member(self._creator_id, self._guild_id) or self._client.cache.get_user(self._creator_id)
 
     @property
     def roles(self) -> List["Role"]:
         """The roles allowed to use this emoji."""
-        return [self._client.cache.role_cache.get(role_id) for role_id in self._role_ids]
+        return [self._client.cache.get_role(role_id) for role_id in self._role_ids]
 
     @property
     def is_usable(self) -> bool:

--- a/dis_snek/models/discord/emoji.py
+++ b/dis_snek/models/discord/emoji.py
@@ -123,7 +123,9 @@ class CustomEmoji(PartialEmoji):
     @property
     def creator(self) -> Optional[Union["Member", "User"]]:
         """The member that created this emoji."""
-        return self._client.cache.get_member(self._creator_id, self._guild_id) or self._client.cache.get_user(self._creator_id)
+        return self._client.cache.get_member(self._creator_id, self._guild_id) or self._client.cache.get_user(
+            self._creator_id
+        )
 
     @property
     def roles(self) -> List["Role"]:

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -217,17 +217,17 @@ class Guild(BaseGuild):
     @property
     def channels(self) -> List["models.TYPE_GUILD_CHANNEL"]:
         """Returns a list of channels associated with this guild."""
-        return [self._client.cache.channel_cache.get(c_id) for c_id in self._channel_ids]
+        return [self._client.cache.get_channel(c_id) for c_id in self._channel_ids]
 
     @property
     def threads(self) -> List["models.TYPE_THREAD_CHANNEL"]:
         """Returns a list of threads associated with this guild."""
-        return [self._client.cache.channel_cache.get(t_id) for t_id in self._thread_ids]
+        return [self._client.cache.get_channel(t_id) for t_id in self._thread_ids]
 
     @property
     def members(self) -> List["models.Member"]:
         """Returns a list of all members within this guild."""
-        return [self._client.cache.member_cache.get((self.id, m_id)) for m_id in self._member_ids]
+        return [self._client.cache.get_member(self.id, m_id) for m_id in self._member_ids]
 
     @property
     def premium_subscribers(self) -> List["models.Member"]:
@@ -247,27 +247,27 @@ class Guild(BaseGuild):
     @property
     def roles(self) -> List["models.Role"]:
         """Returns a list of roles associated with this guild."""
-        return [self._client.cache.role_cache.get(r_id) for r_id in self._role_ids]
+        return [self._client.cache.get_role(r_id) for r_id in self._role_ids]
 
     @property
     def me(self) -> "models.Member":
         """Returns this bots member object within this guild."""
-        return self._client.cache.member_cache.get((self.id, self._client.user.id))
+        return self._client.cache.get_member(self.id, self._client.user.id)
 
     @property
     def system_channel(self) -> Optional["models.GuildText"]:
         """Returns the channel this guild uses for system messages."""
-        return self._client.cache.channel_cache.get(self.system_channel_id)
+        return self._client.cache.get_channel(self.system_channel_id)
 
     @property
     def rules_channel(self) -> Optional["models.GuildText"]:
         """Returns the channel declared as a rules channel."""
-        return self._client.cache.channel_cache.get(self.rules_channel_id)
+        return self._client.cache.get_channel(self.rules_channel_id)
 
     @property
     def public_updates_channel(self) -> Optional["models.GuildText"]:
         """Returns the channel where server staff receive notices from Discord."""
-        return self._client.cache.channel_cache.get(self.public_updates_channel_id)
+        return self._client.cache.get_channel(self.public_updates_channel_id)
 
     @property
     def emoji_limit(self) -> int:
@@ -295,7 +295,7 @@ class Guild(BaseGuild):
     @property
     def default_role(self) -> "models.Role":
         """The `@everyone` role in this guild."""
-        return self._client.cache.role_cache.get(self.id)  # type: ignore
+        return self._client.cache.get_role(self.id)  # type: ignore
 
     @property
     def premium_subscriber_role(self) -> Optional["models.Role"]:
@@ -1253,7 +1253,7 @@ class Guild(BaseGuild):
         """
         thread_id = to_snowflake(thread_id)
         if thread_id in self._thread_ids:
-            return self._client.cache.channel_cache.get(thread_id)
+            return self._client.cache.get_channel(thread_id)
         return None
 
     async def fetch_thread(self, thread_id: Snowflake_Type) -> Optional["models.TYPE_THREAD_CHANNEL"]:

--- a/dis_snek/models/discord/invite.py
+++ b/dis_snek/models/discord/invite.py
@@ -51,17 +51,17 @@ class Invite(ClientObject):
     @property
     def channel(self) -> "TYPE_GUILD_CHANNEL":
         """The channel the invite is for."""
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_channel(self._channel_id)
 
     @property
     def inviter(self) -> Optional["User"]:
         """The user that created the invite or None."""
-        return self._client.cache.user_cache.get(self._inviter_id) if self._inviter_id else None
+        return self._client.cache.get_user(self._inviter_id) if self._inviter_id else None
 
     @property
     def target_user(self) -> Optional["User"]:
         """The user whose stream to display for this voice channel stream invite or None."""
-        return self._client.cache.user_cache.get(self._target_user_id) if self._target_user_id else None
+        return self._client.cache.get_user(self._target_user_id) if self._target_user_id else None
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:

--- a/dis_snek/models/discord/message.py
+++ b/dis_snek/models/discord/message.py
@@ -172,23 +172,23 @@ class BaseMessage(DiscordObject):
 
     @property
     def guild(self) -> "models.Guild":
-        return self._client.cache.guild_cache.get(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     @property
     def channel(self) -> "models.TYPE_MESSAGEABLE_CHANNEL":
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_channel(self._channel_id)
 
     @property
     def thread(self) -> "models.TYPE_THREAD_CHANNEL":
-        return self._client.cache.channel_cache.get(self._thread_channel_id)
+        return self._client.cache.get_channel(self._thread_channel_id)
 
     @property
     def author(self) -> Union["models.Member", "models.User"]:
         if self._author_id:
             member = None
             if self._guild_id:
-                member = self._client.cache.member_cache.get((self._guild_id, self._author_id))
-            return member or self._client.cache.user_cache.get(self._author_id)
+                member = self._client.cache.get_member(self._guild_id, self._author_id)
+            return member or self._client.cache.get_user(self._author_id)
         return MISSING
 
 

--- a/dis_snek/models/discord/reaction.py
+++ b/dis_snek/models/discord/reaction.py
@@ -71,11 +71,11 @@ class Reaction(ClientObject):
 
     @property
     def message(self) -> "Message":
-        return self._client.cache.message_cache.get((self._channel_id, self._message_id))
+        return self._client.cache.get_message((self._channel_id, self._message_id))
 
     @property
     def channel(self) -> "TYPE_ALL_CHANNEL":
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_channel(self._channel_id)
 
     async def remove(self) -> None:
         """Remove all this emoji's reactions from the message."""

--- a/dis_snek/models/discord/role.py
+++ b/dis_snek/models/discord/role.py
@@ -96,7 +96,7 @@ class Role(DiscordObject):
     @property
     def guild(self) -> "Guild":
         """The guild object this role is from."""
-        return self._client.cache.guild_cache.get(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     @property
     def default(self) -> bool:

--- a/dis_snek/models/discord/scheduled_event.py
+++ b/dis_snek/models/discord/scheduled_event.py
@@ -64,7 +64,7 @@ class ScheduledEvent(DiscordObject):
 
     @property
     def guild(self) -> "Guild":
-        return self._client.cache.guild_cache.get(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:
@@ -72,7 +72,7 @@ class ScheduledEvent(DiscordObject):
             data["creator"] = client.cache.place_user_data(data["creator"])
 
         if data.get("channel_id"):
-            data["channel"] = client.cache.channel_cache.get(data["channel_id"])
+            data["channel"] = client.cache.get_channel(data["channel_id"])
 
         data["start_time"] = data.get("scheduled_start_time")
 

--- a/dis_snek/models/discord/stage_instance.py
+++ b/dis_snek/models/discord/stage_instance.py
@@ -23,11 +23,11 @@ class StageInstance(DiscordObject):
 
     @property
     def guild(self) -> "Guild":
-        return self._client.cache.guild_cache.get(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     @property
     def channel(self) -> "GuildStageVoice":
-        return self._client.cache.channel_cache.get(self._channel_id)
+        return self._client.cache.get_channel(self._channel_id)
 
     async def delete(self, reason: Absent[Optional[str]] = MISSING) -> None:
         """

--- a/dis_snek/models/discord/team.py
+++ b/dis_snek/models/discord/team.py
@@ -44,7 +44,7 @@ class Team(DiscordObject):
 
     @property
     def owner(self) -> "User":
-        return self._client.cache.user_cache.get(self.owner_user_id)
+        return self._client.cache.get_user(self.owner_user_id)
 
     def is_in_team(self, user: Union["SnowflakeObject", "Snowflake_Type"]) -> bool:
         """

--- a/dis_snek/models/discord/user.py
+++ b/dis_snek/models/discord/user.py
@@ -156,7 +156,7 @@ class SnakeBotUser(User):
 
     @property
     def guilds(self) -> List["Guild"]:
-        return [self._client.cache.guild_cache.get(g_id) for g_id in self._guild_ids]
+        return [self._client.cache.get_guild(g_id) for g_id in self._guild_ids]
 
     async def edit(
         self, username: Absent[str] = MISSING, avatar: Absent[Union["File", "IOBase", "Path", str, bytes]] = MISSING
@@ -290,7 +290,7 @@ class Member(DiscordObject, _SendDMMixin):
     @property
     def guild(self) -> "Guild":
         """The guild object this member is from."""
-        return self._client.cache.guild_cache.get(self._guild_id)
+        return self._client.cache.get_guild(self._guild_id)
 
     @property
     def roles(self) -> List["Role"]:

--- a/dis_snek/models/discord/voice_state.py
+++ b/dis_snek/models/discord/voice_state.py
@@ -40,12 +40,12 @@ class VoiceState(ClientObject):
     @property
     def guild(self) -> "Guild":
         """The guild this voice state is for."""
-        return self._client.cache.guild_cache.get(self._guild_id) if self._guild_id else None
+        return self._client.cache.get_guild(self._guild_id) if self._guild_id else None
 
     @property
     def channel(self) -> "TYPE_VOICE_CHANNEL":
         """The channel the user is connected to."""
-        channel = self._client.cache.channel_cache.get(self._channel_id)
+        channel = self._client.cache.get_channel(self._channel_id)
 
         # make sure the member is showing up as a part of the channel
         # this is relevant for VoiceStateUpdate.before
@@ -59,7 +59,7 @@ class VoiceState(ClientObject):
     @property
     def member(self) -> "Member":
         """The member this voice state is for."""
-        return self._client.cache.member_cache.get((self._guild_id, self._member_id)) if self._guild_id else None
+        return self._client.cache.get_member(self._guild_id, self._member_id) if self._guild_id else None
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:


### PR DESCRIPTION
Instead of directly accessing the cache object

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
make use of `SmartCache.get_***()` method instead of accessing `***_cache.get()` objects directly. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
