### PR TITLE
feat💥: Add support for perms2.0 and retire support for perms1.0

### DIFF
--- a/dis_snek/api/http/http_requests/interactions.py
+++ b/dis_snek/api/http/http_requests/interactions.py
@@ -171,26 +171,6 @@ class InteractionRequests:
             data=permissions,
         )
 
-    async def batch_edit_application_command_permissions(
-        self, application_id: "Snowflake_Type", scope: "Snowflake_Type", data: List[dict]
-    ) -> List[discord_typings.ApplicationCommandPermissionsData]:
-        """
-        Edit multiple command permissions within a single scope.
-
-        Args:
-            application_id: the id of the application
-            scope: The scope this command is in
-            data: The permissions to be set
-
-        Returns:
-            array of GuildApplicationCommandPermissions objects
-
-        """
-        return await self.request(
-            Route("PUT", f"/applications/{application_id}/guilds/{scope}/commands/permissions"),
-            data=data,
-        )
-
     async def get_application_command_permissions(
         self, application_id: "Snowflake_Type", scope: "Snowflake_Type", cmd_id: "Snowflake_Type"
     ) -> List[discord_typings.ApplicationCommandPermissionsData]:

--- a/dis_snek/client/client.py
+++ b/dis_snek/client/client.py
@@ -1113,7 +1113,6 @@ class Snake(
             # if we're not deleting, just check the scopes we have cmds registered in
             cmd_scopes = list(set(self.interactions) | {GLOBAL_SCOPE})
 
-        guild_perms = {}
         local_cmds_json = application_commands_to_dict(self.interactions)
 
         async def sync_scope(cmd_scope) -> None:
@@ -1163,69 +1162,12 @@ class Snake(
                 else:
                     log.debug(f"{cmd_scope} is already up-to-date with {len(remote_commands)} commands.")
 
-                for local_cmd in self.interactions.get(cmd_scope, {}).values():
-
-                    if not local_cmd.permissions:
-                        continue
-                    for perm in local_cmd.permissions:
-                        if perm.guild_id == cmd_scope:
-                            if perm.guild_id not in guild_perms:
-                                guild_perms[perm.guild_id] = []
-                            payload = [perm.to_dict() for perm in local_cmd.permissions]
-                            perm_json = {
-                                "id": local_cmd.get_cmd_id(perm.guild_id),
-                                "permissions": [dict(tup) for tup in {tuple(d.items()) for d in payload}],
-                            }
-                            if perm_json not in guild_perms[perm.guild_id]:
-                                guild_perms[perm.guild_id].append(perm_json)
-
             except Forbidden as e:
                 raise InteractionMissingAccess(cmd_scope) from e
             except HTTPException as e:
                 self._raise_sync_exception(e, local_cmds_json, cmd_scope)
 
         await asyncio.gather(*[sync_scope(scope) for scope in cmd_scopes])
-
-        for perm_scope in guild_perms:
-            perms_to_sync = {}
-            for cmd in guild_perms[perm_scope]:
-                c = self.get_application_cmd_by_id(cmd["id"])
-
-                if len(cmd["permissions"]) > 10:
-                    log.error(
-                        f"Error in command `{c.name}`: Command has {len(cmd['permissions'])} permissions. Maximum is 10 per guild."
-                    )
-
-                try:
-                    remote_perms = await self.http.get_application_command_permissions(
-                        self.app.id, perm_scope, c.get_cmd_id(perm_scope)
-                    )
-                except HTTPException:
-                    remote_perms = {}
-                cmd_perms = [perm for perm in guild_perms[perm_scope] if perm["id"] == c.get_cmd_id(perm_scope)][0]
-                perms_to_sync[c.get_cmd_id(perm_scope)] = [
-                    perm for perm in cmd_perms["permissions"] if perm not in remote_perms.get("permissions", [])
-                ]
-
-            if perms_to_sync:
-                for cmd_id, cmd_perms in perms_to_sync.items():
-                    log.debug(f"Updating command {cmd_id} permissions in scope {perm_scope}")
-                    if cmd_perms:
-                        try:
-                            await self.http.edit_application_command_permissions(
-                                application_id=self.app.id,
-                                scope=perm_scope,
-                                cmd_id=cmd_id,
-                                permissions=perms_to_sync[cmd_id],
-                            )
-                        except Forbidden:
-                            log.error(
-                                f"Unable to sync permissions for guild `{perm_scope}` -- Ensure the bot was added to that guild with `application.commands` scope."
-                            )
-                        except HTTPException as e:
-                            self._raise_sync_exception(e, local_cmds_json, perm_scope)
-            else:
-                log.debug(f"Permissions in {perm_scope} are already up-to-date!")
 
         t = time.perf_counter() - s
         log.debug(f"Sync of {len(cmd_scopes)} scopes took {t} seconds")

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -194,8 +194,8 @@ class InteractionCommand(BaseCommand):
 
     Args:
         scope: Denotes whether its global or for specific guild.
-        default_permission: Is this command available to all users?
-        permissions: Map of guild id and its respective list of permissions to apply.
+        default_member_permissions: What permissions members need to have by default to use this command.
+        dm_permission: Should this command be available in DMs.
         cmd_id: The id of this command given by discord.
         callback: The coroutine to callback when this interaction is received.
 
@@ -209,14 +209,10 @@ class InteractionCommand(BaseCommand):
         converter=to_snowflake_list,
         metadata=docs("The scopes of this interaction. Global or guild ids") | no_export_meta,
     )
-
-    default_permission: bool = field(
-        default=True, metadata=docs("whether this command is enabled by default when the app is added to a guild")
+    default_member_permissions: bool = field(
+        default=True, metadata=docs("What permissions members need to have by default to use this command")
     )
-    permissions: Optional[List[Union[Permission, Dict]]] = field(
-        factory=dict, metadata=docs("The permissions of this interaction")
-    )
-
+    dm_permission: bool = field(default=True, metadata=docs("Whether this command is enabled in DMs"))
     cmd_id: Dict[str, "Snowflake_Type"] = field(
         factory=dict, metadata=docs("The unique IDs of this commands") | no_export_meta
     )  # scope: cmd_id
@@ -253,21 +249,8 @@ class InteractionCommand(BaseCommand):
     async def _permission_enforcer(self, ctx: "Context") -> bool:
         """A check that enforces Discord permissions."""
         # I wish this wasn't needed, but unfortunately Discord permissions cant be trusted to actually prevent usage
-        for perm in self.permissions or []:
-            if perm.type == PermissionTypes.ROLE:
-                if ctx.author.has_role(perm.id):
-                    if perm.permission is True:
-                        return True
-                    elif self.default_permission is True:
-                        return False
-
-            elif perm.type == PermissionTypes.USER:
-                if ctx.author.id == perm.id:
-                    if perm.permission is True:
-                        return True
-                    elif self.default_permission is True:
-                        return False
-        return self.default_permission
+        if self.dm_permission:
+            return ctx.guild is not None
 
 
 @define()
@@ -466,8 +449,6 @@ class SlashCommand(InteractionCommand):
                     self.options = []
                 self.options += self.callback.options
 
-            if hasattr(self.callback, "permissions"):
-                self.permissions = self.callback.permissions
         super().__attrs_post_init__()
 
     def to_dict(self) -> dict:
@@ -478,8 +459,8 @@ class SlashCommand(InteractionCommand):
             data["description"] = str(self.sub_cmd_description)
             data["name_localizations"] = self.sub_cmd_name.to_locale_dict()
             data["description_localizations"] = self.sub_cmd_description.to_locale_dict()
-            data.pop("default_permission", None)
-            data.pop("permissions", None)
+            data.pop("default_member_permissions", None)
+            data.pop("dm_permission", None)
         else:
             data["name_localizations"] = self.name.to_locale_dict()
             data["description_localizations"] = self.description.to_locale_dict()
@@ -605,8 +586,8 @@ def slash_command(
     description: Absent[str | LocalisedDesc] = MISSING,
     scopes: Absent[List["Snowflake_Type"]] = MISSING,
     options: Optional[List[Union[SlashCommandOption, Dict]]] = None,
-    default_permission: bool = True,
-    permissions: Optional[List[Union[Permission, Dict]]] = None,
+    default_member_permissions: bool = False,
+    dm_permission: bool = True,
     sub_cmd_name: str | LocalisedName = None,
     group_name: str | LocalisedName = None,
     sub_cmd_description: str | LocalisedDesc = "No Description Set",
@@ -623,10 +604,10 @@ def slash_command(
     Args:
         name: 1-32 character name of the command
         description: 1-100 character description of the command
-        scope: The scope this command exists within
+        scopes: The scope this command exists within
         options: The parameters for the command, max 25
-        default_permission: Whether the command is enabled by default when the app is added to a guild
-        permissions: The roles or users who can use this command
+        default_member_permissions: What permissions members need to have by default to use this command.
+        dm_permission: Should this command be available in DMs.
         sub_cmd_name: 1-32 character name of the subcommand
         sub_cmd_description: 1-100 character description of the subcommand
         group_name: 1-32 character name of the group
@@ -653,8 +634,8 @@ def slash_command(
             sub_cmd_description=sub_cmd_description,
             description=_description,
             scopes=scopes if scopes else [GLOBAL_SCOPE],
-            default_permission=default_permission,
-            permissions=permissions or {},
+            default_member_permissions=default_member_permissions,
+            dm_permission=dm_permission,
             callback=func,
             options=options,
         )
@@ -672,8 +653,8 @@ def subcommand(
     description: Absent[str | LocalisedDesc] = MISSING,
     base_description: Optional[str | LocalisedDesc] = None,
     base_desc: Optional[str | LocalisedDesc] = None,
-    base_default_permission: bool = True,
-    base_permissions: Optional[dict] = None,
+    base_default_member_permissions: bool = True,
+    base_dm_permission: bool = True,
     subcommand_group_description: Optional[str | LocalisedDesc] = None,
     sub_group_desc: Optional[str | LocalisedDesc] = None,
     scopes: List["Snowflake_Type"] = None,
@@ -689,8 +670,8 @@ def subcommand(
         description: The description of the subcommand
         base_description: The description of the base command
         base_desc: An alias of `base_description`
-        base_default_permission: If users have permission to run the command by default when no permissions have been set
-        base_permissions: Permissions of the command
+        base_default_member_permissions: What permissions members need to have by default to use this command.
+        base_dm_permission: Should this command be available in DMs.
         subcommand_group_description: Description of the subcommand group
         sub_group_desc: An alias for `subcommand_group_description`
         scopes: The scopes of which this command is available, defaults to GLOBAL_SCOPE
@@ -716,8 +697,8 @@ def subcommand(
             group_description=(subcommand_group_description or sub_group_desc) or "No Description Set",
             sub_cmd_name=name,
             sub_cmd_description=_description,
-            default_permission=base_default_permission,
-            permissions=base_permissions or {},
+            default_member_permissions=base_default_member_permissions,
+            dm_permission=base_dm_permission,
             scopes=scopes if scopes else [GLOBAL_SCOPE],
             callback=func,
             options=options,
@@ -731,8 +712,8 @@ def context_menu(
     name: str | LocalisedName,
     context_type: "CommandTypes",
     scopes: Absent[List["Snowflake_Type"]] = MISSING,
-    default_permission: bool = True,
-    permissions: Optional[List[Union[Permission, Dict]]] = None,
+    default_member_permissions: bool = False,
+    dm_permission: bool = True,
 ) -> Callable[[Coroutine], ContextMenu]:
     """
     A decorator to declare a coroutine as a Context Menu.
@@ -740,9 +721,9 @@ def context_menu(
     Args:
         name: 1-32 character name of the context menu
         context_type: The type of context menu
-        scope: The scope this command exists within
-        default_permission: Whether the menu is enabled by default when the app is added to a guild
-        permissions: The roles or users who can use this menu
+        scopes: The scope this command exists within
+        default_member_permissions: What permissions members need to have by default to use this command.
+        dm_permission: Should this command be available in DMs.
 
     Returns:
         ContextMenu object
@@ -753,19 +734,12 @@ def context_menu(
         if not asyncio.iscoroutinefunction(func):
             raise ValueError("Commands must be coroutines")
 
-        perm = permissions or {}
-        if hasattr(func, "permissions"):
-            if perm:
-                perm.update(func.permissions)
-            else:
-                perm = func.permissions
-
         cmd = ContextMenu(
             name=name,
             type=context_type,
             scopes=scopes if scopes else [GLOBAL_SCOPE],
-            default_permission=default_permission,
-            permissions=perm,
+            default_member_permissions=default_member_permissions,
+            dm_permission=dm_permission,
             callback=func,
         )
         return cmd
@@ -922,14 +896,12 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
         sub_cmds = []
         for subcommand in subcommands:
             if not output_data:
-                perms = [s.to_dict() if not isinstance(s, dict) else s for s in subcommand.permissions]
-                perms_filtered = [dict(t) for t in {tuple(d.items()) for d in perms}]
                 output_data = {
                     "name": str(subcommand.name),
                     "description": str(subcommand.description),
                     "options": [],
-                    "permissions": perms_filtered,
-                    "default_permission": subcommand.default_permission,
+                    "default_member_permissions": subcommand.default_member_permissions,
+                    "dm_permission": subcommand.dm_permission,
                     "name_localizations": subcommand.name.to_locale_dict(),
                     "description_localizations": subcommand.description.to_locale_dict(),
                 }
@@ -965,7 +937,6 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
         if any(c.is_subcommand for c in cmd_list):
             # validate all commands share required attributes
             scopes: list[Snowflake_Type] = list({s for c in cmd_list for s in c.scopes})
-            permissions: list = list({d for c in cmd_list for d in c.permissions})
             base_description = next(
                 (
                     c.description
@@ -979,12 +950,13 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
                 log.warning(
                     f"Conflicting descriptions found in `{cmd_list[0].name}` subcommands; `{str(base_description)}` will be used"
                 )
-            if not all(c.default_permission == cmd_list[0].default_permission for c in cmd_list):
-                raise ValueError(f"Conflicting `default_permission` values found in `{cmd_list[0].name}`")
+            if not all(c.default_member_permissions == cmd_list[0].default_member_permissions for c in cmd_list):
+                raise ValueError(f"Conflicting `default_member_permissions` values found in `{cmd_list[0].name}`")
+            if not all(c.dm_permission == cmd_list[0].dm_permission for c in cmd_list):
+                raise ValueError(f"Conflicting `dm_permission` values found in `{cmd_list[0].name}`")
 
             for cmd in cmd_list:
                 cmd.scopes = list(scopes)
-                cmd.permissions = permissions
                 cmd.description = base_description
             # end validation of attributes
             cmd_data = squash_subcommand(cmd_list)
@@ -1046,7 +1018,8 @@ def sync_needed(local_cmd: dict, remote_cmd: Optional[dict] = None) -> bool:
     if (
         local_cmd["name"] != remote_cmd["name"]
         or local_cmd.get("description", "") != remote_cmd.get("description", "")
-        or local_cmd["default_permission"] != remote_cmd["default_permission"]
+        or local_cmd["default_member_permissions"] != remote_cmd["default_member_permissions"]
+        or local_cmd["dm_permission"] != remote_cmd["dm_permission"]
         or local_cmd.get("name_localized", {}) != remote_cmd.get("name_localized", {})
         or local_cmd.get("description_localized", {}) != remote_cmd.get("description_localized", {})
     ):

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -894,7 +894,9 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
                     "name": str(subcommand.name),
                     "description": str(subcommand.description),
                     "options": [],
-                    "default_member_permissions": str(int(subcommand.default_member_permissions)),
+                    "default_member_permissions": str(int(subcommand.default_member_permissions))
+                    if subcommand.default_member_permissions
+                    else None,
                     "dm_permission": subcommand.dm_permission,
                     "name_localizations": subcommand.name.to_locale_dict(),
                     "description_localizations": subcommand.description.to_locale_dict(),

--- a/docs/src/Guides/03 Creating Commands.md
+++ b/docs/src/Guides/03 Creating Commands.md
@@ -404,11 +404,6 @@ There are a few pre-made checks for you to use, and you can simply create your o
 
     The check will be checked for every command in the extension.
 
-This example only allows the bot owner to execute a command.
-```py
-
-
-```
 
 
 ## I Don't Want To Define The Same Option Every Time

--- a/docs/src/Guides/03 Creating Commands.md
+++ b/docs/src/Guides/03 Creating Commands.md
@@ -301,9 +301,54 @@ You are in luck. There are currently four different ways to create interactions,
 
 ## I Don't Want My Friends Using My Commands
 
-!!! danger "Interaction Permissions"
-    Since a big overhaul to discord's permission system is coming, this page is currently missing. It will be populated when discord updates their permission system. To learn how to use permissions in the meantime, please visit their documentation [here](/API Reference/models/Snek/application_commands/#dis_snek.models.snek.application_commands.slash_permission).
+How rude.
 
+Anyway, this is somewhat possible with command permissions.
+While you cannot explicitly block / allow certain roles / members / channels to use your commands on the bot side, you can define default permissions which members need to have to use the command.
+
+However, these default permissions can be overwritten by server admins, so this system is not safe for stuff like owner only eval commands.
+This system is designed to limit access to admin commands after a bot is added to a server, before admins have a chance to customise the permissions they want.
+
+In this example, we will limit access to the command to members with the `MANAGE_EVENTS` and `MANAGE_THREADS` permissions.
+There are two ways to define permissions.
+
+=== ":one: Decorators"
+    ```py
+    @slash_command(name="my_command")
+    @slash_default_member_permission(Permissions.MANAGE_EVENTS)
+    @slash_default_member_permission(Permissions.MANAGE_THREADS)
+    async def my_command_function(ctx: InteractionContext):
+        ...
+    ```
+
+=== ":two: Function Definition"
+    ```py
+    @slash_command(
+        name="my_command",
+        default_member_permissions=Permissions.MANAGE_EVENTS | Permissions.MANAGE_THREADS,
+    )
+    async def my_command_function(ctx: InteractionContext):
+        ...
+    ```
+
+Multiple permissions are defined with the bitwise OR operator `|`.
+
+### Blocking Commands in DMs
+
+You can also block commands in DMs. To do that, just set `dm_permission` to false.
+
+```py
+@slash_command(
+    name="my_guild_only_command",
+    dm_permission=False,
+)
+async def my_command_function(ctx: InteractionContext):
+    ...
+```
+
+### Context Menus
+
+Both default permissions and DM blocking can be used the same way for context menus, since they are normal slash commands under the hood.
 
 ## I Don't Want To Define The Same Option Every Time
 

--- a/docs/src/Guides/03 Creating Commands.md
+++ b/docs/src/Guides/03 Creating Commands.md
@@ -309,6 +309,8 @@ While you cannot explicitly block / allow certain roles / members / channels to 
 However, these default permissions can be overwritten by server admins, so this system is not safe for stuff like owner only eval commands.
 This system is designed to limit access to admin commands after a bot is added to a server, before admins have a chance to customise the permissions they want.
 
+If you do not want admins to be able to overwrite your permissions, or the permissions are not flexible enough for you, you should use [checks][check-this-out].
+
 In this example, we will limit access to the command to members with the `MANAGE_EVENTS` and `MANAGE_THREADS` permissions.
 There are two ways to define permissions.
 
@@ -349,6 +351,65 @@ async def my_command_function(ctx: InteractionContext):
 ### Context Menus
 
 Both default permissions and DM blocking can be used the same way for context menus, since they are normal slash commands under the hood.
+
+### Check This Out
+
+Checks allow you to define who can use your commands however you want.
+
+There are a few pre-made checks for you to use, and you can simply create your own custom checks.
+
+=== "Build-In Check"
+    Check that the author is the owner of the bot:  
+
+    ```py
+    @is_owner()
+    @slash_command(name="my_command")
+    async def my_command_function(ctx: InteractionContext):
+        ...
+    ```
+
+=== "Custom Check"
+    Check that the author's name starts with `a`:  
+
+    ```py
+    async def my_check(ctx: Context):
+        return ctx.author.name.startswith("a")
+
+    @check(check=my_check)
+    @slash_command(name="my_command")
+    async def my_command_function(ctx: InteractionContext):
+        ...
+    ```
+
+=== "Reusing Checks"
+    You can reuse checks in extensions by adding them to the extension check list
+
+    ```py
+    class MyExtension(Scale):
+        def __init__(self, bot) -> None:
+            super().__init__(bot)
+            self.add_scale_check(is_owner())
+
+    @slash_command(name="my_command")
+    async def my_command_function(ctx: InteractionContext):
+        ...
+
+    @slash_command(name="my_command2")
+    async def my_command_function2(ctx: InteractionContext):
+        ...
+
+    def setup(bot) -> None:
+        MyExtension(bot)
+    ```
+
+    The check will be checked for every command in the extension.
+
+This example only allows the bot owner to execute a command.
+```py
+
+
+```
+
 
 ## I Don't Want To Define The Same Option Every Time
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [x] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR adds support for the permission 2.0 system and retires support for the old system. Testing would be greatly appreciated.

Note for testing: Since discord does not display the default permissions data anywhere I could find (_sigh_), you basically need to inspect the data they send in the synching logic.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- BREAKING: remove `default_permission` attribute
- BREAKING: remove `permissions` attribute
- BREAKING: remove `Permission` class
- BREAKING: remove `PermissionTypes` class
- BREAKING: remove `slash_permission` decorator
- remove client side permissions checks since admins can overwrite the default perms
- add `default_member_permissions` attribute
- add `dm_permission` attribute
- add `slash_default_member_permission` decorator	
- add docs for perms and checks

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
