### PR TITLE
feat: Support async entrypoint for scales

### DIFF
--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -954,11 +954,12 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
 
     for _scope, cmds in commands.items():
         for cmd in cmds.values():
-            if cmd.name not in cmd_bases:
-                cmd_bases[cmd.name] = [cmd]
+            cmd_name = str(cmd.name)
+            if cmd_name not in cmd_bases:
+                cmd_bases[cmd_name] = [cmd]
                 continue
-            if cmd not in cmd_bases[cmd.name]:
-                cmd_bases[cmd.name].append(cmd)
+            if cmd not in cmd_bases[cmd_name]:
+                cmd_bases[cmd_name].append(cmd)
 
     for cmd_list in cmd_bases.values():
         if any(c.is_subcommand for c in cmd_list):

--- a/dis_snek/models/snek/scale.py
+++ b/dis_snek/models/snek/scale.py
@@ -104,6 +104,13 @@ class Scale:
 
         new_cls.extension_name = inspect.getmodule(new_cls).__name__
         new_cls.bot.scales[new_cls.name] = new_cls
+
+        if hasattr(new_cls, "async_start"):
+            if inspect.iscoroutinefunction(new_cls.async_start):
+                bot.async_startup_tasks.append(new_cls.async_start())
+            else:
+                raise TypeError("async_start is a reserved method and must be a coroutine")
+
         return new_cls
 
     @property


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR adds an async entrypoint to scales without modifying how scales are loaded.

Simply add a method to your scale called `async_start` and it will be called during the bot's initialisation. 

```python
from dis_snek import Scale


class AsyncScale(Scale):
    def __init__(self, bot):
        ...

    async def async_start(self):
        print("Hello from async-start!")
        print(self.bot)


def setup(bot):
    AsyncScale(bot)
```

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- add `Snake.async_startup_tasks`
- `asyncio.gather` startup tasks on `websocket_ready`
- Add check for `async_start` in scales


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
