### PR TITLE
fix: Add __all__ to all remaining files, and add a linter to prevent …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
           - flake8-raise
           - flake8-deprecated
           - flake8-print
+          - flake8-dunder-all
         language_version: python3.10
 ci:
   autoupdate_branch: 'dev'

--- a/dis_snek/api/events/discord.py
+++ b/dis_snek/api/events/discord.py
@@ -28,6 +28,57 @@ from dis_snek.client.const import MISSING, Absent
 from dis_snek.client.utils.attr_utils import define, field, docs
 from .internal import BaseEvent, GuildEvent
 
+__all__ = [
+    "BanCreate",
+    "BanRemove",
+    "ChannelCreate",
+    "ChannelDelete",
+    "ChannelPinsUpdate",
+    "ChannelUpdate",
+    "GuildEmojisUpdate",
+    "GuildJoin",
+    "GuildLeft",
+    "GuildMembersChunk",
+    "GuildStickersUpdate",
+    "GuildUnavailable",
+    "GuildUpdate",
+    "IntegrationCreate",
+    "IntegrationDelete",
+    "IntegrationUpdate",
+    "InteractionCreate",
+    "InviteCreate",
+    "InviteDelete",
+    "MemberAdd",
+    "MemberRemove",
+    "MemberUpdate",
+    "MessageCreate",
+    "MessageDelete",
+    "MessageDeleteBulk",
+    "MessageReactionAdd",
+    "MessageReactionRemove",
+    "MessageReactionRemoveAll",
+    "MessageUpdate",
+    "ModalResponse",
+    "PresenceUpdate",
+    "RawGatewayEvent",
+    "RoleCreate",
+    "RoleDelete",
+    "RoleUpdate",
+    "StageInstanceCreate",
+    "StageInstanceDelete",
+    "StageInstanceUpdate",
+    "ThreadCreate",
+    "ThreadDelete",
+    "ThreadListSync",
+    "ThreadMemberUpdate",
+    "ThreadMembersUpdate",
+    "ThreadUpdate",
+    "TypingStart",
+    "VoiceStateUpdate",
+    "WebhooksUpdate",
+]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.guild import Guild, GuildIntegration
     from dis_snek.models.discord.channel import BaseChannel, TYPE_THREAD_CHANNEL

--- a/dis_snek/api/events/internal.py
+++ b/dis_snek/api/events/internal.py
@@ -27,6 +27,22 @@ from dis_snek.client.const import MISSING
 from dis_snek.models.discord.snowflake import to_snowflake
 from dis_snek.client.utils.attr_utils import define, field, docs
 
+__all__ = [
+    "BaseEvent",
+    "Button",
+    "Component",
+    "Connect",
+    "Disconnect",
+    "GuildEvent",
+    "Login",
+    "Ready",
+    "Resume",
+    "Select",
+    "Startup",
+    "WebsocketReady",
+]
+
+
 if TYPE_CHECKING:
     from dis_snek import Snake
     from dis_snek.models.snek.context import ComponentContext

--- a/dis_snek/api/http/http_requests/__init__.py
+++ b/dis_snek/api/http/http_requests/__init__.py
@@ -11,3 +11,19 @@ from .stickers import StickerRequests
 from .threads import ThreadRequests
 from .users import UserRequests
 from .webhooks import WebhookRequests
+
+__all__ = [
+    "BotRequests",
+    "ChannelRequests",
+    "EmojiRequests",
+    "GuildRequests",
+    "InteractionRequests",
+    "MemberRequests",
+    "MessageRequests",
+    "ReactionRequests",
+    "ScheduledEventsRequests",
+    "StickerRequests",
+    "ThreadRequests",
+    "UserRequests",
+    "WebhookRequests",
+]

--- a/dis_snek/api/http/http_requests/bot.py
+++ b/dis_snek/api/http/http_requests/bot.py
@@ -4,6 +4,8 @@ import discord_typings
 
 from ..route import Route
 
+__all__ = ["BotRequests"]
+
 
 class BotRequests:
     request: Any

--- a/dis_snek/api/http/http_requests/channels.py
+++ b/dis_snek/api/http/http_requests/channels.py
@@ -7,6 +7,9 @@ from dis_snek.models.discord.enums import ChannelTypes, StagePrivacyLevel, Permi
 from ..route import Route
 from dis_snek.client.utils.serializer import dict_filter_none, dict_filter_missing
 
