### PR TITLE
feat: add command to Contexts

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1310,20 +1310,19 @@ class Snake(
             if scope in self.interactions:
                 ctx = await self.get_context(interaction_data, True)
 
-                command: SlashCommand = self.interactions[scope][ctx.invoked_name]  # type: ignore
-                ctx.command = command
-                log.debug(f"{scope} :: {command.name} should be called")
+                ctx.command: SlashCommand = self.interactions[scope][ctx.invoked_name]  # type: ignore
+                log.debug(f"{scope} :: {ctx.command.name} should be called")
 
-                if command.auto_defer:
-                    auto_defer = command.auto_defer
-                elif command.scale and command.scale.auto_defer:
-                    auto_defer = command.scale.auto_defer
+                if ctx.command.auto_defer:
+                    auto_defer = ctx.command.auto_defer
+                elif ctx.command.scale and ctx.command.scale.auto_defer:
+                    auto_defer = ctx.command.scale.auto_defer
                 else:
                     auto_defer = self.auto_defer
 
                 if auto_opt := getattr(ctx, "focussed_option", None):
                     try:
-                        await command.autocomplete_callbacks[auto_opt](ctx, **ctx.kwargs)
+                        await ctx.command.autocomplete_callbacks[auto_opt](ctx, **ctx.kwargs)
                     except Exception as e:
                         await self.on_autocomplete_error(ctx, e)
                     finally:
@@ -1333,7 +1332,7 @@ class Snake(
                         await auto_defer(ctx)
                         if self.pre_run_callback:
                             await self.pre_run_callback(ctx, **ctx.kwargs)
-                        await self._run_slash_command(command, ctx)
+                        await self._run_slash_command(ctx.command, ctx)
                         if self.post_run_callback:
                             await self.post_run_callback(ctx, **ctx.kwargs)
                     except Exception as e:

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1311,6 +1311,7 @@ class Snake(
                 ctx = await self.get_context(interaction_data, True)
 
                 command: SlashCommand = self.interactions[scope][ctx.invoked_name]  # type: ignore
+                ctx.command = command
                 log.debug(f"{scope} :: {command.name} should be called")
 
                 if command.auto_defer:
@@ -1349,6 +1350,7 @@ class Snake(
 
             self.dispatch(events.Component(ctx))
             if callback := self._component_callbacks.get(ctx.custom_id):
+                ctx.command = callback
                 try:
                     if self.pre_run_callback:
                         await self.pre_run_callback(ctx)
@@ -1406,6 +1408,7 @@ class Snake(
 
                 if command and command.enabled:
                     context = await self.get_context(message)
+                    context.command = command
                     context.invoked_name = invoked_name
                     context.prefix = prefix_used
                     context.args = get_args(context.content_parameters)

--- a/dis_snek/models/snek/context.py
+++ b/dis_snek/models/snek/context.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from dis_snek.models.discord.role import Role
     from dis_snek.models.discord.modal import Modal
     from dis_snek.models.snek.active_voice_state import ActiveVoiceState
+    from dis_snek.models.snek.command import BaseCommand
 
 __all__ = [
     "Resolved",
@@ -105,6 +106,7 @@ class Context:
 
     _client: "Snake" = field(default=None)
     invoked_name: str = field(default=None, metadata=docs("The name of the command to be invoked"))
+    command: Optional["BaseCommand"] = field(default=None, metadata=docs("The command to be invoked"))
 
     args: List = field(factory=list, metadata=docs("The list of arguments to be passed to the command"))
     kwargs: Dict = field(factory=dict, metadata=docs("The list of keyword arguments to be passed"))


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
I'm sure this doesn't need too much explanation.

Basically, `Context` classes never used to have a `command` attribute or the like. They *did* have an `invoked_name` attribute, which allowed you to do some logic to get the command used based off of its name, but it isn't exactly the best solution out there.

Having `command` as an attribute would be both useful and nice, so this PR does that.


## Changes
- Added `command` as an attribute for the `Context` base class.
  - This is typehinted as `BaseCommand` just so that it works with all subclasses of `Context`. Each subclass could theoretically typehint `command` further if need be.
  - This is *also* typehinted as `Optional` as not all `Context`s *have* commands associated with them.
- Set the `command` attribute where possible.
  - This results in some funny places where the `command` attribute *seemingly* is assigned to the attribute... even though it's actually being assigned to a command due to how `dis-snek` works. See how `MESSAGE_COMPONENT`s are handled for what I mean. 


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
