### PR TITLE
feat: Allow Event class to be passed to `wait_for`

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, NoReturn
 import dis_snek.api.events as events
 from dis_snek.api.events import RawGatewayEvent, MessageCreate
 from dis_snek.api.events import processors
-from dis_snek.api.events.internal import Component
+from dis_snek.api.events.internal import Component, BaseEvent
 from dis_snek.api.gateway.gateway import WebsocketClient
 from dis_snek.api.gateway.state import ConnectionState
 from dis_snek.api.http.http_client import HTTPClient
@@ -30,7 +30,7 @@ from dis_snek.client.errors import (
     NotFound,
 )
 from dis_snek.client.utils.input_utils import get_first_word, get_args
-from dis_snek.client.utils.misc_utils import wrap_partial
+from dis_snek.client.utils.misc_utils import wrap_partial, get_event_name
 from dis_snek.client.utils.serializer import to_image_data
 from dis_snek.models import (
     Activity,
@@ -665,7 +665,10 @@ class Snake(
         await self._ready.wait()
 
     def wait_for(
-        self, event: str, checks: Absent[Optional[Callable[..., bool]]] = MISSING, timeout: Optional[float] = None
+        self,
+        event: Union[str, "BaseEvent"],
+        checks: Absent[Optional[Callable[..., bool]]] = MISSING,
+        timeout: Optional[float] = None,
     ) -> Any:
         """
         Waits for a WebSocket event to be dispatched.
@@ -679,6 +682,8 @@ class Snake(
             The event object.
 
         """
+        event = get_event_name(event)
+
         if event not in self.waits:
             self.waits[event] = []
 

--- a/dis_snek/models/snek/listener.py
+++ b/dis_snek/models/snek/listener.py
@@ -1,12 +1,10 @@
 import asyncio
 import inspect
-import re
 from typing import Coroutine, Callable
 
 from dis_snek.api.events.internal import BaseEvent
 from dis_snek.client.const import MISSING, Absent
-
-camel_to_snake = re.compile(r"([A-Z]+)")
+from dis_snek.client.utils import get_event_name
 
 __all__ = ["Listener", "listen"]
 
@@ -44,17 +42,7 @@ class Listener:
                 if not name:
                     name = coro.__name__
 
-            elif inspect.isclass(name) and issubclass(name, BaseEvent):
-                name = name.__name__
-
-            # convert CamelCase to snake_case
-            name = camel_to_snake.sub(r"_\1", name).lower()
-            # remove any leading underscores
-            name = name.lstrip("_")
-            # remove any `on_` prefixes
-            name = name.removeprefix("on_")
-
-            return cls(coro, name)
+            return cls(coro, get_event_name(name))
 
         return wrapper
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
So now you can do things like `await self.bot.wait_for(ThreadDelete, timeout=2)` instead of `await self.bot.wait_for("thread_delete", timeout=2)`

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
