### PR TITLE
feat: add Modal callbacks

### DIFF
--- a/dis_snek/models/snek/scale.py
+++ b/dis_snek/models/snek/scale.py
@@ -82,7 +82,9 @@ class Scale:
 
                 new_cls._commands.append(val)
 
-                if isinstance(val, snek.ComponentCommand):
+                if isinstance(val, snek.ModalCommand):
+                    bot.add_modal_callback(val)
+                elif isinstance(val, snek.ComponentCommand):
                     bot.add_component_callback(val)
                 elif isinstance(val, snek.InteractionCommand):
                     bot.add_interaction(val)
@@ -126,8 +128,13 @@ class Scale:
     def shed(self) -> None:
         """Called when this Scale is being removed."""
         for func in self._commands:
-            if isinstance(func, snek.ComponentCommand):
+            if isinstance(func, snek.ModalCommand):
                 for listener in func.listeners:
+                    # noinspection PyProtectedMember
+                    self.bot._modal_callbacks.pop(listener)
+            elif isinstance(func, snek.ComponentCommand):
+                for listener in func.listeners:
+                    # noinspection PyProtectedMember
                     self.bot._component_callbacks.pop(listener)
             elif isinstance(func, snek.InteractionCommand):
                 for scope in func.scopes:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Adds modal callbacks as requested by #391. 
Although modal callbacks and component callbacks are practically identical; in the interest of ux and extensibility, ive kept them seperate in this pr. I am aware this causes additional code-duplication; this will be resolved in a follow-up PR after this one is merged. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add modal callbacks and their affiliated functions in client + scales
- Seperate unpack_iterable into its own helper function for application commands


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
