### PR TITLE
fix: Don't crash if someone compares a PartialEmoji against other types

### DIFF
--- a/dis_snek/models/discord/emoji.py
+++ b/dis_snek/models/discord/emoji.py
@@ -71,6 +71,8 @@ class PartialEmoji(SnowflakeObject, DictSerializationMixin):
         return s
 
     def __eq__(self, other) -> bool:
+        if not isinstance(other, PartialEmoji):
+            return False
         if self.id:
             return self.id == other.id
         return self.name == other.name

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -2,10 +2,11 @@ from dis_snek.models.discord.emoji import PartialEmoji
 
 __all__ = ()
 
+
 def test_emoji_comparisons() -> None:
     thumbs_emoji = "👍"
     custom_emoji = "<:sparklesnek:910496037708374016>"
-    
+
     e = PartialEmoji.from_str(thumbs_emoji)
     assert not e == thumbs_emoji
     assert e.name == thumbs_emoji
@@ -14,4 +15,3 @@ def test_emoji_comparisons() -> None:
     assert not e == custom_emoji
     assert e.name == "sparklesnek"
     assert e.id == 910496037708374016
-

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -1,0 +1,17 @@
+from dis_snek.models.discord.emoji import PartialEmoji
+
+__all__ = ()
+
+def test_emoji_comparisons() -> None:
+    thumbs_emoji = "👍"
+    custom_emoji = "<:sparklesnek:910496037708374016>"
+    
+    e = PartialEmoji.from_str(thumbs_emoji)
+    assert not e == thumbs_emoji
+    assert e.name == thumbs_emoji
+
+    e = PartialEmoji.from_str(custom_emoji)
+    assert not e == custom_emoji
+    assert e.name == "sparklesnek"
+    assert e.id == 910496037708374016
+


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [x] Tests change

## Description
We had a crash reported in discord by a user comparing a Partial Emoji against a string representation of said emoji.


## Changes
This fixes the crash, correctly making `__eq__` return False in that scenario, and adds a test I made to debug the issue


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
