### PR TITLE
fix: Loop through Scale pre- and post-runs when executing

### DIFF
--- a/dis_snek/models/snek/command.py
+++ b/dis_snek/models/snek/command.py
@@ -96,7 +96,8 @@ class BaseCommand(DictSerializationMixin):
                     await self.pre_run_callback(context, *args, **kwargs)
 
                 if self.scale is not None and self.scale.scale_prerun:
-                    await self.scale.scale_prerun(context, *args, **kwargs)
+                    for prerun in self.scale.scale_prerun:
+                        await prerun(context, *args, **kwargs)
 
                 await self.call_callback(self.callback, context)
 
@@ -104,7 +105,8 @@ class BaseCommand(DictSerializationMixin):
                     await self.post_run_callback(context, *args, **kwargs)
 
                 if self.scale is not None and self.scale.scale_postrun:
-                    await self.scale.scale_postrun(context, *args, **kwargs)
+                    for postrun in self.scale.scale_postrun:
+                        await postrun(context, *args, **kwargs)
 
         except Exception as e:
             if self.error_callback:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Adding a Scale-level pre- or post-run callback causes the following error:
```py
Traceback (most recent call last):
  File ".../dis_snek/client/client.py", line 1301, in _dispatch_interaction
    await self._run_slash_command(command, ctx)
  File ".../dis_snek/client/client.py", line 1250, in _run_slash_command
    return await command(ctx, **ctx.kwargs)
  File ".../dis_snek/models/snek/command.py", line 107, in __call__
    await self.scale.scale_postrun(context, *args, **kwargs)
TypeError: 'list' object is not callable
```

This should iterate through the list and run each callback.


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Iterate through scale pre- and post-run callbacks and execute each one

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
