### PR TITLE
fix: guild.member_count accuracy

### DIFF
--- a/dis_snek/api/events/processors/member_events.py
+++ b/dis_snek/api/events/processors/member_events.py
@@ -20,12 +20,16 @@ class MemberEvents(EventMixinTemplate):
     async def _on_raw_guild_member_add(self, event: "RawGatewayEvent") -> None:
         g_id = event.data.pop("guild_id")
         member = self.cache.place_member_data(g_id, event.data)
+        guild = self.cache.get_guild(g_id)
+        guild.member_count += 1
         self.dispatch(events.MemberAdd(g_id, member))
 
     @Processor.define()
     async def _on_raw_guild_member_remove(self, event: "RawGatewayEvent") -> None:
         g_id = event.data.pop("guild_id")
         user = self.cache.place_user_data(event.data["user"])
+        guild = self.cache.get_guild(g_id)
+        guild.member_count -= 1
         self.dispatch(events.MemberRemove(g_id, self.cache.get_member(g_id, user.id) or user))
 
     @Processor.define()


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
`Guild.member_count` does not represent the current member count, but an approximation from when the guild was initialized during bot startup. This PR adds code to update the `Guild.member_count` when members join and leave

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Update `Guild.member_count` on `MemberEvent` processing

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code

## Screenshots
Current behaviour:
![image](https://user-images.githubusercontent.com/57541873/163837169-ed4cd4b7-377c-4713-b83f-e322b1b3ae75.png)
![image](https://user-images.githubusercontent.com/57541873/163837180-81448fda-53b4-41ba-b5fb-74edf37517b0.png)
