### PR TITLE
fix: snowflake object comparison when str passed

### DIFF
--- a/dis_snek/models/discord/snowflake.py
+++ b/dis_snek/models/discord/snowflake.py
@@ -58,10 +58,8 @@ class SnowflakeObject:
 
     def __eq__(self, other: "SnowflakeObject") -> bool:
         if hasattr(other, "id"):
-            other_id = other.id
-        else:
-            other_id = other
-        return self.id == other_id
+            other = other.id
+        return self.id == other
 
     def __ne__(self, other: "SnowflakeObject") -> bool:
         return self.id != other.id

--- a/dis_snek/models/discord/snowflake.py
+++ b/dis_snek/models/discord/snowflake.py
@@ -57,7 +57,11 @@ class SnowflakeObject:
     id: int = field(repr=True, converter=to_snowflake, metadata={"docs": "Discord unique snowflake ID"})
 
     def __eq__(self, other: "SnowflakeObject") -> bool:
-        return self.id == other.id
+        if hasattr(other, "id"):
+            other_id = other.id
+        else:
+            other_id = other
+        return self.id == other_id
 
     def __ne__(self, other: "SnowflakeObject") -> bool:
         return self.id != other.id


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Fixes a bug with snowflake object comparison when someone attempts to compare a string against a snowflake object. This should be handled rather than raising a confusing error. 

Tested against the code posted by @deadkex in the discord - seems to work. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Check if object has an `id` attribute before comparing it

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
