### PR TITLE
feat: add VoiceChannelConverter

### DIFF
--- a/dis_snek/models/snek/converters.py
+++ b/dis_snek/models/snek/converters.py
@@ -23,6 +23,7 @@ from dis_snek.models.discord.channel import (
     GuildNewsThread,
     GuildPublicThread,
     GuildPrivateThread,
+    VoiceChannel,
     GuildVoice,
     GuildStageVoice,
     TYPE_ALL_CHANNEL,
@@ -56,6 +57,7 @@ __all__ = (
     "GuildNewsThreadConverter",
     "GuildPublicThreadConverter",
     "GuildPrivateThreadConverter",
+    "VoiceChannelConverter",
     "GuildVoiceConverter",
     "GuildStageVoiceConverter",
     "MessageableChannelConverter",
@@ -237,6 +239,11 @@ class GuildPublicThreadConverter(ChannelConverter[GuildPublicThread]):
 class GuildPrivateThreadConverter(ChannelConverter[GuildPrivateThread]):
     def _check(self, result: BaseChannel) -> bool:
         return isinstance(result, GuildPrivateThread)
+
+
+class VoiceChannelConverter(ChannelConverter[VoiceChannel]):
+    def _check(self, result: BaseChannel) -> bool:
+        return isinstance(result, VoiceChannel)
 
 
 class GuildVoiceConverter(ChannelConverter[GuildVoice]):
@@ -577,13 +584,14 @@ SNEK_MODEL_TO_CONVERTER: dict[type, type[Converter]] = {
     GuildNewsThread: GuildNewsThreadConverter,
     GuildPublicThread: GuildPublicThreadConverter,
     GuildPrivateThread: GuildPrivateThreadConverter,
+    VoiceChannel: VoiceChannelConverter,
     GuildVoice: GuildVoiceConverter,
     GuildStageVoice: GuildStageVoiceConverter,
     TYPE_ALL_CHANNEL: BaseChannelConverter,
     TYPE_DM_CHANNEL: DMChannelConverter,
     TYPE_GUILD_CHANNEL: GuildChannelConverter,
     TYPE_THREAD_CHANNEL: ThreadChannelConverter,
-    TYPE_VOICE_CHANNEL: GuildVoiceConverter,
+    TYPE_VOICE_CHANNEL: VoiceChannelConverter,
     TYPE_MESSAGEABLE_CHANNEL: MessageableChannelConverter,
     User: UserConverter,
     Member: MemberConverter,

--- a/docs/src/Guides/08 Converters.md
+++ b/docs/src/Guides/08 Converters.md
@@ -99,7 +99,8 @@ A table of objects and their respective converter is as follows:
 | `GuildNewsThread`                      | `GuildNewsThreadConverter`    |
 | `GuildPublicThread`                    | `GuildPublicThreadConverter`  |
 | `GuildPrivateThread`                   | `GuildPrivateThreadConverter` |
-| `GuildVoice`, `TYPE_VOICE_CHANNEL`     | `GuildVoiceConverter`         |
+| `VoiceChannel`, `TYPE_VOICE_CHANNEL`   | `VoiceChannelConverter`       |
+| `GuildVoice`                           | `GuildVoiceConverter`         |
 | `GuildStageVoice`                      | `GuildStageVoiceConverter`    |
 | `TYPE_MESSAGEABLE_CHANNEL`             | `MessageableChannelConverter` |
 | `User`                                 | `UserConverter`               |


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition
- [ ] Tests change

## Description
There was a recent change that made `GuildStageVoice` not inherit from `GuildVoice`, *technically* breaking the `TYPE_VOICE_CHANNEL` > converter mapping, as it would ignore `GuildStageVoice` channels.

The easiest solution was just to add a converter for `VoiceChannel`, which is soon to be exposed in the `__all__` anyways... so here we are!


## Changes

- Add `VoiceChannelConverter` and map it in `SNEK_MODEL_TO_CONVERTER`.
- Map `TYPE_VOICE_CHANNEL` to the new converter.
- Update the converter guide to reflect the changes.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
