### PR TITLE
feat: Add support for application cmds attrib of audit log

### DIFF
--- a/dis_snek/client/utils/deserialise_app_cmds.py
+++ b/dis_snek/client/utils/deserialise_app_cmds.py
@@ -1,0 +1,108 @@
+from typing import TYPE_CHECKING
+
+import dis_snek.client.const as const
+import dis_snek.models as models
+from dis_snek.models.discord.enums import CommandTypes
+
+if TYPE_CHECKING:
+    from dis_snek import InteractionCommand, SlashCommand, SlashCommandOption
+
+__all__ = ("deserialize_app_cmds",)
+
+
+def deserialize_app_cmds(data: list[dict]) -> list["InteractionCommand"]:
+    """
+    Deserializes the application_commands field of the audit log.
+
+    Args:
+        data: The application commands data
+
+    Returns:
+        A list of interaction command objects
+    """
+    out = []
+    command_mapping = {
+        CommandTypes.CHAT_INPUT: models.snek.SlashCommand,
+        CommandTypes.USER: models.snek.ContextMenu,
+        CommandTypes.MESSAGE: models.snek.ContextMenu,
+    }
+
+    for cmd_dict in data:
+        options = cmd_dict.pop("options", [])
+        cmd_type = cmd_dict["type"]
+
+        if cmd_type == CommandTypes.CHAT_INPUT:
+            del cmd_dict["type"]
+        else:
+            del cmd_dict["description"]
+
+        cmd_dict["cmd_id"] = cmd_dict.pop("id")
+        cmd_dict["scopes"] = [cmd_dict.pop("guild_id", const.GLOBAL_SCOPE)]
+
+        del cmd_dict["version"]
+        del cmd_dict["default_permission"]
+        cmd = command_mapping[cmd_type](**cmd_dict)  # type: ignore
+
+        if options:
+            if subcommands := deserialize_subcommands(cmd, options):
+                out += subcommands
+                continue
+            cmd.options = deserialize_options(options)
+
+        out.append(cmd)
+    return out
+
+
+def deserialize_subcommands(
+    base_cmd: "SlashCommand", options: list[dict], parent_group: dict | None = None
+) -> list["SlashCommand"]:
+    """
+    Deserializes subcommands.
+
+    Args:
+        base_cmd: The subcommands base command
+        options: The options from the parent
+        parent_group: The parent group, if any
+
+    Returns:
+        A list of slashcommand (subcommand) objects
+    """
+    out = []
+    for opt in options:
+        if opt["type"] == models.snek.OptionTypes.SUB_COMMAND_GROUP:
+            out += deserialize_subcommands(
+                base_cmd, opt["options"], {"name": opt["name"], "description": opt["description"]}
+            )
+        elif opt["type"] == models.snek.OptionTypes.SUB_COMMAND:
+            out.append(
+                models.snek.SlashCommand(
+                    name=base_cmd.name,
+                    description=base_cmd.description,
+                    group_name=parent_group["name"] if parent_group else None,
+                    group_description=parent_group["description"] if parent_group else None,
+                    options=deserialize_options(opt.get("options", [])),
+                    sub_cmd_name=opt["name"],
+                    sub_cmd_description=opt["description"],
+                    default_member_permissions=base_cmd.default_member_permissions,
+                    dm_permission=base_cmd.dm_permission,
+                    scopes=base_cmd.scopes,
+                )
+            )
+    return out
+
+
+def deserialize_options(options: list[dict]) -> list["SlashCommandOption"]:
+    """
+    Deserializes the options of a slash command
+
+    Args:
+        options: The list of options provided by discord
+
+    Returns:
+        list of SlashCommandOption objects
+    """
+    return [
+        models.snek.SlashCommandOption(**opt)
+        for opt in options
+        if opt["type"] not in (models.snek.OptionTypes.SUB_COMMAND_GROUP, models.snek.OptionTypes.SUB_COMMAND)
+    ]

--- a/dis_snek/models/discord/guild.py
+++ b/dis_snek/models/discord/guild.py
@@ -1,20 +1,22 @@
 import asyncio
-from collections import namedtuple
 import logging
 import time
