### PR TITLE
Revert "fix: fixed CustomEmoji by removing guild_id kwarg when it's unncececary"

### DIFF
--- a/dis_snek/api/events/processors/guild_events.py
+++ b/dis_snek/api/events/processors/guild_events.py
@@ -108,7 +108,7 @@ class GuildEvents(EventMixinTemplate):
         else:
             before = []
 
-        after = [self.cache.place_emoji_data(emoji) for emoji in emojis]
+        after = [self.cache.place_emoji_data(guild_id, emoji) for emoji in emojis]
 
         self.dispatch(
             GuildEmojisUpdate(

--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -790,7 +790,7 @@ class GlobalCache:
         emoji = self.emoji_cache.get(emoji_id) if self.emoji_cache is not None else None
         if emoji is None:
             data = await self._client.http.get_guild_emoji(guild_id, emoji_id)
-            emoji = self.place_emoji_data(data)
+            emoji = self.place_emoji_data(guild_id, data)
 
         return emoji
 
@@ -808,17 +808,20 @@ class GlobalCache:
         """
         return self.emoji_cache.get(to_snowflake(emoji_id)) if self.emoji_cache is not None else None
 
-    def place_emoji_data(self, data: discord_typings.EmojiData) -> "CustomEmoji":
+    def place_emoji_data(self, guild_id: "Snowflake_Type", data: discord_typings.EmojiData) -> "CustomEmoji":
         """
         Take json data representing an emoji, process it, and cache it. This cache is disabled by default, start your bot with `Snake(enable_emoji_cache=True)` to enable it.
 
         Args:
+            guild_id: The ID of the guild this emoji belongs to
             data: json representation of the emoji
 
         Returns:
             The processed emoji
         """
-        emoji = CustomEmoji.from_dict(data, self._client)
+        guild_id = to_snowflake(guild_id)
+
+        emoji = CustomEmoji.from_dict(data, self._client, guild_id)
         if self.emoji_cache is not None:
             self.emoji_cache[emoji.id] = emoji
 

--- a/dis_snek/models/discord/emoji.py
+++ b/dis_snek/models/discord/emoji.py
@@ -111,9 +111,9 @@ class CustomEmoji(PartialEmoji):
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any], client: "Snake") -> "CustomEmoji":
+    def from_dict(cls, data: Dict[str, Any], client: "Snake", guild_id: int) -> "CustomEmoji":
         data = cls._process_dict(data, client)
-        return cls(client=client, **cls._filter_kwargs(data, cls._get_init_keys()))
+        return cls(client=client, guild_id=guild_id, **cls._filter_kwargs(data, cls._get_init_keys()))
 
     @property
     def guild(self) -> "Guild":

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -598,7 +598,7 @@ class Guild(BaseGuild):
         }
 
         emoji_data = await self._client.http.create_guild_emoji(data_payload, self.id, reason=reason)
-        return self._client.cache.place_emoji_data(emoji_data)
+        return self._client.cache.place_emoji_data(self.id, emoji_data)
 
     async def create_guild_template(self, name: str, description: Absent[str] = MISSING) -> "models.GuildTemplate":
         template = await self._client.http.create_guild_template(self.id, name, description)
@@ -617,7 +617,7 @@ class Guild(BaseGuild):
 
         """
         emojis_data = await self._client.http.get_all_guild_emoji(self.id)
-        return [self._client.cache.place_emoji_data(emoji_data) for emoji_data in emojis_data]
+        return [self._client.cache.place_emoji_data(self.id, emoji_data) for emoji_data in emojis_data]
 
     async def fetch_custom_emoji(self, emoji_id: Snowflake_Type) -> Optional["models.CustomEmoji"]:
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This reverts commit 45345709ea8b73190a3a312651b8d176037c0b75.

The above commit removed guild_id from place_emoji, presumably assuming that guild_id was always in the emoji payload.
This is very much not the case, as guild_id is omitted in the payloads of the following methods:
- guild.fetch_all_custom_emojis
- guild.create_custom_emoji
- guild_events._on_raw_guild_emojis_update

## Changes
Literally just a revert of 45345709ea8b73190a3a312651b8d176037c0b75. 

It adds back the `guild_id` parameter of cache.place_emoji_data, and anywhere that called it.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
