### PR TITLE
Fix: `VoiceChannel.voice_members` was not updating correctly

### DIFF
--- a/dis_snek/client/smart_cache.py
+++ b/dis_snek/client/smart_cache.py
@@ -740,12 +740,9 @@ class GlobalCache:
         old_state = self.get_voice_state(user_id)
         if old_state:
             # noinspection PyProtectedMember
-            # for some unholy reason, self.get_channel() seems to return a copy(), and does not update the cache after changing the obj
-            old_channel = self.channel_cache[old_state._channel_id]
-            # noinspection PyProtectedMember
-            if user_id in old_channel._voice_member_ids:
+            if user_id in old_state.channel._voice_member_ids:
                 # noinspection PyProtectedMember
-                old_channel._voice_member_ids.remove(user_id)
+                old_state.channel._voice_member_ids.remove(user_id)
 
         # check if the channel_id is None
         # if that is the case, the user disconnected, and we can delete them from the cache

--- a/dis_snek/models/discord/voice_state.py
+++ b/dis_snek/models/discord/voice_state.py
@@ -55,13 +55,22 @@ class VoiceState(ClientObject):
     @property
     def channel(self) -> "TYPE_VOICE_CHANNEL":
         """The channel the user is connected to."""
-        channel = self._client.cache.get_channel(self._channel_id)
+        channel: "TYPE_VOICE_CHANNEL" = self._client.cache.get_channel(self._channel_id)
 
         # make sure the member is showing up as a part of the channel
         # this is relevant for VoiceStateUpdate.before
+        # noinspection PyProtectedMember
         if self._member_id not in channel._voice_member_ids:
-            # create a copy and add the member to that list
+            # the list of voice members need to be deepcopied, otherwise the cached obj will be updated
+            # noinspection PyProtectedMember
+            voice_member_ids = copy.deepcopy(channel._voice_member_ids)
+
+            # create a copy of the obj
             channel = copy.copy(channel)
+            channel._voice_member_ids = voice_member_ids
+
+            # add the member to that list
+            # noinspection PyProtectedMember
             channel._voice_member_ids.append(self._member_id)
 
         return channel


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
`VoiceChannel.voice_members` was not updating correctly when people left a voice channel. The user was not correctly removed from their old voice channel. This was due to a copied list that needed to be deepcopied, as far as my tests could tell.

Test Code:

```py
@listen()
async def _event(event: VoiceStateUpdate):
    before = event.before.channel if event.before else None
    before_members = before.voice_members if before else None
    before_members_cache = event.bot.cache.get_channel(before.id).voice_members if before else None

    after = event.after.channel
    after_members = after.voice_members if after else None
    after_members_cache = event.bot.cache.get_channel(after.id).voice_members if after else None

    assert after_members == after_members_cache
    if before:
        assert before_members != before_members_cache
```


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- deecopy the `_voice_member_ids` instead of copying them
- remove some unnecessary code in place_voice_state_data - this was necessary before the cache rewrite polls did a while ago

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
