### PR TITLE
feat: Cache user status and activity

### DIFF
--- a/dis_snek/api/events/processors/user_events.py
+++ b/dis_snek/api/events/processors/user_events.py
@@ -57,7 +57,9 @@ class UserEvents(EventMixinTemplate):
         """
         g_id = to_snowflake(event.data["guild_id"])
         if user := self.cache.get_user(event.data["user"]["id"]):
-            status = Status[event.data["status"].upper()]
-            activities = Activity.from_list(event.data.get("activities"))
+            user.status = Status[event.data["status"].upper()]
+            user.activities = Activity.from_list(event.data.get("activities"))
 
-            self.dispatch(events.PresenceUpdate(user, status, activities, event.data.get("client_status", None), g_id))
+            self.dispatch(
+                events.PresenceUpdate(user, user.status, user.activities, event.data.get("client_status", None), g_id)
+            )

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -519,6 +519,17 @@ class Guild(BaseGuild):
         if self.chunked.is_set():
             self.chunked.clear()
 
+        if presences := chunk.get("presences"):
+            # combine the presence dict into the members dict
+            for presence in presences:
+                u_id = presence["user"]["id"]
+                # find the user this presence is for
+                member_index = next(
+                    (index for (index, d) in enumerate(chunk.get("members")) if d["user"]["id"] == u_id), None
+                )
+                del presence["user"]
+                chunk["members"][member_index]["user"] = chunk["members"][member_index]["user"] | presence
+
         if not self._chunk_cache:
             self._chunk_cache: List = chunk.get("members")
         else:

--- a/dis_snek/models/discord/user.py
+++ b/dis_snek/models/discord/user.py
@@ -6,13 +6,14 @@ from dis_snek.client.const import MISSING, logger_name, Absent
 from dis_snek.client.errors import HTTPException, TooManyChanges
 from dis_snek.client.mixins.send import SendMixin
 from dis_snek.client.utils.attr_utils import define, docs, field
-from dis_snek.client.utils.converters import list_converter
+from dis_snek.client.utils.converters import list_converter, optional
 from dis_snek.client.utils.converters import optional as optional_c
 from dis_snek.client.utils.converters import timestamp_converter
 from dis_snek.client.utils.serializer import to_image_data
+from dis_snek.models.discord.activity import Activity
 from dis_snek.models.discord.asset import Asset
 from dis_snek.models.discord.color import Color
-from dis_snek.models.discord.enums import Permissions, PremiumTypes, UserFlags
+from dis_snek.models.discord.enums import Permissions, PremiumTypes, UserFlags, Status
 from dis_snek.models.discord.file import UPLOADABLE_TYPE
 from dis_snek.models.discord.role import Role
 from dis_snek.models.discord.snowflake import Snowflake_Type
@@ -116,6 +117,10 @@ class User(BaseUser):
         converter=optional_c(Color),
         metadata=docs("The user's banner color"),
     )
+    activities: list[Activity] = field(
+        factory=list, converter=list_converter(optional(Activity)), metadata=docs("A list of activities the user is in")
+    )
+    status: Absent[Status] = field(default=MISSING, metadata=docs("The user's status"), converter=optional(Status))
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Snake") -> Dict[str, Any]:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Resolves #436 
Snek now caches user status/ activity updates in user objects. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `Status` and `activities` attributes to user object
- Combine guild-chunk presence and status payload with members payload
- presence-update events update user objects

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
