### PR TITLE
fix: make get_x(None, ...) return None

### DIFF
--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -113,7 +113,7 @@ class GlobalCache:
         Returns:
             User object if found
         """
-        return self.user_cache.get(to_snowflake(user_id))
+        return self.user_cache.get(to_optional_snowflake(user_id))
 
     def place_user_data(self, data: discord_typings.UserData) -> User:
         """
@@ -180,7 +180,7 @@ class GlobalCache:
         Returns:
             Member object if found
         """
-        return self.member_cache.get((to_snowflake(guild_id), to_snowflake(user_id)))
+        return self.member_cache.get((to_optional_snowflake(guild_id), to_optional_snowflake(user_id)))
 
     def place_member_data(
         self, guild_id: "Snowflake_Type", data: discord_typings.resources.guild.GuildMemberData
@@ -383,7 +383,7 @@ class GlobalCache:
         Returns:
             The message if found
         """
-        return self.message_cache.get((to_snowflake(channel_id), to_snowflake(message_id)))
+        return self.message_cache.get((to_optional_snowflake(channel_id), to_optional_snowflake(message_id)))
 
     def place_message_data(self, data: discord_typings.MessageData) -> Message:
         """
@@ -448,7 +448,7 @@ class GlobalCache:
         Returns:
             The channel if found
         """
-        return self.channel_cache.get(to_snowflake(channel_id))
+        return self.channel_cache.get(to_optional_snowflake(channel_id))
 
     def place_channel_data(self, data: discord_typings.ChannelData) -> "TYPE_ALL_CHANNEL":
         """
@@ -520,7 +520,7 @@ class GlobalCache:
         Args:
             user_id: The ID of the user
         """
-        user_id = to_snowflake(user_id)
+        user_id = to_optional_snowflake(user_id)
         channel_id = self.dm_channels.get(user_id)
         if channel_id is None:
             return None
@@ -573,7 +573,7 @@ class GlobalCache:
         Returns:
             The guild if found
         """
-        return self.guild_cache.get(to_snowflake(guild_id))
+        return self.guild_cache.get(to_optional_snowflake(guild_id))
 
     def place_guild_data(self, data: discord_typings.GuildData) -> Guild:
         """
@@ -647,7 +647,7 @@ class GlobalCache:
         Returns:
             The role if found
         """
-        return self.role_cache.get(to_snowflake(role_id))
+        return self.role_cache.get(to_optional_snowflake(role_id))
 
     def place_role_data(
         self, guild_id: "Snowflake_Type", data: List[Dict["Snowflake_Type", Any]]
@@ -709,9 +709,7 @@ class GlobalCache:
             VoiceState object if found
 
         """
-        user_id = to_snowflake(user_id)
-
-        return self.voice_state_cache.get(user_id)
+        return self.voice_state_cache.get(to_optional_snowflake(user_id))
 
     async def place_voice_state_data(self, data: discord_typings.VoiceStateData) -> Optional[VoiceState]:
         """
@@ -806,7 +804,7 @@ class GlobalCache:
         Returns:
             The Emoji if found
         """
-        return self.emoji_cache.get(to_snowflake(emoji_id)) if self.emoji_cache is not None else None
+        return self.emoji_cache.get(to_optional_snowflake(emoji_id)) if self.emoji_cache is not None else None
 
     def place_emoji_data(self, data: discord_typings.EmojiData) -> "CustomEmoji":
         """

--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -103,7 +103,7 @@ class GlobalCache:
             user = self.place_user_data(data)
         return user
 
-    def get_user(self, user_id: "Snowflake_Type") -> Optional[User]:
+    def get_user(self, user_id: Optional["Snowflake_Type"]) -> Optional[User]:
         """
         Get a user by their ID.
 
@@ -169,7 +169,7 @@ class GlobalCache:
             member = self.place_member_data(guild_id, data)
         return member
 
-    def get_member(self, guild_id: "Snowflake_Type", user_id: "Snowflake_Type") -> Optional[Member]:
+    def get_member(self, guild_id: Optional["Snowflake_Type"], user_id: Optional["Snowflake_Type"]) -> Optional[Member]:
         """
         Get a member by their guild and user IDs.
 
@@ -372,7 +372,9 @@ class GlobalCache:
                 message._guild_id = message.channel._guild_id
         return message
 
-    def get_message(self, channel_id: "Snowflake_Type", message_id: "Snowflake_Type") -> Optional[Message]:
+    def get_message(
+        self, channel_id: Optional["Snowflake_Type"], message_id: Optional["Snowflake_Type"]
+    ) -> Optional[Message]:
         """
         Get a message from a channel based on their IDs.
 
@@ -438,7 +440,7 @@ class GlobalCache:
             channel = self.place_channel_data(data)
         return channel
 
-    def get_channel(self, channel_id: "Snowflake_Type") -> Optional["TYPE_ALL_CHANNEL"]:
+    def get_channel(self, channel_id: Optional["Snowflake_Type"]) -> Optional["TYPE_ALL_CHANNEL"]:
         """
         Get a channel based on its ID.
 
@@ -513,7 +515,7 @@ class GlobalCache:
         channel = await self.fetch_channel(channel_id)
         return channel
 
-    def get_dm_channel(self, user_id) -> Optional["DM"]:
+    def get_dm_channel(self, user_id: Optional["Snowflake_Type"]) -> Optional["DM"]:
         """
         Get the DM channel for a user.
 
@@ -563,7 +565,7 @@ class GlobalCache:
             guild = self.place_guild_data(data)
         return guild
 
-    def get_guild(self, guild_id: "Snowflake_Type") -> Optional[Guild]:
+    def get_guild(self, guild_id: Optional["Snowflake_Type"]) -> Optional[Guild]:
         """
         Get a guild based on its ID.
 
@@ -637,7 +639,7 @@ class GlobalCache:
             role = self.place_role_data(guild_id, data)[role_id]
         return role
 
-    def get_role(self, role_id: "Snowflake_Type") -> Optional[Role]:
+    def get_role(self, role_id: Optional["Snowflake_Type"]) -> Optional[Role]:
         """
         Get a role based on the role ID.
 
@@ -698,7 +700,7 @@ class GlobalCache:
 
     # region Voice cache
 
-    def get_voice_state(self, user_id: "Snowflake_Type") -> Optional[VoiceState]:
+    def get_voice_state(self, user_id: Optional["Snowflake_Type"]) -> Optional[VoiceState]:
         """
         Get a voice state by their guild and user IDs.
 
@@ -792,7 +794,7 @@ class GlobalCache:
 
         return emoji
 
-    def get_emoji(self, emoji_id: "Snowflake_Type") -> Optional["CustomEmoji"]:
+    def get_emoji(self, emoji_id: Optional["Snowflake_Type"]) -> Optional["CustomEmoji"]:
         """
         Get an emoji based on the emoji ID.
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
PR #369 made it cache methods were being used instead of getting directly from the dict for many internal methods. However, as `to_snowflake` was used in these methods, using `None` as an argument for `get_x` would error them out, and this was done at *least* for `_on_raw_message_reaction_add`.

This PR attempts to fix that by making `get_x(None, ...)` return `None`, using `to_optional_snowflake` to correctly handle `None`s and letting the cache miss.


## Changes

- Use `to_optional_snowflake` instead of `to_snowflake` for `get_x` methods in the cache.
  - As for `fetch_x` methods, they were left unchanged due to their added complexity to make them return `None`, the fact they are *not* marked as `Optional` right now, and the fact that they *should* error out.
- Typehint `get_x` arguments to `Optional` snowflakes to reflect this change.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
