### PR TITLE
fix: semaphore/max-concurrency handling

### DIFF
--- a/dis_snek/models/snek/command.py
+++ b/dis_snek/models/snek/command.py
@@ -97,7 +97,7 @@ class BaseCommand(DictSerializationMixin):
         # signals if a semaphore has been acquired, for exception handling
         # if present assume one will be acquired
         max_conc_acquired = self.max_concurrency is not MISSING
-        
+
         try:
             if await self._can_run(context):
                 if self.pre_run_callback is not None:
@@ -119,7 +119,7 @@ class BaseCommand(DictSerializationMixin):
         except Exception as e:
             # if a MaxConcurrencyReached-exception is raised a connection was never acquired
             max_conc_acquired = not isinstance(e, MaxConcurrencyReached)
-            
+
             if self.error_callback:
                 await self.error_callback(e, context, *args, **kwargs)
             elif self.scale and self.scale.scale_error:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
semaphores are now only released if one was acquired

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
add checks whether a semaphore was actually acquired or not (if MaxConcurrencyReached is raised no semaphore was acquired)

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
