### PR TITLE
feat 🔥: Handle unknown channel types without data-loss

### DIFF
--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -705,7 +705,7 @@ class WebhookMixin:
 class BaseChannel(DiscordObject):
     name: Optional[str] = field(repr=True, default=None)
     """The name of the channel (1-100 characters)"""
-    type: Union[ChannelTypes, int] = field(repr=True, converter=ChannelTypes)
+    type: Union[ChannelTypes, int] = field(repr=True, converter=ChannelTypes.converter)
     """The channel topic (0-1024 characters)"""
 
     @classmethod

--- a/dis_snek/models/discord/enums.py
+++ b/dis_snek/models/discord/enums.py
@@ -464,6 +464,20 @@ class ChannelTypes(IntEnum):
     GUILD_STAGE_VOICE = 13
     """Voice channel for hosting events with an audience"""
 
+    @classmethod
+    def converter(cls, value) -> "ChannelTypes":
+        """A converter to handle discord creating new channel types that the lib isn't aware of, without losing type info"""
+        try:
+            out = cls(value)
+            return out
+        except ValueError:
+            # construct a new enum item to represent this new unknown type - without losing the value
+            new = int.__new__(cls)
+            new._name_ = f"UNKNOWN-TYPE-{value}"
+            new._value_ = value
+
+            return cls._value2member_map_.setdefault(value, new)
+
     @property
     def guild(self) -> bool:
         """Whether this channel is a guild channel."""


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
### 🔥HOT FIX FOR BUG RAISED BY FORUM CHANNELS

This pr allows the library to handle unknown channel types without losing the channel type value. The library was *supposed* to be using `BaseChannel` for any `ChannelType` it didnt know, however due to the converter this wasnt working. This pr adds a `converter` classmethod to the ChannelType enum which will dynamically add an `unknown-type` item to the enum as needed. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add converter classmethod to `ChannelType` enum
- Use convert in channel objects


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
