### PR TITLE
ci: Run tests on each of the possible extras snek can be installed with

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,14 @@ jobs:
   pytest:
     name: runner / pytest tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        extras:
+          - .
+          - .[voice]
+          - .[all]
+          - .[docs]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -12,7 +20,7 @@ jobs:
           python-version: '3.10'
       - name: Install pytest
         run: |
-          pip install -e .[all]
+          pip install -e ${{ matrix.extras }}
           pip install pytest pytest-recording pytest-asyncio pytest-cov
       - name: Run Tests
         run: |


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [x] Tests change

## Description
As we saw a few days ago, it's possible to end up with import errors if new code is expecting dis-snek[all] but the user isn't.

This makes the pytest job use a matrix of each extra, and run our test suite on each mode.


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [ ] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
