### PR TITLE
refactor: remove pointless regex from get_first_word

### DIFF
--- a/dis_snek/client/utils/input_utils.py
+++ b/dis_snek/client/utils/input_utils.py
@@ -42,7 +42,6 @@ _pending_regex = _pending_regex.replace("2", f"[{''.join(list(_quotes.values()))
 
 arg_parse = re.compile(_pending_regex)
 white_space = re.compile(r"\s+")
-initial_word = re.compile(r"^([^\s]+)\s*?")
 
 
 class OverriddenJson:
@@ -98,7 +97,4 @@ def get_first_word(text: str) -> Optional[str]:
          The requested word
 
     """
-    found = initial_word.findall(text)
-    if len(found) == 0:
-        return None
-    return found[0]
+    return split[0] if (split := text.split(maxsplit=1)) else None


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
On today's episode of "Astrea messes around with message commands", we find a startling discovery! It seems as if someone loves regex too much... is that an unneeded regex I see? Oh, how expected!

(Jokes aside, `get_first_word` was using regex when `str.split()` does the same thing. This was done because it was thought `str.split()` only splits by spaces, but it splits by whitespace instead. Suggesting how `.split()` is faster than using a *whole regex*, it's probably for the best.)


## Changes
- Use `str.split()` over regex for `input_utils.get_first_word`.
  - Adjustments were done to make sure this wasn't a breaking change, even for that one function.
  - ...though the `initial_word` regex variable was removed. It probably wasn't used anyways.
  - I also decided to use `maxsplit=1` just so Python doesn't have to split 1000 times when we only need to get the first split.
  - Also, `str.split()` automatically does a little `str.strip()` (or something like it) on its own when using it, so that's nice.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
