### PR TITLE
feat: use overloads to better type get_context

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -9,7 +9,26 @@ import time
 import traceback
 from collections.abc import Iterable
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, NoReturn, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    NoReturn,
+    Optional,
+    Type,
+    Union,
+    overload,
+    Literal,
+)
+
+from discord_typings.interactions.receiving import (
+    ComponentChannelInteractionData,
+    AutocompleteChannelInteractionData,
+    InteractionData,
+)
 
 import dis_snek.api.events as events
 from dis_snek.api.events import RawGatewayEvent, MessageCreate
@@ -1140,9 +1159,39 @@ class Snake(
                                     scope
                                 ] = int(cmd_data["id"])
 
+    @overload
+    async def get_context(self, data: ComponentChannelInteractionData, interaction: Literal[True]) -> ComponentContext:
+        ...
+
+    @overload
     async def get_context(
-        self, data: Union[dict, Message], interaction: bool = False
-    ) -> Union[MessageContext, InteractionContext, ComponentContext, AutocompleteContext]:
+        self, data: AutocompleteChannelInteractionData, interaction: Literal[True]
+    ) -> AutocompleteContext:
+        ...
+
+    # as of right now, discord_typings doesn't include anything like this
+    # @overload
+    # async def get_context(self, data: ModalSubmitInteractionData, interaction: Literal[True]) -> ModalContext:
+    #     ...
+
+    @overload
+    async def get_context(self, data: InteractionData, interaction: Literal[True]) -> InteractionContext:
+        ...
+
+    @overload
+    async def get_context(
+        self, data: dict, interaction: Literal[True]
+    ) -> ComponentContext | AutocompleteContext | ModalContext | InteractionContext:
+        # fallback case since some data isn't typehinted properly
+        ...
+
+    @overload
+    async def get_context(self, data: Message, interaction: Literal[False] = False) -> MessageContext:
+        ...
+
+    async def get_context(
+        self, data: InteractionData | dict | Message, interaction: bool = False
+    ) -> ComponentContext | AutocompleteContext | ModalContext | InteractionContext | MessageContext:
         """
         Return a context object based on data passed.
 
@@ -1158,7 +1207,7 @@ class Snake(
 
         """
         # this line shuts up IDE warnings
-        cls: Union[MessageContext, ComponentContext, InteractionContext, AutocompleteContext]
+        cls: ComponentContext | AutocompleteContext | ModalContext | InteractionContext | MessageContext
 
         if interaction:
             match data["type"]:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
While `Snake.get_context`'s typehinting worked, it was quite imprecise, to put it in words. For example, the `get_context` in both `_dispatch_msg_commamnd` and `_dispatch_interaction` would cause issues with typehinting later down in those two functions, with them respectively not expecting fields/types from `InteractionContext` or `MessageContext`.

This PR *somewhat* fixes that. Due to the fact that the interaction data itself isn't really typehinted by type, it can only do so much, but it sure does produce a lot less red.

## Changes

- Use `typing.overload` and interaction data typings from `discord_typings` to typehint `get_context` depending on what data was receieved.
  - A "catch-all" `dict` overload was also added for the sake of `dis-snek`'s internal functions.
  - This involved importing `overload` and `Literal` from `typing`, making `black` trigger and re-format the imports.
  - This does not support modal response interaction typehinting as `discord_typings` does not have that yet. A comment detailing how the overload could be added in the future was left for any future maintainer who needs to add it in.
- Adjust typehintings of the main `get_context` to reflect the overloads.
  - `ModalContext` is now included in the union of types returned by it since, well, why wasn't it included before?


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