+__all__ = ["ChannelRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.channel import PermissionOverwrite
     from dis_snek.models.discord.snowflake import Snowflake_Type

--- a/dis_snek/api/http/http_requests/emojis.py
+++ b/dis_snek/api/http/http_requests/emojis.py
@@ -5,6 +5,9 @@ import discord_typings
 from dis_snek.client.const import MISSING, Absent
 from ..route import Route
 
+__all__ = ["EmojiRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/guild.py
+++ b/dis_snek/api/http/http_requests/guild.py
@@ -9,6 +9,9 @@ from urllib.parse import urlencode
 
 from ..route import Route
 
+__all__ = ["GuildRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
     from dis_snek.models.discord.enums import AuditLogEventType

--- a/dis_snek/api/http/http_requests/interactions.py
+++ b/dis_snek/api/http/http_requests/interactions.py
@@ -5,6 +5,9 @@ import discord_typings
 from dis_snek.client.const import GLOBAL_SCOPE
 from ..route import Route
 
+__all__ = ["InteractionRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/members.py
+++ b/dis_snek/api/http/http_requests/members.py
@@ -7,6 +7,9 @@ from ..route import Route
 from dis_snek.models.discord.timestamp import Timestamp
 from dis_snek.client.utils.serializer import dict_filter_missing
 
+__all__ = ["MemberRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/messages.py
+++ b/dis_snek/api/http/http_requests/messages.py
@@ -5,6 +5,9 @@ import discord_typings
 from dis_snek.client.const import MISSING, Absent
 from ..route import Route
 
+__all__ = ["MessageRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/reactions.py
+++ b/dis_snek/api/http/http_requests/reactions.py
@@ -6,6 +6,9 @@ from dis_snek.client.const import MISSING, Absent
 from ..route import Route
 from dis_snek.client.utils.serializer import dict_filter_missing
 
+__all__ = ["ReactionRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/scheduled_events.py
+++ b/dis_snek/api/http/http_requests/scheduled_events.py
@@ -7,6 +7,9 @@ from dis_snek.client.const import MISSING, Absent
 from ..route import Route
 from dis_snek.client.utils.serializer import dict_filter_missing
 
+__all__ = ["ScheduledEventsRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/stickers.py
+++ b/dis_snek/api/http/http_requests/stickers.py
@@ -5,6 +5,9 @@ import discord_typings
 from dis_snek.client.const import MISSING
 from ..route import Route
 
+__all__ = ["StickerRequests"]
+
+
 if TYPE_CHECKING:
     from aiohttp import FormData
     from dis_snek.models.discord.snowflake import Snowflake_Type

--- a/dis_snek/api/http/http_requests/threads.py
+++ b/dis_snek/api/http/http_requests/threads.py
@@ -6,6 +6,9 @@ from dis_snek.client.const import MISSING, Absent
 from ..route import Route
 from dis_snek.client.utils.converters import timestamp_converter
 
+__all__ = ["ThreadRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/users.py
+++ b/dis_snek/api/http/http_requests/users.py
@@ -4,6 +4,9 @@ import discord_typings
 
 from ..route import Route
 
+__all__ = ["UserRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/api/http/http_requests/webhooks.py
+++ b/dis_snek/api/http/http_requests/webhooks.py
@@ -5,6 +5,9 @@ import discord_typings
 from ..route import Route
 from dis_snek.client.utils.serializer import dict_filter_none
 
+__all__ = ["WebhookRequests"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
 

--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -16,6 +16,9 @@ from dis_snek.models.discord.snowflake import to_snowflake, to_optional_snowflak
 from dis_snek.client.utils.attr_utils import define, field
 from dis_snek.client.utils.cache import TTLCache
 
+__all__ = ["GlobalCache", "create_cache"]
+
+
 if TYPE_CHECKING:
     from dis_snek.client import Snake
     from dis_snek.models.discord.channel import DM, TYPE_ALL_CHANNEL

--- a/dis_snek/models/discord/modal.py
+++ b/dis_snek/models/discord/modal.py
@@ -11,6 +11,8 @@ from dis_snek.models.snek.application_commands import CallbackTypes
 from dis_snek.models.discord.components import InteractiveComponent, ComponentTypes
 from dis_snek.client.utils.attr_utils import define, field, str_validator
 
+__all__ = ["InputText", "Modal", "ParagraphText", "ShortText", "TextStyles"]
+
 
 class TextStyles(IntEnum):
     SHORT = 1

--- a/dis_snek/models/snek/annotations/argument.py
+++ b/dis_snek/models/snek/annotations/argument.py
@@ -4,6 +4,9 @@ from dis_snek.client.utils.misc_utils import get_parameters
 from dis_snek.models.snek.context import Context, MessageContext
 from dis_snek.models.snek.scale import Scale
 
+__all__ = ["CMD_ARGS", "CMD_AUTHOR", "CMD_BODY", "CMD_CHANNEL", "define_annotation"]
+
+
 if TYPE_CHECKING:
     from dis_snek.models import Member, User, TYPE_MESSAGEABLE_CHANNEL
 

--- a/dis_snek/models/snek/annotations/slash.py
+++ b/dis_snek/models/snek/annotations/slash.py
@@ -4,6 +4,18 @@ import dis_snek.models as models
 
 from dis_snek.models.snek.application_commands import SlashCommandOption
 
+__all__ = [
+    "slash_attachment_option",
+    "slash_bool_option",
+    "slash_channel_option",
+    "slash_float_option",
+    "slash_int_option",
+    "slash_mentionable_option",
+    "slash_role_option",
+    "slash_str_option",
+    "slash_user_option",
+]
+
 
 if TYPE_CHECKING:
     from dis_snek.models.snek import SlashCommandChoice

--- a/tests/consts.py
+++ b/tests/consts.py
@@ -6,6 +6,8 @@ Because the library has a habit of mangling the data (_process_dict), these are 
 
 import discord_typings
 
+__all__ = ["SAMPLE_DM_DATA", "SAMPLE_GUILD_DATA", "SAMPLE_USER_DATA"]
+
 
 def SAMPLE_USER_DATA() -> discord_typings.UserData:
     return {

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,6 +6,8 @@ from dis_snek.models.discord.channel import DM, GuildText
 from dis_snek.models.discord.snowflake import to_snowflake
 from tests.consts import SAMPLE_DM_DATA, SAMPLE_GUILD_DATA, SAMPLE_USER_DATA
 
+__all__ = ["bot", "test_dm_channel", "test_get_user_from_dm", "test_guild_channel", "test_update_guild"]
+
 
 @pytest.fixture()
 def bot() -> Snake:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This might be breaking for Proxy, who was importing TYPE_CHECKING and Union from dis_snek 😉 

In all seriousness, we don't want to have things accidentally leaking through, especially with the excessive use of `import *` across the library.
This adds a new linter, and addresses all warnings produced by it.


## Changes
- Adds ci dependency to `flake8-dunder-all`
- Adds `__all__` methods to the 22 files that didn't have one.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
