### PR TITLE
feat: Allow cleaner syntax for slash command groups/subcommands creation

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -814,7 +814,7 @@ class Snake(
             self.listeners[listener.event] = []
         self.listeners[listener.event].append(listener)
 
-    def add_interaction(self, command: InteractionCommand) -> None:
+    def add_interaction(self, command: InteractionCommand) -> bool:
         """
         Add a slash command to the client.
 
@@ -826,9 +826,8 @@ class Snake(
             command.scopes = [self.debug_scope]
 
         # for SlashCommand objs without callback (like objects made to hold group info etc)
-        # it's not ideal, but we're due command framework rework soon(tm)
         if command.callback is None:
-            return
+            return False
 
         for scope in command.scopes:
             if scope not in self.interactions:
@@ -841,6 +840,8 @@ class Snake(
                 command.checks.append(command._permission_enforcer)  # noqa : w0212
 
             self.interactions[scope][command.resolved_name] = command
+
+        return True
 
     def add_message_command(self, command: MessageCommand) -> None:
         """

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -824,8 +824,13 @@ class Snake(
         """
         if self.debug_scope:
             command.scopes = [self.debug_scope]
-        for scope in command.scopes:
 
+        # for SlashCommand objs without callback (like objects made to hold group info etc)
+        # it's not ideal, but we're due command framework rework soon(tm)
+        if command.callback is None:
+            return
+
+        for scope in command.scopes:
             if scope not in self.interactions:
                 self.interactions[scope] = {}
             elif command.resolved_name in self.interactions[scope]:

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -378,23 +378,23 @@ class SlashCommand(InteractionCommand):
         return self.sub_cmd_name is not None
 
     def __attrs_post_init__(self) -> None:
-        params = get_parameters(self.callback)
-        for name, val in params.items():
-            annotation = None
-            if val.annotation and isinstance(val.annotation, SlashCommandOption):
-                annotation = val.annotation
-            elif typing.get_origin(val.annotation) is Annotated:
-                for ann in typing.get_args(val.annotation):
-                    if isinstance(ann, SlashCommandOption):
-                        annotation = ann
-
-            if annotation:
-                if not self.options:
-                    self.options = []
-                ann.name = name
-                self.options.append(ann)
-
         if self.callback is not None:
+            params = get_parameters(self.callback)
+            for name, val in params.items():
+                annotation = None
+                if val.annotation and isinstance(val.annotation, SlashCommandOption):
+                    annotation = val.annotation
+                elif typing.get_origin(val.annotation) is Annotated:
+                    for ann in typing.get_args(val.annotation):
+                        if isinstance(ann, SlashCommandOption):
+                            annotation = ann
+
+                if annotation:
+                    if not self.options:
+                        self.options = []
+                    ann.name = name
+                    self.options.append(ann)
+
             if hasattr(self.callback, "options"):
                 if not self.options:
                     self.options = []

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -466,29 +466,40 @@ class SlashCommand(InteractionCommand):
         option_name = option_name.lower()
         return wrapper
 
+    def group(self, name: str = None, description: str = "No Description Set") -> "SlashCommand":
+
+        return SlashCommand(
+            name=self.name,
+            description=self.description,
+            group_name=name,
+            group_description=description,
+            scopes=self.scopes,
+        )
+
     def subcommand(
         self,
         sub_cmd_name: str,
         group_name: str = None,
-        group_description: str = "No Description Set",
         sub_cmd_description: Absent[str] = MISSING,
+        group_description: Absent[str] = MISSING,
         options: List[Union[SlashCommandOption, Dict]] = None,
     ) -> Callable[..., "SlashCommand"]:
         def wrapper(call: Callable[..., Coroutine]) -> "SlashCommand":
+            nonlocal sub_cmd_description
+
             if not asyncio.iscoroutinefunction(call):
                 raise TypeError("Subcommand must be coroutine")
 
-            _description = sub_cmd_description
-            if _description is MISSING:
-                _description = call.__doc__ if call.__doc__ else "No Description Set"
+            if sub_cmd_description is MISSING:
+                sub_cmd_description = call.__doc__ or "No Description Set"
 
             return SlashCommand(
                 name=self.name,
                 description=self.description,
-                group_name=group_name,
-                group_description=group_description,
+                group_name=group_name or self.group_name,
+                group_description=group_description or self.group_description,
                 sub_cmd_name=sub_cmd_name,
-                sub_cmd_description=_description,
+                sub_cmd_description=sub_cmd_description,
                 options=options,
                 callback=call,
                 scopes=self.scopes,


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [X] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This PR will allow cleaner syntax for slash command groups/subcommands creation
I will advise to promote it as recommended syntax in our docs and tutorials
Syntax example:
```py
poll = dis_snek.SlashCommand(name="poll")
edit_poll = poll.group(name="edit")

@edit_poll.subcommand(sub_cmd_name="add_option")
async def command_callback(ctx):
    pass
```

## Changes
- Allowed (fixed)  to make direct standalone instances of SlashCommand objects
- Added SlashCommand.group method that makes new SlashCommand that contains information about slash command group
- [Snake.add_interaction](https://github.com/Discord-Snake-Pit/Dis-Snek/pull/400/commits/0810b90fc86d6ed3f96dbd14da32e4bcfd316c53) now ignores SlashCommand objects without callback set to fascillate creation of "dummy" SlashCommand objects that only contain information about base command or groups

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
