### PR TITLE
refactor💥: Simplify thread create into one method

### DIFF
--- a/dis_snek/api/http/http_requests/threads.py
+++ b/dis_snek/api/http/http_requests/threads.py
@@ -149,9 +149,9 @@ class ThreadRequests:
         channel_id: "Snowflake_Type",
         name: str,
         auto_archive_duration: int,
-        thread_type: int = None,
-        invitable: Optional[bool] = None,
-        message_id: Optional["Snowflake_Type"] = None,
+        thread_type: Absent[int] = MISSING,
+        invitable: Absent[bool] = MISSING,
+        message_id: Absent["Snowflake_Type"] = MISSING,
         reason: Absent[str] = MISSING,
     ) -> discord_typings.ThreadChannelData:
         """

--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -428,61 +428,45 @@ class InvitableMixin:
 
 @define(slots=False)
 class ThreadableMixin:
-    async def create_thread_with_message(
+    async def create_thread(
         self,
         name: str,
-        message: Union[Snowflake_Type, "models.Message"],
-        auto_archive_duration: Union[AutoArchiveDuration, int] = AutoArchiveDuration.ONE_DAY,
-        reason: Optional[str] = None,
-    ) -> Union["GuildNewsThread", "GuildPublicThread"]:
+        message: Absent[Union[Snowflake_Type]] = MISSING,
+        thread_type: Absent[Union[ChannelTypes]] = MISSING,
+        invitable: Absent[bool] = MISSING,
+        auto_archive_duration: Union[AutoArchiveDuration] = AutoArchiveDuration.ONE_DAY,
+        reason: Absent[str] = None,
+    ) -> Union["GuildNewsThread", "GuildPublicThread", "GuildPrivateThread"]:
         """
-        Create a thread connected to a message.
+        Creates a nee thread in this channel. If a message is provided, it will be used as the initial message.
 
         Args:
             name: 1-100 character thread name
-            message: The message to connect this thread to
-            auto_archive_duration: Time before the thread will be automatically archived
-            reason: The reason for creating this thread
+            message: The message to connect this thread to. Required for news channel.
+            thread_type: Is the thread private or public. Not applicable to news channel, it always be GUILD_NEWS_THREAD.
+            invitable: whether non-moderators can add other non-moderators to a thread. Only applicable when creating a private thread.
+            auto_archive_duration: Time before the thread will be automatically archived. Note 3 day and 7 day archive durations require the server to be boosted.
+            reason: The reason for creating this thread.
 
         Returns:
             The created thread, if successful
         """
-        thread_data = await self._client.http.create_thread(
-            channel_id=self.id,
-            name=name,
-            auto_archive_duration=auto_archive_duration,
-            message_id=to_snowflake(message),
-            reason=reason,
-        )
-        return self._client.cache.place_channel_data(thread_data)
+        if self.type == ChannelTypes.GUILD_NEWS and not message:
+            raise ValueError("News channel must include message to create thread from.")
 
-    async def create_thread_without_message(
-        self,
-        name: str,
-        thread_type: Union[ChannelTypes, int],
-        invitable: Optional[bool] = None,
-        auto_archive_duration: Union[AutoArchiveDuration, int] = AutoArchiveDuration.ONE_DAY,
-        reason: Optional[str] = None,
-    ) -> Union["GuildPrivateThread", "GuildPublicThread"]:
-        """
-        Creates a thread without a message source.
+        elif message and (thread_type or invitable):
+            raise ValueError("Message cannot be used with thread_type or invitable.")
 
-        Args:
-            name: 	1-100 character thread name
-            thread_type: Is the thread private or public
-            invitable: whether non-moderators can add other non-moderators to a thread; only available when creating a private thread
-            auto_archive_duration: Time before the thread will be automatically archived
-            reason: The reason to create this thread
+        elif thread_type != ChannelTypes.GUILD_PRIVATE_THREAD and invitable:
+            raise ValueError("Invitable only applies to private threads.")
 
-        Returns:
-            The created thread, if successful
-        """
         thread_data = await self._client.http.create_thread(
             channel_id=self.id,
             name=name,
             thread_type=thread_type,
-            auto_archive_duration=auto_archive_duration,
             invitable=invitable,
+            auto_archive_duration=auto_archive_duration,
+            message_id=to_optional_snowflake(message),
             reason=reason,
         )
         return self._client.cache.place_channel_data(thread_data)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Mainly made this change bcu `create_thread_without_message` doesn't work for the news channel. So I think its better to condense to one method and add checks/docstring to inform users on allowed/disallowed behaviours.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
* Simplify thread create into one method

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
