### PR TITLE
feat💥: Localisation support

### DIFF
--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1065,17 +1065,18 @@ class Snake(
             found = set()  # this is a temporary hack to fix subcommand detection
             if scope in self.interactions:
                 for cmd in self.interactions[scope].values():
-                    cmd_data = remote_cmds.get(cmd.name, MISSING)
+                    cmd_name = str(cmd.name)
+                    cmd_data = remote_cmds.get(cmd_name, MISSING)
                     if cmd_data is MISSING:
-                        if cmd.name not in found:
+                        if cmd_name not in found:
                             if warn_missing:
                                 log.error(
-                                    f'Detected yet to sync slash command "/{cmd.name}" for scope '
+                                    f'Detected yet to sync slash command "/{cmd_name}" for scope '
                                     f"{'global' if scope == GLOBAL_SCOPE else scope}"
                                 )
                         continue
                     else:
-                        found.add(cmd.name)
+                        found.add(cmd_name)
                     self._interaction_scopes[str(cmd_data["id"])] = scope
                     cmd.cmd_id[scope] = int(cmd_data["id"])
 

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -487,7 +487,7 @@ class Snake(
         Override this to change error handling behavior
 
         """
-        await self.on_error(f"cmd /`{ctx.invoked_name}`", error, *args, **kwargs)
+        await self.on_error(f"cmd /`{ctx.invoke_target}`", error, *args, **kwargs)
         try:
             if isinstance(error, errors.CommandOnCooldown):
                 await ctx.send(
@@ -541,7 +541,7 @@ class Snake(
             symbol = "/"
         else:
             symbol = "?"  # likely custom context
-        log.info(f"Command Called: {symbol}{ctx.invoked_name} with {ctx.args = } | {ctx.kwargs = }")
+        log.info(f"Command Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     async def on_component_error(self, ctx: ComponentContext, error: Exception, *args, **kwargs) -> None:
         """
@@ -565,7 +565,7 @@ class Snake(
 
         """
         symbol = "¢"
-        log.info(f"Component Called: {symbol}{ctx.invoked_name} with {ctx.args = } | {ctx.kwargs = }")
+        log.info(f"Component Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     async def on_autocomplete_error(self, ctx: AutocompleteContext, error: Exception, *args, **kwargs) -> None:
         """
@@ -577,7 +577,7 @@ class Snake(
 
         """
         return await self.on_error(
-            f"Autocomplete Callback for /{ctx.invoked_name} - Option: {ctx.focussed_option}",
+            f"Autocomplete Callback for /{ctx.invoke_target} - Option: {ctx.focussed_option}",
             error,
             *args,
             **kwargs,
@@ -594,7 +594,7 @@ class Snake(
 
         """
         symbol = "$"
-        log.info(f"Autocomplete Called: {symbol}{ctx.invoked_name} with {ctx.args = } | {ctx.kwargs = }")
+        log.info(f"Autocomplete Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     @Listener.create()
     async def on_resume(self) -> None:
@@ -1119,7 +1119,7 @@ class Snake(
                         (v for v in remote_commands if int(v["id"]) == local_cmd.cmd_id.get(cmd_scope)), None
                     )
                     # get json representation of this command
-                    local_cmd_json = next((c for c in local_cmds_json[cmd_scope] if c["name"] == local_cmd.name))
+                    local_cmd_json = next((c for c in local_cmds_json[cmd_scope] if c["name"] == str(local_cmd.name)))
 
                     # this works by adding any command we *want* on Discord, to a payload, and synchronising that
                     # this allows us to delete unused commands, add new commands, or do nothing in 1 or less API calls
@@ -1372,7 +1372,7 @@ class Snake(
             if scope in self.interactions:
                 ctx = await self.get_context(interaction_data, True)
 
-                ctx.command: SlashCommand = self.interactions[scope][ctx.invoked_name]  # type: ignore
+                ctx.command: SlashCommand = self.interactions[scope][ctx.invoke_target]  # type: ignore
                 log.debug(f"{scope} :: {ctx.command.name} should be called")
 
                 if ctx.command.auto_defer:
@@ -1486,7 +1486,7 @@ class Snake(
                 if command and command.enabled:
                     context = await self.get_context(message)
                     context.command = command
-                    context.invoked_name = invoked_name
+                    context.invoke_target = invoked_name
                     context.prefix = prefix_used
                     context.args = get_args(context.content_parameters)
                     try:

--- a/dis_snek/client/const.py
+++ b/dis_snek/client/const.py
@@ -82,6 +82,7 @@ __repo_url__ = "https://github.com/Discord-Snake-Pit/Dis-Snek"
 __py_version__ = f"{_ver_info[0]}.{_ver_info[1]}"
 __api_version__ = 10
 logger_name = "dis.snek"
+default_locale = "english_us"
 kwarg_spam = False
 
 DISCORD_EPOCH = 1420070400000

--- a/dis_snek/client/utils/attr_utils.py
+++ b/dis_snek/client/utils/attr_utils.py
@@ -1,8 +1,10 @@
 import logging
 from functools import partial
-from typing import Any, Dict
+from typing import Any, Dict, Callable
 
 import attrs
+from attr import Attribute
+
 from dis_snek.client.const import MISSING, logger_name
 
 __all__ = ["define", "field", "docs", "str_validator"]
@@ -46,3 +48,29 @@ def str_validator(self, attribute: attrs.Attribute, value: Any) -> None:
             f"Value of {attribute.name} has been automatically converted to a string. Please use strings in future.\n"
             "Note: Discord will always return value as a string"
         )
+
+
+def attrs_validator(
+    validator: Callable, skip_fields: list[str] | None = None
+) -> Callable[[Any, list[Attribute]], list[Attribute]]:
+    """
+    Sets a validator to all fields of an attrs-dataclass.
+
+    Args:
+        validator: The validator to set
+        skip_fields: A list of fields to skip adding the validator to
+
+    Returns:
+        The new fields for the attrs class
+    """
+
+    def operation(_, attributes: list[Attribute]) -> list[Attribute]:
+        new_attrs = []
+        for attr in attributes:
+            if skip_fields and attr.name in skip_fields:
+                new_attrs.append(attr)
+            else:
+                new_attrs.append(attr.evolve(validator=validator))
+        return new_attrs
+
+    return operation

--- a/dis_snek/client/utils/attr_utils.pyi
+++ b/dis_snek/client/utils/attr_utils.pyi
@@ -1,6 +1,8 @@
-import attrs
 import logging
 from typing import Any, TypeVar, Callable, Tuple, Union
+
+import attrs
+from attr import Attribute
 
 # this took way too lonk to solve
 # but this solution is based on https://www.attrs.org/en/stable/extending.html
@@ -27,3 +29,6 @@ def field(**kwargs) -> Any: ...
 def define(**kwargs) -> Callable[[_T], _T]: ...
 def docs(doc_string: str) -> dict[str, str]: ...
 def str_validator(self, attribute: attrs.Attribute, value: Any) -> None: ...
+def attrs_validator(
+    validator: Callable, skip_fields: list[str] | None = None
+) -> Callable[[Any, list[Attribute]], list[Attribute]]: ...

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -56,6 +56,10 @@ __all__ = [
     "auto_defer",
     "application_commands_to_dict",
     "sync_needed",
+    "LocalisedName",
+    "LocalizedName",
+    "LocalizedDesc",
+    "LocalisedDesc",
 ]
 
 log = logging.getLogger(logger_name)

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -228,6 +228,9 @@ class InteractionCommand(BaseCommand):
         """A representation of this interaction's name."""
         return str(self.name)
 
+    def get_localised_name(self, locale: str) -> str:
+        return self.name.get_locale(locale)
+
     def get_cmd_id(self, scope: "Snowflake_Type") -> "Snowflake_Type":
         return self.cmd_id.get(scope, self.cmd_id.get(GLOBAL_SCOPE, None))
 
@@ -400,7 +403,18 @@ class SlashCommand(InteractionCommand):
 
     @property
     def resolved_name(self) -> str:
-        return f"{self.name}{f' {self.group_name}' if self.group_name else ''}{f' {self.sub_cmd_name}' if self.sub_cmd_name else ''}"
+        return (
+            f"{self.name}"
+            f"{f' {self.group_name}' if bool(self.group_name) else ''}"
+            f"{f' {self.sub_cmd_name}' if bool(self.sub_cmd_name) else ''}"
+        )
+
+    def get_localised_name(self, locale: str) -> str:
+        return (
+            f"{self.name.get_locale(locale)}"
+            f"{f' {self.group_name.get_locale(locale)}' if bool(self.group_name) else ''}"
+            f"{f' {self.sub_cmd_name.get_locale(locale)}' if bool(self.sub_cmd_name) else ''}"
+        )
 
     @property
     def is_subcommand(self) -> bool:

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -87,6 +87,10 @@ class LocalisedDesc(LocalisedField):
         return super().__repr__()
 
 
+LocalizedName = LocalisedName
+LocalizedDesc = LocalisedDesc
+
+
 class OptionTypes(IntEnum):
     """Option types supported by slash commands."""
 

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -81,12 +81,16 @@ def desc_validator(_: Any, attr: Attribute, value: str) -> None:
 
 @define(field_transformer=attrs_validator(name_validator, skip_fields=["default_locale"]))
 class LocalisedName(LocalisedField):
+    """A localisation object for names."""
+
     def __repr__(self) -> str:
         return super().__repr__()
 
 
 @define(field_transformer=attrs_validator(desc_validator, skip_fields=["default_locale"]))
 class LocalisedDesc(LocalisedField):
+    """A localisation object for descriptions."""
+
     def __repr__(self) -> str:
         return super().__repr__()
 

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -992,6 +992,9 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
                         or local_option["description"] != remote_option["description"]
                         or local_option["required"] != remote_option.get("required", False)
                         or local_option["autocomplete"] != remote_option.get("autocomplete", False)
+                        or local_option.get("name_localized", {}) != remote_option.get("name_localized", {})
+                        or local_option.get("description_localized", {})
+                        != remote_option.get("description_localized", {})
                         or local_option.get("choices", []) != remote_option.get("choices", [])
                     ):
                         return False
@@ -1020,6 +1023,8 @@ def sync_needed(local_cmd: dict, remote_cmd: Optional[dict] = None) -> bool:
         local_cmd["name"] != remote_cmd["name"]
         or local_cmd.get("description", "") != remote_cmd.get("description", "")
         or local_cmd["default_permission"] != remote_cmd["default_permission"]
+        or local_cmd.get("name_localized", {}) != remote_cmd.get("name_localized", {})
+        or local_cmd.get("description_localized", {}) != remote_cmd.get("description_localized", {})
     ):
         # basic comparison of attributes
         return True

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -6,11 +6,12 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, Annotated, Callable, Coroutine, Dict, List, Union, Optional, Any
 import typing
 
+import attrs
+from attr import Attribute
+
 import dis_snek.models.discord.channel as channel
 from dis_snek.client.const import (
     GLOBAL_SCOPE,
-    CONTEXT_MENU_NAME_LENGTH,
-    SLASH_OPTION_NAME_LENGTH,
     SLASH_CMD_NAME_LENGTH,
     SLASH_CMD_MAX_OPTIONS,
     SLASH_CMD_MAX_DESC_LENGTH,
@@ -19,7 +20,7 @@ from dis_snek.client.const import (
     Absent,
 )
 from dis_snek.client.mixins.serialization import DictSerializationMixin
-from dis_snek.client.utils.attr_utils import define, field, docs
+from dis_snek.client.utils.attr_utils import define, field, docs, attrs_validator
 from dis_snek.client.utils.misc_utils import get_parameters
 from dis_snek.client.utils.serializer import no_export_meta, export_converter
 from dis_snek.models.discord.enums import ChannelTypes, CommandTypes
@@ -28,6 +29,7 @@ from dis_snek.models.discord.snowflake import to_snowflake, to_snowflake_list
 from dis_snek.models.discord.user import BaseUser
 from dis_snek.models.snek.auto_defer import AutoDefer
 from dis_snek.models.snek.command import BaseCommand
+from dis_snek.models.snek.localisation import LocalisedField
 
 if TYPE_CHECKING:
     from dis_snek.models.discord.snowflake import Snowflake_Type
@@ -57,6 +59,32 @@ __all__ = [
 ]
 
 log = logging.getLogger(logger_name)
+
+
+def name_validator(_: Any, attr: Attribute, value: str) -> None:
+    if value:
+        if not re.match(rf"^[\w-]{{1,{SLASH_CMD_NAME_LENGTH}}}$", value) or value != value.lower():
+            raise ValueError(
+                f"Slash Command names must be lower case and match this regex: ^[\w-]{1, {SLASH_CMD_NAME_LENGTH} }$"  # noqa: W605
+            )
+
+
+def desc_validator(_: Any, attr: Attribute, value: str) -> None:
+    if value:
+        if not 1 <= len(value) <= SLASH_CMD_MAX_DESC_LENGTH:
+            raise ValueError(f"Description must be between 1 and {SLASH_CMD_MAX_DESC_LENGTH} characters long")
+
+
+@define(field_transformer=attrs_validator(name_validator, skip_fields=["default_locale"]))
+class LocalisedName(LocalisedField):
+    def __repr__(self) -> str:
+        return super().__repr__()
+
+
+@define(field_transformer=attrs_validator(desc_validator, skip_fields=["default_locale"]))
+class LocalisedDesc(LocalisedField):
+    def __repr__(self) -> str:
+        return super().__repr__()
 
 
 class OptionTypes(IntEnum):
@@ -161,7 +189,9 @@ class InteractionCommand(BaseCommand):
 
     """
 
-    name: str = field(metadata=docs("1-32 character name") | no_export_meta)
+    name: LocalisedName = field(
+        metadata=docs("1-32 character name") | no_export_meta, converter=LocalisedName.converter
+    )
     scopes: List["Snowflake_Type"] = field(
         default=[GLOBAL_SCOPE],
         converter=to_snowflake_list,
@@ -196,7 +226,7 @@ class InteractionCommand(BaseCommand):
     @property
     def resolved_name(self) -> str:
         """A representation of this interaction's name."""
-        return self.name
+        return str(self.name)
 
     def get_cmd_id(self, scope: "Snowflake_Type") -> "Snowflake_Type":
         return self.cmd_id.get(scope, self.cmd_id.get(GLOBAL_SCOPE, None))
@@ -236,13 +266,8 @@ class ContextMenu(InteractionCommand):
 
     """
 
-    name: str = field(metadata=docs("1-32 character name"))
+    name: LocalisedName = field(metadata=docs("1-32 character name"), converter=LocalisedName.converter)
     type: CommandTypes = field(metadata=docs("The type of command, defaults to 1 if not specified"))
-
-    @name.validator
-    def _name_validator(self, attribute: str, value: str) -> None:
-        if not 1 <= len(value) <= CONTEXT_MENU_NAME_LENGTH:
-            raise ValueError("Context Menu name attribute must be between 1 and 32 characters")
 
     @type.validator
     def _type_validator(self, attribute: str, value: int) -> None:
@@ -266,7 +291,7 @@ class SlashCommandChoice(DictSerializationMixin):
 
     """
 
-    name: str = field()
+    name: LocalisedField = field(converter=LocalisedField.converter)
     value: Union[str, int, float] = field()
 
 
@@ -287,27 +312,15 @@ class SlashCommandOption(DictSerializationMixin):
 
     """
 
-    name: str = field()
+    name: LocalisedName = field(converter=LocalisedName.converter)
     type: Union[OptionTypes, int] = field()
-    description: str = field(default="No Description Set")
+    description: LocalisedDesc = field(default="No Description Set", converter=LocalisedDesc.converter)
     required: bool = field(default=True)
     autocomplete: bool = field(default=False)
     choices: List[Union[SlashCommandChoice, Dict]] = field(factory=list)
     channel_types: Optional[list[Union[ChannelTypes, int]]] = field(default=None)
     min_value: Optional[float] = field(default=None)
     max_value: Optional[float] = field(default=None)
-
-    @name.validator
-    def _name_validator(self, attribute: str, value: str) -> None:
-        if not re.match(rf"^[\w-]{{1,{SLASH_CMD_NAME_LENGTH}}}$", value) or value != value.lower():
-            raise ValueError(
-                f"Options names must be lower case and match this regex: ^[\w-]{1, {SLASH_CMD_NAME_LENGTH} }$"  # noqa: W605
-            )
-
-    @description.validator
-    def _description_validator(self, attribute: str, value: str) -> None:
-        if not 1 <= len(value) <= SLASH_OPTION_NAME_LENGTH:
-            raise ValueError("Options must be between 1 and 100 characters long")
 
     @type.validator
     def _type_validator(self, attribute: str, value: int) -> None:
@@ -356,17 +369,31 @@ class SlashCommandOption(DictSerializationMixin):
                 if self.max_value < self.min_value:
                     raise ValueError("`min_value` needs to be <= than `max_value`")
 
+    def as_dict(self) -> dict:
+        data = attrs.asdict(self)
+        data["name"] = str(self.name)
+        data["description"] = str(self.description)
+
+        data["name_localizations"] = self.name.to_locale_dict()
+        data["description_localizations"] = self.description.to_locale_dict()
+
+        return data
+
 
 @define()
 class SlashCommand(InteractionCommand):
-    name: str = field()
-    description: str = field(default="No Description Set")
+    name: LocalisedName = field(converter=LocalisedName.converter)
+    description: LocalisedDesc = field(default="No Description Set", converter=LocalisedDesc.converter)
 
-    group_name: str = field(default=None, metadata=no_export_meta)
-    group_description: str = field(default="No Description Set", metadata=no_export_meta)
+    group_name: LocalisedName = field(default=None, metadata=no_export_meta, converter=LocalisedName.converter)
+    group_description: LocalisedDesc = field(
+        default="No Description Set", metadata=no_export_meta, converter=LocalisedDesc.converter
+    )
 
-    sub_cmd_name: str = field(default=None, metadata=no_export_meta)
-    sub_cmd_description: str = field(default="No Description Set", metadata=no_export_meta)
+    sub_cmd_name: LocalisedName = field(default=None, metadata=no_export_meta, converter=LocalisedName.converter)
+    sub_cmd_description: LocalisedDesc = field(
+        default="No Description Set", metadata=no_export_meta, converter=LocalisedDesc.converter
+    )
 
     options: List[Union[SlashCommandOption, Dict]] = field(factory=list)
     autocomplete_callbacks: dict = field(factory=dict, metadata=no_export_meta)
@@ -377,7 +404,7 @@ class SlashCommand(InteractionCommand):
 
     @property
     def is_subcommand(self) -> bool:
-        return self.sub_cmd_name is not None
+        return bool(self.sub_cmd_name)
 
     def __attrs_post_init__(self) -> None:
         if self.callback is not None:
@@ -408,29 +435,18 @@ class SlashCommand(InteractionCommand):
 
     def to_dict(self) -> dict:
         data = super().to_dict()
+
         if self.is_subcommand:
-            data["name"] = self.sub_cmd_name
-            data["description"] = self.sub_cmd_description
+            data["name"] = str(self.sub_cmd_name)
+            data["description"] = str(self.sub_cmd_description)
+            data["name_localizations"] = self.sub_cmd_name.to_locale_dict()
+            data["description_localizations"] = self.sub_cmd_description.to_locale_dict()
             data.pop("default_permission", None)
             data.pop("permissions", None)
+        else:
+            data["name_localizations"] = self.name.to_locale_dict()
+            data["description_localizations"] = self.description.to_locale_dict()
         return data
-
-    @name.validator
-    @group_name.validator
-    @sub_cmd_name.validator
-    def name_validator(self, attribute: str, value: str) -> None:
-        if value:
-            if not re.match(rf"^[\w-]{{1,{SLASH_CMD_NAME_LENGTH}}}$", value) or value != value.lower():
-                raise ValueError(
-                    f"Slash Command names must be lower case and match this regex: ^[\w-]{1, {SLASH_CMD_NAME_LENGTH} }$"  # noqa: W605
-                )
-
-    @description.validator
-    @group_description.validator
-    @sub_cmd_description.validator
-    def description_validator(self, attribute: str, value: str) -> None:
-        if not 1 <= len(value) <= SLASH_CMD_MAX_DESC_LENGTH:
-            raise ValueError(f"Description must be between 1 and {SLASH_CMD_MAX_DESC_LENGTH} characters long")
 
     @options.validator
     def options_validator(self, attribute: str, value: List) -> None:
@@ -480,10 +496,10 @@ class SlashCommand(InteractionCommand):
 
     def subcommand(
         self,
-        sub_cmd_name: str,
-        group_name: str = None,
-        sub_cmd_description: Absent[str] = MISSING,
-        group_description: Absent[str] = MISSING,
+        sub_cmd_name: LocalisedName | str,
+        group_name: LocalisedName | str = None,
+        sub_cmd_description: Absent[LocalisedDesc | str] = MISSING,
+        group_description: Absent[LocalisedDesc | str] = MISSING,
         options: List[Union[SlashCommandOption, Dict]] = None,
     ) -> Callable[..., "SlashCommand"]:
         def wrapper(call: Callable[..., Coroutine]) -> "SlashCommand":
@@ -546,17 +562,17 @@ def _unpack_helper(iterable: typing.Iterable[str]) -> list[str]:
 
 
 def slash_command(
-    name: str,
+    name: str | LocalisedName,
     *,
-    description: Absent[str] = MISSING,
+    description: Absent[str | LocalisedDesc] = MISSING,
     scopes: Absent[List["Snowflake_Type"]] = MISSING,
     options: Optional[List[Union[SlashCommandOption, Dict]]] = None,
     default_permission: bool = True,
     permissions: Optional[List[Union[Permission, Dict]]] = None,
-    sub_cmd_name: str = None,
-    group_name: str = None,
-    sub_cmd_description: str = "No Description Set",
-    group_description: str = "No Description Set",
+    sub_cmd_name: str | LocalisedName = None,
+    group_name: str | LocalisedName = None,
+    sub_cmd_description: str | LocalisedDesc = "No Description Set",
+    group_description: str | LocalisedDesc = "No Description Set",
 ) -> Callable[[Callable[..., Coroutine]], SlashCommand]:
     """
     A decorator to declare a coroutine as a slash command.
@@ -611,17 +627,17 @@ def slash_command(
 
 
 def subcommand(
-    base: str,
+    base: str | LocalisedName,
     *,
-    subcommand_group: Optional[str] = None,
-    name: Optional[str] = None,
-    description: Absent[str] = MISSING,
-    base_description: Optional[str] = None,
-    base_desc: Optional[str] = None,
+    subcommand_group: Optional[str | LocalisedName] = None,
+    name: Optional[str | LocalisedName] = None,
+    description: Absent[str | LocalisedDesc] = MISSING,
+    base_description: Optional[str | LocalisedDesc] = None,
+    base_desc: Optional[str | LocalisedDesc] = None,
     base_default_permission: bool = True,
     base_permissions: Optional[dict] = None,
-    subcommand_group_description: Optional[str] = None,
-    sub_group_desc: Optional[str] = None,
+    subcommand_group_description: Optional[str | LocalisedDesc] = None,
+    sub_group_desc: Optional[str | LocalisedDesc] = None,
     scopes: List["Snowflake_Type"] = None,
     options: List[dict] = None,
 ) -> Callable[[Coroutine], SlashCommand]:
@@ -674,7 +690,7 @@ def subcommand(
 
 
 def context_menu(
-    name: str,
+    name: str | LocalisedName,
     context_type: "CommandTypes",
     scopes: Absent[List["Snowflake_Type"]] = MISSING,
     default_permission: bool = True,
@@ -871,21 +887,25 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
                 perms = [s.to_dict() if not isinstance(s, dict) else s for s in subcommand.permissions]
                 perms_filtered = [dict(t) for t in {tuple(d.items()) for d in perms}]
                 output_data = {
-                    "name": subcommand.name,
-                    "description": subcommand.description,
+                    "name": str(subcommand.name),
+                    "description": str(subcommand.description),
                     "options": [],
                     "permissions": perms_filtered,
                     "default_permission": subcommand.default_permission,
+                    "name_localizations": subcommand.name.to_locale_dict(),
+                    "description_localizations": subcommand.description.to_locale_dict(),
                 }
-            if subcommand.group_name:
-                if subcommand.group_name not in groups:
-                    groups[subcommand.group_name] = {
-                        "name": subcommand.group_name,
-                        "description": subcommand.group_description,
+            if bool(subcommand.group_name):
+                if str(subcommand.group_name) not in groups:
+                    groups[str(subcommand.group_name)] = {
+                        "name": str(subcommand.group_name),
+                        "description": str(subcommand.group_description),
                         "type": int(OptionTypes.SUB_COMMAND_GROUP),
                         "options": [],
+                        "name_localizations": subcommand.group_name.to_locale_dict(),
+                        "description_localizations": subcommand.group_description.to_locale_dict(),
                     }
-                groups[subcommand.group_name]["options"].append(
+                groups[str(subcommand.group_name)]["options"].append(
                     subcommand.to_dict() | {"type": int(OptionTypes.SUB_COMMAND)}
                 )
             elif subcommand.is_subcommand:
@@ -911,14 +931,14 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
                 (
                     c.description
                     for c in cmd_list
-                    if c.description is not None and c.description != "No Description Set"
+                    if str(c.description) is not None and str(c.description) != "No Description Set"
                 ),
                 "No Description Set",
             )
 
-            if not all(c.description in (base_description, "No Description Set") for c in cmd_list):
+            if not all(str(c.description) in (str(base_description), "No Description Set") for c in cmd_list):
                 log.warning(
-                    f"Conflicting descriptions found in `{cmd_list[0].name}` subcommands; `{base_description}` will be used"
+                    f"Conflicting descriptions found in `{cmd_list[0].name}` subcommands; `{str(base_description)}` will be used"
                 )
             if not all(c.default_permission == cmd_list[0].default_permission for c in cmd_list):
                 raise ValueError(f"Conflicting `default_permission` values found in `{cmd_list[0].name}`")

--- a/dis_snek/models/snek/command.py
+++ b/dis_snek/models/snek/command.py
@@ -175,7 +175,7 @@ class BaseCommand(DictSerializationMixin):
                             args.append(await convert(c_args.pop(0)))
                         except IndexError:
                             raise ValueError(
-                                f"{context.invoked_name} expects {len([p for p in parameters.values() if p.default is p.empty])+len(callback.args)}"
+                                f"{context.invoke_target} expects {len([p for p in parameters.values() if p.default is p.empty]) + len(callback.args)}"
                                 f" arguments but received {len(context.args)} instead"
                             ) from None
                     else:

--- a/dis_snek/models/snek/localisation.py
+++ b/dis_snek/models/snek/localisation.py
@@ -8,6 +8,12 @@ __all__ = ("LocalisedField", "LocalizedField")
 
 @define(slots=False)
 class LocalisedField:
+    """
+    An object that enables support for localising fields.
+
+    Supported locales: https://discord.com/developers/docs/reference#locales
+    """
+
     default_locale: str = field(default=const.default_locale)
 
     bulgarian: str | None = field(default=None, metadata={"locale-code": "bg"})

--- a/dis_snek/models/snek/localisation.py
+++ b/dis_snek/models/snek/localisation.py
@@ -3,7 +3,7 @@ from functools import cached_property
 from dis_snek.client import const
 from dis_snek.client.utils import define, field
 
-__all__ = ("LocalisedField",)
+__all__ = ("LocalisedField", "LocalizedField")
 
 
 @define(slots=False)
@@ -115,3 +115,6 @@ class LocalisedField:
                     if val := getattr(self, attr.name):
                         data[attr.metadata["locale-code"]] = val
         return data
+
+
+LocalizedField = LocalisedField

--- a/dis_snek/models/snek/localisation.py
+++ b/dis_snek/models/snek/localisation.py
@@ -1,0 +1,71 @@
+from dis_snek.client import const
+from dis_snek.client.utils import define, field
+
+__all__ = ("LocalisedField",)
+
+
+@define()
+class LocalisedField:
+    default_locale: str = field(default=const.default_locale)
+
+    bulgarian: str | None = field(default=None, metadata={"locale-code": "bg"})
+    chinese_china: str | None = field(default=None, metadata={"locale-code": "zh-CN"})
+    chinese_taiwan: str | None = field(default=None, metadata={"locale-code": "zh-TW"})
+    croatian: str | None = field(default=None, metadata={"locale-code": "hr"})
+    czech: str | None = field(default=None, metadata={"locale-code": "cs"})
+    danish: str | None = field(default=None, metadata={"locale-code": "da"})
+    dutch: str | None = field(default=None, metadata={"locale-code": "nl"})
+    english_uk: str | None = field(default=None, metadata={"locale-code": "en-GB"})
+    english_us: str | None = field(default=None, metadata={"locale-code": "en-US"})
+    finnish: str | None = field(default=None, metadata={"locale-code": "fi"})
+    french: str | None = field(default=None, metadata={"locale-code": "fr"})
+    german: str | None = field(default=None, metadata={"locale-code": "de"})
+    greek: str | None = field(default=None, metadata={"locale-code": "el"})
+    hindi: str | None = field(default=None, metadata={"locale-code": "hi"})
+    hungarian: str | None = field(default=None, metadata={"locale-code": "hu"})
+    italian: str | None = field(default=None, metadata={"locale-code": "it"})
+    japanese: str | None = field(default=None, metadata={"locale-code": "ja"})
+    korean: str | None = field(default=None, metadata={"locale-code": "ko"})
+    lithuanian: str | None = field(default=None, metadata={"locale-code": "lt"})
+    norwegian: str | None = field(default=None, metadata={"locale-code": "no"})
+    polish: str | None = field(default=None, metadata={"locale-code": "pl"})
+    portuguese_brazilian: str | None = field(default=None, metadata={"locale-code": "pt-BR"})
+    romanian_romania: str | None = field(default=None, metadata={"locale-code": "ro"})
+    russian: str | None = field(default=None, metadata={"locale-code": "ru"})
+    spanish: str | None = field(default=None, metadata={"locale-code": "es-ES"})
+    swedish: str | None = field(default=None, metadata={"locale-code": "sv-SE"})
+    thai: str | None = field(default=None, metadata={"locale-code": "th"})
+    turkish: str | None = field(default=None, metadata={"locale-code": "tr"})
+    ukrainian: str | None = field(default=None, metadata={"locale-code": "uk"})
+    vietnamese: str | None = field(default=None, metadata={"locale-code": "vi"})
+
+    def __str__(self) -> str:
+        return getattr(self, self.default_locale)
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: default_locale={self.default_locale}, value='{self.__str__()}'>"
+
+    @classmethod
+    def converter(cls, value: str | None) -> "LocalisedField":
+        if isinstance(value, LocalisedField):
+            return value
+        obj = cls()
+        if value:
+            obj.__setattr__(obj.default_locale, str(value))
+
+        return obj
+
+    @default_locale.validator
+    def _default_locale_validator(self, _, value: str) -> None:
+        try:
+            getattr(self, value)
+        except AttributeError:
+            raise ValueError(f"`{value}` is not a supported default localisation") from None
+
+    def to_dict(self) -> dict:
+        data = {}
+        for attr in self.__attrs_attrs__:
+            if "locale-code" in attr.metadata:
+                if val := getattr(self, attr.name):
+                    data[attr.metadata["locale-code"]] = val
+        return data

--- a/dis_snek/models/snek/localisation.py
+++ b/dis_snek/models/snek/localisation.py
@@ -80,7 +80,7 @@ class LocalisedField:
             return val
         if attr := self._code_mapping.get(locale):
             # assume the locale is a code, and attempt to find an attribute with that code
-            if val := getattr(self, attr, self.default):
+            if val := getattr(self, attr, None):
                 # if the value isn't None, return
                 return val
 

--- a/dis_snek/models/snek/localisation.py
+++ b/dis_snek/models/snek/localisation.py
@@ -67,7 +67,7 @@ class LocalisedField:
 
     def get_locale(self, locale: str) -> str:
         """
-        Get the value for the specified locale.
+        Get the value for the specified locale. Supports locale-codes and locale names.
 
         Args:
             locale: The locale to fetch
@@ -75,10 +75,17 @@ class LocalisedField:
         Returns:
             The localised string, or the default value
         """
+        if val := getattr(self, locale, None):
+            # Attempt to retrieve an attribute with the specified locale
+            return val
         if attr := self._code_mapping.get(locale):
+            # assume the locale is a code, and attempt to find an attribute with that code
             if val := getattr(self, attr, self.default):
+                # if the value isn't None, return
                 return val
-        return getattr(self, locale, self.default)
+
+        # no value was found, return default
+        return self.default
 
     @classmethod
     def converter(cls, value: str | None) -> "LocalisedField":

--- a/dis_snek/models/snek/localisation.py
+++ b/dis_snek/models/snek/localisation.py
@@ -40,7 +40,10 @@ class LocalisedField:
     vietnamese: str | None = field(default=None, metadata={"locale-code": "vi"})
 
     def __str__(self) -> str:
-        return getattr(self, self.default_locale)
+        return str(getattr(self, self.default_locale))
+
+    def __bool__(self) -> bool:
+        return getattr(self, self.default_locale) is not None
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: default_locale={self.default_locale}, value='{self.__str__()}'>"
@@ -62,10 +65,14 @@ class LocalisedField:
         except AttributeError:
             raise ValueError(f"`{value}` is not a supported default localisation") from None
 
-    def to_dict(self) -> dict:
+    def as_dict(self) -> str:
+        return str(self)
+
+    def to_locale_dict(self) -> dict:
         data = {}
         for attr in self.__attrs_attrs__:
-            if "locale-code" in attr.metadata:
-                if val := getattr(self, attr.name):
-                    data[attr.metadata["locale-code"]] = val
+            if attr.name != self.default_locale:
+                if "locale-code" in attr.metadata:
+                    if val := getattr(self, attr.name):
+                        data[attr.metadata["locale-code"]] = val
         return data

--- a/docs/src/API Reference/models/Snek/index.md
+++ b/docs/src/API Reference/models/Snek/index.md
@@ -9,6 +9,7 @@
 - [Cooldowns](cooldowns)
 - [Iterator](iterator)
 - [Listeners](listener)
+- [Localisation](localisation)
 - [Scales](scale)
 - [Tasks](tasks.md)
 - [Waits](wait)

--- a/docs/src/API Reference/models/Snek/localisation.md
+++ b/docs/src/API Reference/models/Snek/localisation.md
@@ -1,0 +1,1 @@
+::: dis_snek.models.snek.localisation

--- a/docs/src/Guides/23 Localisation.md
+++ b/docs/src/Guides/23 Localisation.md
@@ -35,6 +35,8 @@ async def hello_cmd(ctx: dis_snek.InteractionContext):
     await ctx.send(f"{ctx.invoked_name} {ctx.author.display_name}")
 ```
 Simply by changing `"hello"` to `ctx.invoked_name` the command will always use whatever the user typed to greet them.
+If you want to know what locale the user is in, simply use `ctx.locale`.
+
 
 This will work for any object with a `name` or `description` field. Simply use `LocalisedDesc` instead for descriptions.
 For example, you can localise options, choices, and subcommands.

--- a/docs/src/Guides/23 Localisation.md
+++ b/docs/src/Guides/23 Localisation.md
@@ -1,0 +1,40 @@
+# Localising
+
+So your bot has grown, and now you need to ~~localize~~ localise your bot. Well thank god we support localisation then, huh?
+
+To clarify; localisation is a feature of application commands that discord offers,
+this means the same command will have different names and descriptions depending on the user's locale settings.
+
+# How its made:
+
+Let's take this nice and simple `hello` command
+```python
+import dis_snek
+
+@dis_snek.slash_command(name="hello")
+async def hello_cmd(ctx: dis_snek.InteractionContext):
+    await ctx.send(f"Hello {ctx.author.display_name}")
+```
+This command was immensely popular, and now we have some 🇫🇷 French users. Wouldn't it be nice if we could speak their language.
+```python
+import dis_snek
+from dis_snek import LocalisedName
+
+@dis_snek.slash_command(name=LocalisedName(english_us="hello", french="salut"))
+async def hello_cmd(ctx: dis_snek.InteractionContext):
+    await ctx.send(f"Hello {ctx.author.display_name}")
+```
+All we need to do is set the field to a `Localised` object, and dis-snek and discord wil handle the rest for you.
+For extra flavour lets make this command more dynamic.
+```python
+import dis_snek
+from dis_snek import LocalisedName
+
+@dis_snek.slash_command(name=LocalisedName(english_us="hello", french="salut"))
+async def hello_cmd(ctx: dis_snek.InteractionContext):
+    await ctx.send(f"{ctx.invoked_name} {ctx.author.display_name}")
+```
+Simply by changing `"hello"` to `ctx.invoked_name` the command will always use whatever the user typed to greet them.
+
+This will work for any object with a `name` or `description` field. Simply use `LocalisedDesc` instead for descriptions.
+For example, you can localise options, choices, and subcommands.


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Breaking in the event someone was performing operations on the name or description fields of app_cmds and their affiliated objects, or using `ctx.invoked_name` in a situation where localisation is not desirable.

Adds support for application command localisation. This is done by converting `name` and `description` fields into a subclass of a new object called `LocalisedField`.
These subclassed objects include all the validation that used to be done in a per-object basis. The syntax looks like this:

```python
@slash_command(name=LocalisedName(english_us="test_cmd", french="la_test_cmd", german="der_test_cmd"))
async def localised_test(ctx: InteractionContext):
    await ctx.send(f"{ctx.invoked_name} was invoked under {ctx.locale}")
````


Syntax for people who don't want to localise is unaffected. The below snippet will work as normal, however localised fields will be converted transparently from string to `LocalisedField`
```python
@slash_command(name="test_command")
async def normal(ctx: InteractionContext):
    await ctx.send(f"{ctx.invoked_name} was invoked under {ctx.locale}")
```

This PR also makes `ctx.invoked_name` localised: meaning it now returns the localised name of the application command. To handle use cases where the non-localised name was needed, `ctx.invoke_target` was added to handle that. This could have been done without being breaking, however the naming would not have made sense. Invoked name sounds like the command the user invoked, which was the original purpose.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `LocalisedField` in `models/snek/localisation.py`
- Add `LocalisedName` and `LocalisedDesc` in `models/snek/application_commands.py`
- Change all existing name/desc fields to use `LocalisedFields`
- Update syncing to support localisation

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code


