### PR TITLE
feat:  Add mypy plugin.  This adds support for our custom attrs wrapper.

### DIFF
--- a/dis_snek/ext/mypy/__init__.py
+++ b/dis_snek/ext/mypy/__init__.py
@@ -1,0 +1,41 @@
+"""
+Mypy plugin.
+
+This is a simple plugin, that adds support for our custom attrs wrapper.
+
+To use it, add `dis_snek.ext.mypy` to the plugins list in your mypy config.
+
+For mypy.ini:
+```ini
+[mypy]
+plugins = dis_snek.ext.mypy
+```
+
+For pyproject.toml:
+```toml
+[tool.mypy]
+plugins = "dis_snek.ext.mypy"
+```
+"""
+from functools import partial
+from typing import Callable, Optional
+from mypy.plugin import Plugin, ClassDefContext
+from mypy.plugins import attrs
+
+__all__ = ["plugin"]
+
+
+class SnekPlugin(Plugin):
+    # This could be smarter, but it does the job.
+    def get_class_decorator_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
+        if fullname == "dis_snek.client.utils.attr_utils.define":
+            return partial(
+                attrs.attr_class_maker_callback,
+                auto_attribs_default=None,
+            )
+        return None
+
+
+def plugin(version: str) -> SnekPlugin:
+    # ignore version argument if the plugin works with all mypy versions.
+    return SnekPlugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,7 @@ line-length = 120
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+ignore_missing_imports = true
+plugins = "dis_snek.ext.mypy"


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
mypy detects the use of attrs by a hardcoded list of fullnames for each of attrs's decorators.

By wrapping `@attrs.define` with our own `@dis_snek.client.utils.attr_utils.define`, we effectively removed mypy support for our attrs classes.

This PR adds a simple mypy plugin that tells mypy that we're defining an attrs class when we use `dis_snek.client.utils.attr_utils.define`.

It is intentionally not imported by `dis_snek.ext`, as it should only ever be used by directly accessing it via a mypy configuration file.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
