### PR TITLE
feat: support multi-scale unloading

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1504,22 +1504,24 @@ class Snake(
     async def _disconnect(self) -> None:
         self._ready.clear()
 
-    def get_scale(self, name) -> Optional[Scale]:
+    def get_scale(self, name) -> list[Scale]:
         """
-        Get a scale.
+        Get all scales with a name or extension name.
 
         Args:
             name: The name of the scale, or the name of it's extension
 
         Returns:
-            Scale or None if no scale is found
+            List of Scales
         """
+        out = []
         if name not in self.scales.keys():
             for scale in self.scales.values():
                 if scale.extension_name == name:
-                    return scale
+                    out.append(scale)
+            return out
 
-        return self.scales.get(name, None)
+        return [self.scales.get(name, None)]
 
     def grow_scale(self, file_name: str, package: str = None, **load_kwargs) -> None:
         """
@@ -1622,7 +1624,7 @@ class Snake(
         except AttributeError:
             pass
 
-        if scale := self.get_scale(name):
+        for scale in self.get_scale(name):
             scale.shed(**unload_kwargs)
 
         del sys.modules[name]

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1545,7 +1545,7 @@ class Snake(
 
         """
         if scale := self.get_scales(scale_name):
-            return self.unload_extension(inspect.getmodule(scale).__name__, **unload_kwargs)
+            return self.unload_extension(inspect.getmodule(scale[0]).__name__, **unload_kwargs)
 
         raise ScaleLoadException(f"Unable to shed scale: No scale exists with name: `{scale_name}`")
 

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1504,7 +1504,7 @@ class Snake(
     async def _disconnect(self) -> None:
         self._ready.clear()
 
-    def get_scales(self, name) -> list[Scale]:
+    def get_scales(self, name: str) -> list[Scale]:
         """
         Get all scales with a name or extension name.
 
@@ -1522,6 +1522,20 @@ class Snake(
             return out
 
         return [self.scales.get(name, None)]
+
+    def get_scale(self, name: str) -> Scale | None:
+        """
+        Get a scale with a name or extension name.
+
+        Args:
+            name: The name of the scale, or the name of it's extension
+
+        Returns:
+            A scale, if found
+        """
+        if scales := self.get_scales(name):
+            return scales[0]
+        return None
 
     def grow_scale(self, file_name: str, package: str = None, **load_kwargs) -> None:
         """

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1504,7 +1504,7 @@ class Snake(
     async def _disconnect(self) -> None:
         self._ready.clear()
 
-    def get_scale(self, name) -> list[Scale]:
+    def get_scales(self, name) -> list[Scale]:
         """
         Get all scales with a name or extension name.
 
@@ -1544,7 +1544,7 @@ class Snake(
             unload_kwargs: The auto-filled mapping of the unload keyword arguments
 
         """
-        if scale := self.get_scale(scale_name):
+        if scale := self.get_scales(scale_name):
             return self.unload_extension(inspect.getmodule(scale).__name__, **unload_kwargs)
 
         raise ScaleLoadException(f"Unable to shed scale: No scale exists with name: `{scale_name}`")
@@ -1624,7 +1624,7 @@ class Snake(
         except AttributeError:
             pass
 
-        for scale in self.get_scale(name):
+        for scale in self.get_scales(name):
             scale.shed(**unload_kwargs)
 
         del sys.modules[name]


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
cc: https://canary.discord.com/channels/870046872864165888/964080046153281586/964085134934552627
Allows for multiple scales to be defined in one file and successfully unload them. IE

```python
from dis_snek import Scale, message_command


class ScaleOne(Scale):
    @message_command()
    async def scale_one_test(self, ctx):
        await ctx.send(ctx.invoked_name)


class ScaleTwo(Scale):
    @message_command()
    async def scale_two_test(self, ctx):
        await ctx.send(ctx.invoked_name)


def setup(bot):
    ScaleOne(bot)
    ScaleTwo(bot)
```
Previously, reloading the above extension would result in a duplicate command exception, this fixes that. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Added `Snake.get_scales` which returns a list of all matching scales
- `Snake.unload_extension` now handles the above, and sheds each scale

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