+from collections import namedtuple
 from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
-from dis_snek.models.discord.file import UPLOADABLE_TYPE
-from dis_snek.models.misc.iterator import AsyncIterator
+
 from aiohttp import FormData
 
 import dis_snek.models as models
 from dis_snek.client.const import MISSING, PREMIUM_GUILD_LIMITS, logger_name, Absent
 from dis_snek.client.errors import EventLocationNotProvided, NotFound
 from dis_snek.client.mixins.serialization import DictSerializationMixin
-from dis_snek.client.utils.attr_utils import define, field, docs
 from dis_snek.client.utils.attr_converters import optional
 from dis_snek.client.utils.attr_converters import timestamp_converter
+from dis_snek.client.utils.attr_utils import define, field, docs
+from dis_snek.client.utils.deserialise_app_cmds import deserialize_app_cmds
 from dis_snek.client.utils.serializer import to_image_data, no_export_meta
+from dis_snek.models.discord.file import UPLOADABLE_TYPE
+from dis_snek.models.misc.iterator import AsyncIterator
 from .base import DiscordObject, ClientObject
 from .enums import (
     NSFWLevels,
@@ -34,6 +36,7 @@ from .snowflake import to_snowflake, Snowflake_Type, to_optional_snowflake, to_s
 
 if TYPE_CHECKING:
     from dis_snek.client.client import Snake
+    from dis_snek import InteractionCommand
 
 __all__ = [
     "GuildBan",
@@ -1906,6 +1909,8 @@ class AuditLogEntry(DiscordObject):
 class AuditLog(ClientObject):
     """Contains entries and other data given from selected"""
 
+    application_commands: list["InteractionCommand"] = field(factory=list, converter=optional(deserialize_app_cmds))
+    """list of application commands that have had their permissions updated"""
     entries: Optional[List["AuditLogEntry"]] = field(default=MISSING)
     """list of audit log entries"""
     scheduled_events: Optional[List["models.ScheduledEvent"]] = field(default=MISSING)

--- a/dis_snek/models/snek/application_commands.py
+++ b/dis_snek/models/snek/application_commands.py
@@ -2,9 +2,9 @@ import asyncio
 import inspect
 import logging
 import re
+import typing
 from enum import IntEnum
 from typing import TYPE_CHECKING, Annotated, Callable, Coroutine, Dict, List, Union, Optional, Any
-import typing
 
 import attrs
 from attr import Attribute
@@ -20,12 +20,13 @@ from dis_snek.client.const import (
     Absent,
 )
 from dis_snek.client.mixins.serialization import DictSerializationMixin
+from dis_snek.client.utils import optional
 from dis_snek.client.utils.attr_utils import define, field, docs, attrs_validator
 from dis_snek.client.utils.misc_utils import get_parameters
 from dis_snek.client.utils.serializer import no_export_meta
 from dis_snek.models.discord.enums import ChannelTypes, CommandTypes, Permissions
 from dis_snek.models.discord.role import Role
-from dis_snek.models.discord.snowflake import to_snowflake_list
+from dis_snek.models.discord.snowflake import to_snowflake_list, to_snowflake
 from dis_snek.models.discord.user import BaseUser
 from dis_snek.models.snek.auto_defer import AutoDefer
 from dis_snek.models.snek.command import BaseCommand
@@ -188,6 +189,7 @@ class InteractionCommand(BaseCommand):
         default=MISSING,
         metadata=docs("A system to automatically defer this command after a set duration") | no_export_meta,
     )
+    _application_id: "Snowflake_Type" = field(default=None, converter=optional(to_snowflake))
 
     def __attrs_post_init__(self) -> None:
         if self.callback is not None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Adds support for the `application_commands` attribute of the audit log. This attribute seemingly holds any commands of which have been updated by a guild member. 

This PR does this by deserialising the incoming json data into `InteractionCommand` objects, and stores them as a list. This supports `SlashCommands` `Subcommands` and `ContextMenus`

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add support for application commands attrib
- Add `client/utils/deserialise_app_cmds.py`
- Add missing `_application_id` field to `InteractionCommand` (seems useful to have)

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
