### PR TITLE
fix: Capture as many channel mentions as possible

### DIFF
--- a/dis_snek/models/discord/message.py
+++ b/dis_snek/models/discord/message.py
@@ -283,8 +283,8 @@ class Message(BaseMessage):
         data["mention_ids"] = mention_ids
 
         found_ids = []
+        mention_channels = []
         if "mention_channels" in data:
-            mention_channels = []
             for channel_data in data["mention_channels"]:
                 mention_channels.append(ChannelMention.from_dict(channel_data, client))
                 found_ids.append(channel_data["id"])

--- a/dis_snek/models/discord/message.py
+++ b/dis_snek/models/discord/message.py
@@ -288,7 +288,6 @@ class Message(BaseMessage):
             for channel_data in data["mention_channels"]:
                 mention_channels.append(ChannelMention.from_dict(channel_data, client))
                 found_ids.append(channel_data["id"])
-            data["mention_channels"] = mention_channels
 
         if len(extra := channel_mention.findall(data["content"])) > 0:
             for channel_id in extra:
@@ -300,6 +299,7 @@ class Message(BaseMessage):
                         "name": channel.name,
                     }
                     mention_channels.append(ChannelMention.from_dict(channel_data, client))
+        data["mention_channels"] = mention_channels
 
         data["attachments"] = Attachment.from_list(data.get("attachments", []), client)
 


### PR DESCRIPTION

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This adds in some extra regex matching during `Message._process_dict` to scan the message content for more channel mentions, and then process them as if they were normal channel mentions. 

This bug is seen here: #324 

While this isn't technically a bug, but rather an API oddity, we still believe that it's necessary to "fix" this for the end users' sake.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add regex to `Message._process_dict` to capture more channel mentions

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
