### PR TITLE
fix💥: GuildStageVoice no longer inherits from GuildVoice

### DIFF
--- a/dis_snek/models/discord/channel.py
+++ b/dis_snek/models/discord/channel.py
@@ -1937,7 +1937,7 @@ class GuildVoice(VoiceChannel, InvitableMixin, MessageableMixin):
 
 
 @define()
-class GuildStageVoice(GuildVoice):
+class GuildStageVoice(VoiceChannel, InvitableMixin):
     stage_instance: "models.StageInstance" = field(default=MISSING)
     """The stage instance that this voice channel belongs to"""
 


### PR DESCRIPTION
## What type of pull request is this?
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Breaking as it will break any checks that were relying on said inheritance. 
`GuildVoice` supports messages, `GuildStageVoice` should not, as such the inheritance should be removed. 

## Changes
- `GuildStageVoice` now only inherits from `VoiceChannel` and `InvitableMixin`

## Checklist
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
