### PR TITLE
feat: Replace the assorted ways of typing a file upload with UPLOADABLE_TYPE

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -36,7 +36,6 @@ from dis_snek.models import (
     Activity,
     Application,
     CustomEmoji,
-    File,
     Guild,
     GuildTemplate,
     Message,
@@ -68,6 +67,7 @@ from dis_snek.models import (
 from dis_snek.models import Wait
 from dis_snek.models.discord.components import get_components_ids, BaseComponent
 from dis_snek.models.discord.enums import ComponentTypes, Intents, InteractionTypes, Status
+from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from dis_snek.models.discord.modal import Modal
 from dis_snek.models.snek.auto_defer import AutoDefer
 from dis_snek.models.snek.listener import Listener
@@ -75,8 +75,6 @@ from dis_snek.models.snek.tasks import Task
 from .smart_cache import GlobalCache
 
 if TYPE_CHECKING:
-    from io import IOBase
-    from pathlib import Path
     from dis_snek.models import Snowflake_Type, TYPE_ALL_CHANNEL
 
 log = logging.getLogger(logger_name)
@@ -1501,7 +1499,7 @@ class Snake(
         self,
         template_code: Union["GuildTemplate", str],
         name: str,
-        icon: Absent[Union["File", "IOBase", "Path", str, bytes]] = MISSING,
+        icon: Absent[UPLOADABLE_TYPE] = MISSING,
     ) -> Optional[Guild]:
         """
         Creates a new guild based on a template.

--- a/dis_snek/client/mixins/send.py
+++ b/dis_snek/client/mixins/send.py
@@ -4,13 +4,10 @@ import dis_snek.client.errors as errors
 import dis_snek.models as models
 
 if TYPE_CHECKING:
-    from io import IOBase
-    from pathlib import Path
-
     from aiohttp.formdata import FormData
 
     from dis_snek.client import Snake
-    from dis_snek.models import File
+    from dis_snek.models.discord.file import UPLOADABLE_TYPE
     from dis_snek.models.discord.components import BaseComponent
     from dis_snek.models.discord.embed import Embed
     from dis_snek.models.discord.message import AllowedMentions, Message, MessageReference
@@ -38,8 +35,8 @@ class SendMixin:
         stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        files: Optional[Union["File", "IOBase", "Path", str, List[Union["File", "IOBase", "Path", str]]]] = None,
-        file: Optional[Union["File", "IOBase", "Path", str]] = None,
+        files: Optional[Union["UPLOADABLE_TYPE", List["UPLOADABLE_TYPE"]]] = None,
+        file: Optional["UPLOADABLE_TYPE"] = None,
         tts: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
         **kwargs,

--- a/dis_snek/client/utils/serializer.py
+++ b/dis_snek/client/utils/serializer.py
@@ -2,12 +2,12 @@ from base64 import b64encode
 from datetime import datetime, timezone
 from io import IOBase
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 from attr import fields, has
 
 from dis_snek.client.const import MISSING
-from dis_snek.models.discord.file import File
+from dis_snek.models.discord.file import UPLOADABLE_TYPE, File
 
 __all__ = ["no_export_meta", "export_converter", "to_dict", "dict_filter_none", "dict_filter_missing", "to_image_data"]
 
@@ -68,7 +68,7 @@ def dict_filter_missing(data: dict) -> dict:
     return {k: v for k, v in data.items() if v is not MISSING}
 
 
-def to_image_data(imagefile: Optional[Union["File", "IOBase", "Path", str, bytes]]) -> Optional[str]:
+def to_image_data(imagefile: Optional[UPLOADABLE_TYPE]) -> Optional[str]:
     match imagefile:
         case bytes():
             image_data = imagefile

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -15,6 +15,7 @@ from dis_snek.client.utils.converters import timestamp_converter
 from dis_snek.client.utils.misc_utils import get
 from dis_snek.client.utils.serializer import to_dict, to_image_data
 from dis_snek.models.discord.base import DiscordObject
+from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from dis_snek.models.discord.snowflake import Snowflake_Type, to_snowflake, to_optional_snowflake, SnowflakeObject
 from dis_snek.models.snek import AsyncIterator
 from .enums import (
@@ -29,9 +30,6 @@ from .enums import (
 )
 
 if TYPE_CHECKING:
-    from io import IOBase
-    from pathlib import Path
-
     from aiohttp import FormData
     from dis_snek import Snake
 
@@ -594,9 +592,7 @@ class ThreadableMixin:
 
 @define(slots=False)
 class WebhookMixin:
-    async def create_webhook(
-        self, name: str, avatar: Absent[Union["models.File", "IOBase", "Path", str, bytes]] = MISSING
-    ) -> "models.Webhook":
+    async def create_webhook(self, name: str, avatar: Absent[UPLOADABLE_TYPE] = MISSING) -> "models.Webhook":
         """
         Create a webhook in this channel.
 
@@ -665,7 +661,7 @@ class BaseChannel(DiscordObject):
     async def edit(
         self,
         name: Absent[str] = MISSING,
-        icon: Absent[Union[str, "Path", "IOBase", "models.File"]] = MISSING,
+        icon: Absent[UPLOADABLE_TYPE] = MISSING,
         type: Absent[ChannelTypes] = MISSING,
         position: Absent[int] = MISSING,
         topic: Absent[str] = MISSING,
@@ -758,7 +754,7 @@ class DMGroup(DMChannel):
     async def edit(
         self,
         name: Absent[str] = MISSING,
-        icon: Absent[Union[str, "Path", "IOBase", "models.File"]] = MISSING,
+        icon: Absent[UPLOADABLE_TYPE] = MISSING,
         reason: Absent[str] = MISSING,
         **kwargs,
     ) -> "DMGroup":
@@ -1129,7 +1125,11 @@ class GuildCategory(GuildChannel):
             reason: the reason for this change
         """
         return await super().edit(
-            name=name, position=position, permission_overwrites=permission_overwrites, reason=reason, **kwargs
+            name=name,
+            position=position,
+            permission_overwrites=permission_overwrites,
+            reason=reason,
+            **kwargs,
         )
 
     async def create_channel(

--- a/dis_snek/models/discord/file.py
+++ b/dis_snek/models/discord/file.py
@@ -1,6 +1,6 @@
 from io import IOBase
 from pathlib import Path
-from typing import Optional, Union
+from typing import BinaryIO, Optional, Union
 
 from dis_snek.client.utils.attr_utils import define, field
 
@@ -16,19 +16,22 @@ class File:
 
     """
 
-    file: Union["IOBase", "Path", str] = field(repr=True)
+    file: Union["IOBase", BinaryIO, "Path", str] = field(repr=True)
     """Location of file to send or the bytes."""
     file_name: Optional[str] = field(repr=True, default=None)
     """Set a filename that will be displayed when uploaded to discord. If you leave this empty, the file will be called `file` by default"""
 
-    def open_file(self) -> "IOBase":
+    def open_file(self) -> BinaryIO:
         if isinstance(self.file, IOBase):
             return self.file
         else:
             return open(str(self.file), "rb")
 
 
-def open_file(file: Union[File, "IOBase", "Path", str]) -> IOBase:
+UPLOADABLE_TYPE = Union[File, IOBase, BinaryIO, Path, str]
+
+
+def open_file(file: UPLOADABLE_TYPE) -> BinaryIO:
     match file:
         case File():
             return file.open_file()

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -2,9 +2,8 @@ import asyncio
 from collections import namedtuple
 import logging
 import time
-from io import IOBase
-from pathlib import Path
 from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
+from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from dis_snek.models.snek import AsyncIterator
 from aiohttp import FormData
 
@@ -506,10 +505,10 @@ class Guild(BaseGuild):
         system_channel_flags: Absent[Union[SystemChannelFlags, int]] = MISSING,
         # ToDo: these are not tested. Mostly, since I do not have access to those features
         owner: Absent[Optional[Union["models.Member", Snowflake_Type]]] = MISSING,
-        icon: Absent[Optional[Union[str, "Path", "IOBase"]]] = MISSING,
-        splash: Absent[Optional[Union["models.File", "IOBase", "Path", str, bytes]]] = MISSING,
-        discovery_splash: Absent[Optional[Union[str, "Path", "IOBase"]]] = MISSING,
-        banner: Absent[Optional[Union[str, "Path", "IOBase"]]] = MISSING,
+        icon: Absent[Optional[UPLOADABLE_TYPE]] = MISSING,
+        splash: Absent[Optional[UPLOADABLE_TYPE]] = MISSING,
+        discovery_splash: Absent[Optional[UPLOADABLE_TYPE]] = MISSING,
+        banner: Absent[Optional[UPLOADABLE_TYPE]] = MISSING,
         rules_channel: Absent[Optional[Union["models.GuildText", Snowflake_Type]]] = MISSING,
         public_updates_channel: Absent[Optional[Union["models.GuildText", Snowflake_Type]]] = MISSING,
         preferred_locale: Absent[Optional[str]] = MISSING,
@@ -574,7 +573,7 @@ class Guild(BaseGuild):
     async def create_custom_emoji(
         self,
         name: str,
-        imagefile: Union["models.File", "IOBase", "Path", str, bytes],
+        imagefile: UPLOADABLE_TYPE,
         roles: Absent[List[Union[Snowflake_Type, "models.Role"]]] = MISSING,
         reason: Absent[Optional[str]] = MISSING,
     ) -> "models.CustomEmoji":
@@ -1025,7 +1024,7 @@ class Guild(BaseGuild):
     async def create_custom_sticker(
         self,
         name: str,
-        imagefile: Union["models.File", "IOBase", "Path", str],
+        imagefile: UPLOADABLE_TYPE,
         description: Absent[Optional[str]] = MISSING,
         tags: Absent[Optional[str]] = MISSING,
         reason: Absent[Optional[str]] = MISSING,
@@ -1143,7 +1142,7 @@ class Guild(BaseGuild):
         hoist: Optional[bool] = False,
         mentionable: Optional[bool] = False,
         # ToDo: icon needs testing. I have to access to that
-        icon: Absent[Optional[Union[str, "Path", "IOBase"]]] = MISSING,
+        icon: Absent[Optional[UPLOADABLE_TYPE]] = MISSING,
         reason: Absent[Optional[str]] = MISSING,
     ) -> "models.Role":
         """

--- a/dis_snek/models/discord/message.py
+++ b/dis_snek/models/discord/message.py
@@ -1,8 +1,6 @@
 import asyncio
 import re
 from dataclasses import dataclass
-from io import IOBase
-from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Union
 from aiohttp import FormData
 
@@ -15,6 +13,7 @@ from dis_snek.client.utils.converters import optional as optional_c
 from dis_snek.client.utils.converters import timestamp_converter
 from dis_snek.client.utils.input_utils import OverriddenJson
 from dis_snek.client.utils.serializer import dict_filter_none
+from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from .base import DiscordObject
 from .enums import (
     ChannelTypes,
@@ -366,10 +365,8 @@ class Message(BaseMessage):
         ] = None,
         allowed_mentions: Optional[Union[AllowedMentions, dict]] = None,
         attachments: Optional[Optional[List[Union[Attachment, dict]]]] = None,
-        files: Optional[
-            Union["models.File", "IOBase", "Path", str, List[Union["models.File", "IOBase", "Path", str]]]
-        ] = None,
-        file: Optional[Union["models.File", "IOBase", "Path", str]] = None,
+        files: Optional[Union[UPLOADABLE_TYPE, List[UPLOADABLE_TYPE]]] = None,
+        file: Optional[UPLOADABLE_TYPE] = None,
         tts: bool = False,
         flags: Optional[Union[int, MessageFlags]] = None,
     ) -> "Message":
@@ -659,9 +656,7 @@ def process_message_payload(
     allowed_mentions: Optional[Union[AllowedMentions, dict]] = None,
     reply_to: Optional[Union[MessageReference, Message, dict, "Snowflake_Type"]] = None,
     attachments: Optional[List[Union[Attachment, dict]]] = None,
-    files: Optional[
-        Union["models.File", "IOBase", "Path", str, List[Union["models.File", "IOBase", "Path", str]]]
-    ] = None,
+    files: Optional[Union[UPLOADABLE_TYPE, List[UPLOADABLE_TYPE]]] = None,
     tts: bool = False,
     flags: Optional[Union[int, MessageFlags]] = None,
     **kwargs,

--- a/dis_snek/models/discord/user.py
+++ b/dis_snek/models/discord/user.py
@@ -1,7 +1,5 @@
 import logging
 from datetime import datetime
-from io import IOBase
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Set, Dict, List, Optional, Union
 
 from dis_snek.client.const import MISSING, logger_name, Absent
@@ -15,6 +13,7 @@ from dis_snek.client.utils.serializer import to_image_data
 from dis_snek.models.discord.asset import Asset
 from dis_snek.models.discord.color import Color
 from dis_snek.models.discord.enums import Permissions, PremiumTypes, UserFlags
+from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from dis_snek.models.discord.role import Role
 from dis_snek.models.discord.snowflake import Snowflake_Type
 from dis_snek.models.discord.snowflake import to_snowflake
@@ -158,9 +157,7 @@ class SnakeBotUser(User):
     def guilds(self) -> List["Guild"]:
         return [self._client.cache.get_guild(g_id) for g_id in self._guild_ids]
 
-    async def edit(
-        self, username: Absent[str] = MISSING, avatar: Absent[Union["File", "IOBase", "Path", str, bytes]] = MISSING
-    ) -> None:
+    async def edit(self, username: Absent[str] = MISSING, avatar: Absent[UPLOADABLE_TYPE] = MISSING) -> None:
         """
         Edit the client's user.
 

--- a/dis_snek/models/discord/webhooks.py
+++ b/dis_snek/models/discord/webhooks.py
@@ -12,16 +12,13 @@ from dis_snek.models.discord.snowflake import to_snowflake, to_optional_snowflak
 from .base import DiscordObject
 
 if TYPE_CHECKING:
-    from io import IOBase
-    from pathlib import Path
-
+    from dis_snek.models.discord.file import UPLOADABLE_TYPE
     from dis_snek.client import Snake
     from dis_snek.models.discord.enums import MessageFlags
     from dis_snek.models.discord.snowflake import Snowflake_Type
     from dis_snek.models.discord.channel import TYPE_MESSAGEABLE_CHANNEL
     from dis_snek.models.discord.components import BaseComponent
     from dis_snek.models.discord.embed import Embed
-    from dis_snek.models import File
 
     from dis_snek.models.discord.message import (
         AllowedMentions,
@@ -95,7 +92,7 @@ class Webhook(DiscordObject, SendMixin):
         client: "Snake",
         channel: Union["Snowflake_Type", "TYPE_MESSAGEABLE_CHANNEL"],
         name: str,
-        avatar: Absent[Union["File", "IOBase", "Path", str, bytes]] = MISSING,
+        avatar: Absent["UPLOADABLE_TYPE"] = MISSING,
     ) -> "Webhook":
         """
         Create a webhook.
@@ -138,7 +135,7 @@ class Webhook(DiscordObject, SendMixin):
     async def edit(
         self,
         name: Absent[str] = MISSING,
-        avatar: Absent[Union["File", "IOBase", "Path", str, bytes]] = MISSING,
+        avatar: Absent["UPLOADABLE_TYPE"] = MISSING,
         channel_id: Absent["Snowflake_Type"] = MISSING,
     ) -> None:
         """
@@ -176,8 +173,8 @@ class Webhook(DiscordObject, SendMixin):
         stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        files: Optional[Union["File", "IOBase", "Path", str, List[Union["File", "IOBase", "Path", str]]]] = None,
-        file: Optional[Union["File", "IOBase", "Path", str]] = None,
+        files: Optional[Union["UPLOADABLE_TYPE", List["UPLOADABLE_TYPE"]]] = None,
+        file: Optional["UPLOADABLE_TYPE"] = None,
         tts: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
         username: str = None,
@@ -247,8 +244,8 @@ class Webhook(DiscordObject, SendMixin):
         stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        files: Optional[Union["File", "IOBase", "Path", str, List[Union["File", "IOBase", "Path", str]]]] = None,
-        file: Optional[Union["File", "IOBase", "Path", str]] = None,
+        files: Optional[Union["UPLOADABLE_TYPE", List["UPLOADABLE_TYPE"]]] = None,
+        file: Optional["UPLOADABLE_TYPE"] = None,
         tts: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
     ) -> Optional["Message"]:

--- a/dis_snek/models/snek/context.py
+++ b/dis_snek/models/snek/context.py
@@ -1,9 +1,8 @@
 import logging
-from io import IOBase
-from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from aiohttp import FormData
+from dis_snek.models.discord.file import UPLOADABLE_TYPE
 
 import dis_snek.models.discord.message as message
 from dis_snek.client.const import MISSING, logger_name, Absent
@@ -18,7 +17,6 @@ from dis_snek.models.snek.application_commands import CallbackTypes, OptionTypes
 
 if TYPE_CHECKING:
     from dis_snek.client import Snake
-    from dis_snek.models import File
     from dis_snek.models.discord.channel import TYPE_MESSAGEABLE_CHANNEL
     from dis_snek.models.discord.components import BaseComponent
     from dis_snek.models.discord.embed import Embed
@@ -320,8 +318,8 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
         stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        files: Optional[Union["File", "IOBase", "Path", str, List[Union["File", "IOBase", "Path", str]]]] = None,
-        file: Optional[Union["File", "IOBase", "Path", str]] = None,
+        files: Optional[Union[UPLOADABLE_TYPE, List[UPLOADABLE_TYPE]]] = None,
+        file: Optional[UPLOADABLE_TYPE] = None,
         tts: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
         ephemeral: bool = False,
@@ -460,8 +458,8 @@ class ComponentContext(InteractionContext):
             Union[List[List[Union["BaseComponent", dict]]], List[Union["BaseComponent", dict]], "BaseComponent", dict]
         ] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
-        files: Optional[Union["File", "IOBase", "Path", str, List[Union["File", "IOBase", "Path", str]]]] = None,
-        file: Optional[Union["File", "IOBase", "Path", str]] = None,
+        files: Optional[Union[UPLOADABLE_TYPE, List[UPLOADABLE_TYPE]]] = None,
+        file: Optional[UPLOADABLE_TYPE] = None,
         tts: bool = False,
     ) -> "Message":
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
As mentioned in #376, the type hints for `file` was a messy spread of some combinations of File, IOBase, BinaryIO, Path, str, and bytes.
I've created a single variable `UPLOADABLE_TYPE`, and replaced all references with it.  

I also dropped the hint for `bytes`, as there's no reason people should every be passing a bytes (and it wouldn't have worked properly under the current code anyway), and changed the return annotations from `io.IOBase` to `typing.BinaryIO`.


## Changes
- Added `UPLOADABLE_TYPE = Union[File, IOBase, BinaryIO, Path, str]`
- Used it on every parameter that could take a File, filename, or IO stream.
- Cleaned up return types in file.py 


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code

Closes #376