### PR TITLE
fix: check for more cases for Role ordering

### DIFF
--- a/dis_snek/models/discord/role.py
+++ b/dis_snek/models/discord/role.py
@@ -58,7 +58,20 @@ class Role(DiscordObject):
         if self._guild_id != other._guild_id:
             raise RuntimeError("Unable to compare Roles from different guilds.")
 
-        return self.position < other.position
+        if self.id == self._guild_id:  # everyone role
+            # everyone role is on the bottom, so check if the other role is, well, not it
+            # because then it must be higher than it
+            return other.id != self.id
+
+        if self.position < other.position:
+            return True
+
+        if self.position == other.position:
+            # if two roles have the same position, which can happen thanks to discord, then
+            # we can thankfully use their ids to determine which one is lower
+            return self.id < other.id
+
+        return False
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Ordering methods (`>`, `>=`, `<`, `<=`) for `Role` were notoriously buggy, not always correctly determining if a role is higher than another in the role hierarchy.

This turned out to be an issue with how Discord... is, really. There were edge cases we missed.
This PR accounts for that.

## Changes

- Added more cases for `__lt__` in `Role` to check for.
  - It now checks if the role is the `@everyone` role for a guild and if Discord says they have the same position... for some reason. Discord does that at times.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
