### PR TITLE
feat: add `unavailable` bool to `GuildUnavailable`

### DIFF
--- a/dis_snek/api/events/discord.py
+++ b/dis_snek/api/events/discord.py
@@ -235,6 +235,8 @@ class GuildUnavailable(BaseEvent, GuildEvent):
 
     guild: Optional["Guild"] = field(default=MISSING)
     """The guild, if it was cached"""
+    unavailable: Optional[bool] = field(default=MISSING)
+    """The guild's state, whether accessible temporarily or on the time of dispatch."""
 
 
 @define(kw_only=False)


### PR DESCRIPTION
## What type of pull request is this?

- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition
- [ ] Tests change

## Description
Sometimes, an ["Unavailable Guild" object](https://discord.com/developers/docs/resources/guild#unavailable-guild-object-example-unavailable-guild) returned from the API can also return an `unavailable` boolean denoting whether it's accessible or not. For clarification, this was internally explained that this is a value given for events such as guild termination via. TnS and can represent whether it's actually unavailable by means of the server being deleted, or if the `GUILD_CREATE` event was unable to return data at the time of its dispatch for whatever API issues may be present.

## Changes
- Added an `unavailable` attribute to the `GuildUnavailable` object.

## Checklist

- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
