### PR TITLE
feat: move formdata processing to http_client.request

### DIFF
--- a/naff/api/http/http_requests/channels.py
+++ b/naff/api/http/http_requests/channels.py
@@ -125,7 +125,7 @@ class ChannelRequests:
                 user_limit=user_limit,
             )
 
-        return await self.request(Route("POST", f"/guilds/{guild_id}/channels"), data=payload, reason=reason)
+        return await self.request(Route("POST", f"/guilds/{guild_id}/channels"), payload=payload, reason=reason)
 
     async def move_channel(
         self,
@@ -152,7 +152,7 @@ class ChannelRequests:
         if parent_id:
             payload["parent_id"] = parent_id
 
-        return await self.request(Route("PATCH", f"/guilds/{guild_id}/channels"), data=payload, reason=reason)
+        return await self.request(Route("PATCH", f"/guilds/{guild_id}/channels"), payload=payload, reason=reason)
 
     async def modify_channel(
         self, channel_id: "Snowflake_Type", data: dict, reason: Absent[str] = MISSING
@@ -169,7 +169,7 @@ class ChannelRequests:
             Channel object on success
 
         """
-        return await self.request(Route("PATCH", f"/channels/{channel_id}"), data=data, reason=reason)
+        return await self.request(Route("PATCH", f"/channels/{channel_id}"), payload=data, reason=reason)
 
     async def delete_channel(self, channel_id: "Snowflake_Type", reason: Absent[str] = MISSING) -> None:
         """
@@ -233,7 +233,7 @@ class ChannelRequests:
         if target_application_id:
             payload["target_application_id"] = target_application_id
 
-        return await self.request(Route("POST", f"/channels/{channel_id}/invites"), data=payload, reason=reason)
+        return await self.request(Route("POST", f"/channels/{channel_id}/invites"), payload=payload, reason=reason)
 
     async def get_invite(
         self,
@@ -301,7 +301,7 @@ class ChannelRequests:
         """
         return await self.request(
             Route("PUT", f"/channels/{channel_id}/permissions/{overwrite_id}"),
-            data={"allow": allow, "deny": deny, "type": perm_type},
+            payload={"allow": allow, "deny": deny, "type": perm_type},
             reason=reason,
         )
 
@@ -334,7 +334,7 @@ class ChannelRequests:
 
         """
         return await self.request(
-            Route("POST", f"/channels/{channel_id}/followers"), data={"webhook_channel_id": webhook_channel_id}
+            Route("POST", f"/channels/{channel_id}/followers"), payload={"webhook_channel_id": webhook_channel_id}
         )
 
     async def trigger_typing_indicator(self, channel_id: "Snowflake_Type") -> None:
@@ -382,7 +382,7 @@ class ChannelRequests:
         """
         return await self.request(
             Route("POST", "/stage-instances"),
-            data={
+            payload={
                 "channel_id": channel_id,
                 "topic": topic,
                 "privacy_level": StagePrivacyLevel(privacy_level),
@@ -421,7 +421,7 @@ class ChannelRequests:
         """
         return await self.request(
             Route("PATCH", f"/stage-instances/{channel_id}"),
-            data=dict_filter_none({"topic": topic, "privacy_level": privacy_level}),
+            payload=dict_filter_none({"topic": topic, "privacy_level": privacy_level}),
             reason=reason,
         )
 

--- a/naff/api/http/http_requests/emojis.py
+++ b/naff/api/http/http_requests/emojis.py
@@ -62,7 +62,7 @@ class EmojiRequests:
             The created emoji object
 
         """
-        return await self.request(Route("POST", f"/guilds/{guild_id}/emojis"), data=payload, reason=reason)
+        return await self.request(Route("POST", f"/guilds/{guild_id}/emojis"), payload=payload, reason=reason)
 
     async def modify_guild_emoji(
         self, payload: dict, guild_id: "Snowflake_Type", emoji_id: "Snowflake_Type", reason: Absent[str] = MISSING
@@ -80,7 +80,9 @@ class EmojiRequests:
             The updated emoji object
 
         """
-        return await self.request(Route("PATCH", f"/guilds/{guild_id}/emojis/{emoji_id}"), data=payload, reason=reason)
+        return await self.request(
+            Route("PATCH", f"/guilds/{guild_id}/emojis/{emoji_id}"), payload=payload, reason=reason
+        )
 
     async def delete_guild_emoji(
         self, guild_id: "Snowflake_Type", emoji_id: "Snowflake_Type", reason: Absent[str] = MISSING

--- a/naff/api/http/http_requests/guild.py
+++ b/naff/api/http/http_requests/guild.py
@@ -136,7 +136,7 @@ class GuildRequests:
 
         # only do the request if there is something to modify
         if kwargs_copy:
-            await self.request(Route("PATCH", f"/guilds/{guild_id}"), data=kwargs_copy, reason=reason)
+            await self.request(Route("PATCH", f"/guilds/{guild_id}"), payload=kwargs_copy, reason=reason)
 
     async def delete_guild(self, guild_id: "Snowflake_Type") -> None:
         """
@@ -175,7 +175,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("PUT", f"/guilds/{guild_id}/members/{user_id}"),
-            data=dict_filter_none(
+            payload=dict_filter_none(
                 {"access_token": access_token, "nick": nick, "roles": roles, "mute": mute, "deaf": deaf}
             ),
         )
@@ -257,7 +257,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("PUT", f"/guilds/{guild_id}/bans/{user_id}"),
-            data={"delete_message_days": delete_message_days},
+            payload={"delete_message_days": delete_message_days},
             reason=reason,
         )
 
@@ -322,7 +322,7 @@ class GuildRequests:
         if include_roles:
             payload["include_roles"] = ", ".join(include_roles)
 
-        return await self.request(Route("POST", f"/guilds/{guild_id}/prune"), data=payload, reason=reason)
+        return await self.request(Route("POST", f"/guilds/{guild_id}/prune"), payload=payload, reason=reason)
 
     async def get_guild_invites(self, guild_id: "Snowflake_Type") -> List[discord_typings.InviteData]:
         """
@@ -352,7 +352,7 @@ class GuildRequests:
             Role object
 
         """
-        return await self.request(Route("POST", f"/guilds/{guild_id}/roles"), data=payload, reason=reason)
+        return await self.request(Route("POST", f"/guilds/{guild_id}/roles"), payload=payload, reason=reason)
 
     async def modify_guild_role_positions(
         self, guild_id: "Snowflake_Type", role_id: "Snowflake_Type", position: int, reason: Absent[str] = MISSING
@@ -371,7 +371,7 @@ class GuildRequests:
 
         """
         return await self.request(
-            Route("PATCH", f"/guilds/{guild_id}/roles"), data={"id": role_id, "position": position}, reason=reason
+            Route("PATCH", f"/guilds/{guild_id}/roles"), payload={"id": role_id, "position": position}, reason=reason
         )
 
     async def modify_guild_role(
@@ -390,7 +390,7 @@ class GuildRequests:
             Role object
 
         """
-        return await self.request(Route("PATCH", f"/guilds/{guild_id}/roles/{role_id}"), data=payload, reason=reason)
+        return await self.request(Route("PATCH", f"/guilds/{guild_id}/roles/{role_id}"), payload=payload, reason=reason)
 
     async def delete_guild_role(
         self, guild_id: "Snowflake_Type", role_id: "Snowflake_Type", reason: Absent[str] = MISSING
@@ -575,7 +575,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("PATCH", f"/guilds/{guild_id}/widget"),
-            data=dict_filter_none({"enabled": enabled, "channel_id": channel_id}),
+            payload=dict_filter_none({"enabled": enabled, "channel_id": channel_id}),
         )
 
     async def modify_guild_welcome_screen(
@@ -596,7 +596,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("PATCH", f"/guilds/{guild_id}/welcome-screen"),
-            data={"enabled": enabled, "welcome_channels": welcome_channels, "description": description},
+            payload={"enabled": enabled, "welcome_channels": welcome_channels, "description": description},
         )
 
     async def modify_current_user_voice_state(
@@ -618,7 +618,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("PATCH", f"/guilds/{guild_id}/voice-states/@me"),
-            data=dict_filter_none(
+            payload=dict_filter_none(
                 {
                     "channel_id": channel_id,
                     "suppress": suppress,
@@ -642,7 +642,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("PATCH", f"/guilds/{guild_id}/voice-states/{user_id}"),
-            data=dict_filter_none({"channel_id": channel_id, "suppress": suppress}),
+            payload=dict_filter_none({"channel_id": channel_id, "suppress": suppress}),
         )
 
     async def create_guild(
@@ -661,7 +661,7 @@ class GuildRequests:
     ) -> dict:
         return await self.request(
             Route("POST", "/guilds"),
-            data=dict_filter_missing(
+            payload=dict_filter_missing(
                 {
                     "name": name,
                     "icon": icon,
@@ -697,7 +697,7 @@ class GuildRequests:
 
         """
         return await self.request(
-            Route("POST", f"/guilds/templates/{template_code}"), data={"name": name, "icon": icon}
+            Route("POST", f"/guilds/templates/{template_code}"), payload={"name": name, "icon": icon}
         )
 
     async def get_guild_templates(self, guild_id: "Snowflake_Type") -> List[discord_typings.GuildTemplateData]:
@@ -730,7 +730,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("POST", f"/guilds/{guild_id}/templates"),
-            data={"name": name, "description": description},
+            payload={"name": name, "description": description},
         )
 
     async def sync_guild_template(
@@ -771,7 +771,7 @@ class GuildRequests:
         """
         return await self.request(
             Route("PATCH", f"/guilds/{guild_id}/templates/{template_code}"),
-            data={"name": name, "description": description},
+            payload={"name": name, "description": description},
         )
 
     async def delete_guild_template(

--- a/naff/api/http/http_requests/interactions.py
+++ b/naff/api/http/http_requests/interactions.py
@@ -10,6 +10,7 @@ __all__ = ("InteractionRequests",)
 
 if TYPE_CHECKING:
     from naff.models.discord.snowflake import Snowflake_Type
+    from naff import UPLOADABLE_TYPE
 
 
 class InteractionRequests:
@@ -64,8 +65,8 @@ class InteractionRequests:
 
         """
         if guild_id == GLOBAL_SCOPE:
-            return await self.request(Route("PUT", f"/applications/{app_id}/commands"), data=data)
-        return await self.request(Route("PUT", f"/applications/{app_id}/guilds/{guild_id}/commands"), data=data)
+            return await self.request(Route("PUT", f"/applications/{app_id}/commands"), payload=data)
+        return await self.request(Route("PUT", f"/applications/{app_id}/guilds/{guild_id}/commands"), payload=data)
 
     async def create_application_command(
         self, app_id: "Snowflake_Type", command: Dict, guild_id: "Snowflake_Type"
@@ -82,10 +83,12 @@ class InteractionRequests:
             An application command object
         """
         if guild_id == GLOBAL_SCOPE:
-            return await self.request(Route("POST", f"/applications/{app_id}/commands"), data=command)
-        return await self.request(Route("POST", f"/applications/{app_id}/guilds/{guild_id}/commands"), data=command)
+            return await self.request(Route("POST", f"/applications/{app_id}/commands"), payload=command)
+        return await self.request(Route("POST", f"/applications/{app_id}/guilds/{guild_id}/commands"), payload=command)
 
-    async def post_initial_response(self, payload: dict, interaction_id: str, token: str) -> None:
+    async def post_initial_response(
+        self, payload: dict, interaction_id: str, token: str, files: list["UPLOADABLE_TYPE"] | None = None
+    ) -> None:
         """
         Post an initial response to an interaction.
 
@@ -93,11 +96,16 @@ class InteractionRequests:
             payload: the payload to send
             interaction_id: the id of the interaction
             token: the token of the interaction
+            files: The files to send in this message
 
         """
-        return await self.request(Route("POST", f"/interactions/{interaction_id}/{token}/callback"), data=payload)
+        return await self.request(
+            Route("POST", f"/interactions/{interaction_id}/{token}/callback"), payload=payload, files=files
+        )
 
-    async def post_followup(self, payload: dict, application_id: "Snowflake_Type", token: str) -> None:
+    async def post_followup(
+        self, payload: dict, application_id: "Snowflake_Type", token: str, files: list["UPLOADABLE_TYPE"] | None = None
+    ) -> None:
         """
         Send a followup to an interaction.
 
@@ -105,12 +113,18 @@ class InteractionRequests:
             payload: the payload to send
             application_id: the id of the application
             token: the token of the interaction
+            files: The files to send with this interaction
 
         """
-        return await self.request(Route("POST", f"/webhooks/{application_id}/{token}"), data=payload)
+        return await self.request(Route("POST", f"/webhooks/{application_id}/{token}"), payload=payload, files=files)
 
     async def edit_interaction_message(
-        self, payload: dict, application_id: "Snowflake_Type", token: str, message_id: str = "@original"
+        self,
+        payload: dict,
+        application_id: "Snowflake_Type",
+        token: str,
+        message_id: str = "@original",
+        files: list["UPLOADABLE_TYPE"] | None = None,
     ) -> discord_typings.MessageData:
         """
         Edits an existing interaction message.
@@ -120,13 +134,14 @@ class InteractionRequests:
             application_id: The id of the application.
             token: The token of the interaction.
             message_id: The target message to edit. Defaults to @original which represents the initial response message.
+            files: The files to send with this interaction
 
         Returns:
             The edited message data.
 
         """
         return await self.request(
-            Route("PATCH", f"/webhooks/{application_id}/{token}/messages/{message_id}"), data=payload
+            Route("PATCH", f"/webhooks/{application_id}/{token}/messages/{message_id}"), payload=payload, files=files
         )
 
     async def get_interaction_message(
@@ -168,7 +183,7 @@ class InteractionRequests:
         """
         return await self.request(
             Route("PUT", f"/applications/{application_id}/guilds/{scope}/commands/{cmd_id}/permissions"),
-            data=permissions,
+            payload=permissions,
         )
 
     async def get_application_command_permissions(

--- a/naff/api/http/http_requests/members.py
+++ b/naff/api/http/http_requests/members.py
@@ -95,7 +95,7 @@ class MemberRequests:
 
         return await self.request(
             Route("PATCH", f"/guilds/{guild_id}/members/{user_id}"),
-            data={
+            payload={
                 "nick": nickname,
                 "roles": roles,
                 "mute": mute,
@@ -122,7 +122,7 @@ class MemberRequests:
         """
         await self.request(
             Route("PATCH", f"/guilds/{guild_id}/members/@me"),
-            data={
+            payload={
                 "nick": nickname or None,
             },
             reason=reason,

--- a/naff/api/http/http_requests/messages.py
+++ b/naff/api/http/http_requests/messages.py
@@ -10,23 +10,27 @@ __all__ = ("MessageRequests",)
 
 if TYPE_CHECKING:
     from naff.models.discord.snowflake import Snowflake_Type
+    from naff import UPLOADABLE_TYPE
 
 
 class MessageRequests:
     request: Any
 
-    async def create_message(self, payload: dict, channel_id: "Snowflake_Type") -> discord_typings.MessageData:
+    async def create_message(
+        self, payload: dict, channel_id: "Snowflake_Type", files: list["UPLOADABLE_TYPE"] | None = None
+    ) -> discord_typings.MessageData:
         """
         Send a message to the specified channel.
 
         Args:
             payload: The message to send
+            files: Any files to send with this message
 
         Returns:
             The resulting message object
 
         """
-        return await self.request(Route("POST", f"/channels/{channel_id}/messages"), data=payload)
+        return await self.request(Route("POST", f"/channels/{channel_id}/messages"), payload=payload, files=files)
 
     async def delete_message(
         self, channel_id: "Snowflake_Type", message_id: "Snowflake_Type", reason: Absent[str] = MISSING
@@ -55,7 +59,9 @@ class MessageRequests:
 
         """
         return await self.request(
-            Route("POST", f"/channels/{channel_id}/messages/bulk-delete"), data={"messages": message_ids}, reason=reason
+            Route("POST", f"/channels/{channel_id}/messages/bulk-delete"),
+            payload={"messages": message_ids},
+            reason=reason,
         )
 
     async def get_message(
@@ -101,6 +107,7 @@ class MessageRequests:
         payload: dict,
         channel_id: "Snowflake_Type",
         message_id: "Snowflake_Type",
+        files: list["UPLOADABLE_TYPE"] | None = None,
     ) -> discord_typings.MessageData:
         """
         Edit an existing message.
@@ -109,12 +116,15 @@ class MessageRequests:
             payload:
             channel_id: Channel of message to edit.
             message_id: Message to edit.
+            files: Any files to send with this message
 
         Returns:
             Message object of edited message
 
         """
-        return await self.request(Route("PATCH", f"/channels/{channel_id}/messages/{message_id}"), data=payload)
+        return await self.request(
+            Route("PATCH", f"/channels/{channel_id}/messages/{message_id}"), payload=payload, files=files
+        )
 
     async def crosspost_message(
         self, channel_id: "Snowflake_Type", message_id: "Snowflake_Type"

--- a/naff/api/http/http_requests/scheduled_events.py
+++ b/naff/api/http/http_requests/scheduled_events.py
@@ -69,7 +69,7 @@ class ScheduledEventsRequests:
             Scheduled Event or None
 
         """
-        return await self.request(Route("POST", f"/guilds/{guild_id}/scheduled-events"), data=payload, reason=reason)
+        return await self.request(Route("POST", f"/guilds/{guild_id}/scheduled-events"), payload=payload, reason=reason)
 
     async def modify_scheduled_event(
         self,
@@ -92,7 +92,7 @@ class ScheduledEventsRequests:
 
         """
         return await self.request(
-            Route("PATCH", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}"), data=payload, reason=reason
+            Route("PATCH", f"/guilds/{guild_id}/scheduled-events/{scheduled_event_id}"), payload=payload, reason=reason
         )
 
     async def delete_scheduled_event(

--- a/naff/api/http/http_requests/stickers.py
+++ b/naff/api/http/http_requests/stickers.py
@@ -9,8 +9,8 @@ __all__ = ("StickerRequests",)
 
 
 if TYPE_CHECKING:
-    from aiohttp import FormData
     from naff.models.discord.snowflake import Snowflake_Type
+    from naff import UPLOADABLE_TYPE
 
 
 class StickerRequests:
@@ -69,7 +69,7 @@ class StickerRequests:
         return await self.request(Route("GET", f"/guilds/{guild_id}/stickers/{sticker_id}"))
 
     async def create_guild_sticker(
-        self, payload: "FormData", guild_id: "Snowflake_Type", reason: Optional[str] = MISSING
+        self, payload: dict, guild_id: "Snowflake_Type", file: "UPLOADABLE_TYPE", reason: Optional[str] = MISSING
     ) -> discord_typings.StickerData:
         """
         Create a new sticker for the guild. Requires the MANAGE_EMOJIS_AND_STICKERS permission.
@@ -77,13 +77,16 @@ class StickerRequests:
         Args:
             payload: the payload to send.
             guild_id: The guild to create sticker at.
+            file: the image to use for the sticker
             reason: The reason for this action.
 
         Returns:
             The new sticker data on success.
 
         """
-        return await self.request(Route("POST", f"/guild/{guild_id}/stickers"), data=payload, reason=reason)
+        return await self.request(
+            Route("POST", f"/guild/{guild_id}/stickers"), payload=payload, files=[file], reason=reason
+        )
 
     async def modify_guild_sticker(
         self, payload: dict, guild_id: "Snowflake_Type", sticker_id: "Snowflake_Type", reason: Optional[str] = MISSING
@@ -102,7 +105,7 @@ class StickerRequests:
 
         """
         return await self.request(
-            Route("PATCH", f"/guild/{guild_id}/stickers/{sticker_id}"), data=payload, reason=reason
+            Route("PATCH", f"/guild/{guild_id}/stickers/{sticker_id}"), payload=payload, reason=reason
         )
 
     async def delete_guild_sticker(

--- a/naff/api/http/http_requests/threads.py
+++ b/naff/api/http/http_requests/threads.py
@@ -183,9 +183,9 @@ class ThreadRequests:
         payload = {"name": name, "auto_archive_duration": auto_archive_duration}
         if message_id:
             return await self.request(
-                Route("POST", f"/channels/{channel_id}/messages/{message_id}/threads"), data=payload, reason=reason
+                Route("POST", f"/channels/{channel_id}/messages/{message_id}/threads"), payload=payload, reason=reason
             )
         else:
             payload["type"] = thread_type or ChannelTypes.GUILD_PUBLIC_THREAD
             payload["invitable"] = invitable
-            return await self.request(Route("POST", f"/channels/{channel_id}/threads"), data=payload, reason=reason)
+            return await self.request(Route("POST", f"/channels/{channel_id}/threads"), payload=payload, reason=reason)

--- a/naff/api/http/http_requests/users.py
+++ b/naff/api/http/http_requests/users.py
@@ -45,7 +45,7 @@ class UserRequests:
             payload: The data to send.
 
         """
-        return await self.request(Route("PATCH", "/users/@me"), data=payload)
+        return await self.request(Route("PATCH", "/users/@me"), payload=payload)
 
     async def get_user_guilds(self) -> List[discord_typings.GuildData]:
         """
@@ -74,7 +74,7 @@ class UserRequests:
             recipient_id: The recipient to open a DM channel with.
 
         """
-        return await self.request(Route("POST", "/users/@me/channels"), data={"recipient_id": recipient_id})
+        return await self.request(Route("POST", "/users/@me/channels"), payload={"recipient_id": recipient_id})
 
     async def create_group_dm(self, payload: dict) -> discord_typings.GroupDMChannelData:
         """
@@ -84,7 +84,7 @@ class UserRequests:
             payload: The data to send.
 
         """
-        return await self.request(Route("POST", "/users/@me/channels"), data=payload)
+        return await self.request(Route("POST", "/users/@me/channels"), payload=payload)
 
     async def get_user_connections(self) -> list:
         """
@@ -110,7 +110,7 @@ class UserRequests:
         """
         return await self.request(
             Route("PUT", f"/channels/{channel_id}/recipients/{user_id}"),
-            data={"access_token": access_token, "nick": nick},
+            payload={"access_token": access_token, "nick": nick},
         )
 
     async def group_dm_remove_recipient(self, channel_id: "Snowflake_Type", user_id: "Snowflake_Type") -> None:
@@ -133,4 +133,4 @@ class UserRequests:
             nickname: The new nickname to use
 
         """
-        return await self.request(Route("PATCH", f"/guilds/{guild_id}/members/@me/nick"), data={"nick": nickname})
+        return await self.request(Route("PATCH", f"/guilds/{guild_id}/members/@me/nick"), payload={"nick": nickname})

--- a/naff/api/http/http_requests/webhooks.py
+++ b/naff/api/http/http_requests/webhooks.py
@@ -10,6 +10,7 @@ __all__ = ("WebhookRequests",)
 
 if TYPE_CHECKING:
     from naff.models.discord.snowflake import Snowflake_Type
+    from naff import UPLOADABLE_TYPE
 
 
 class WebhookRequests:
@@ -28,7 +29,7 @@ class WebhookRequests:
 
         """
         return await self.request(
-            Route("POST", f"/channels/{channel_id}/webhooks"), data={"name": name, "avatar": avatar}
+            Route("POST", f"/channels/{channel_id}/webhooks"), payload={"name": name, "avatar": avatar}
         )
 
     async def get_channel_webhooks(self, channel_id: "Snowflake_Type") -> List[discord_typings.WebhookData]:
@@ -95,7 +96,7 @@ class WebhookRequests:
         endpoint = f"/webhooks/{webhook_id}{f'/{webhook_token}' if webhook_token else ''}"
 
         return await self.request(
-            Route("PATCH", endpoint), data={"name": name, "avatar": avatar, "channel_id": channel_id}
+            Route("PATCH", endpoint), payload={"name": name, "avatar": avatar, "channel_id": channel_id}
         )
 
     async def delete_webhook(self, webhook_id: "Snowflake_Type", webhook_token: str = None) -> None:
@@ -140,7 +141,7 @@ class WebhookRequests:
         return await self.request(
             Route("POST", f"/webhooks/{webhook_id}/{webhook_token}"),
             params=dict_filter_none({"wait": "true" if wait else "false", "thread_id": thread_id}),
-            data=payload,
+            payload=payload,
         )
 
     async def get_webhook_message(
@@ -161,7 +162,12 @@ class WebhookRequests:
         return await self.request(Route("GET", f"/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}"))
 
     async def edit_webhook_message(
-        self, webhook_id: "Snowflake_Type", webhook_token: str, message_id: "Snowflake_Type", payload: dict
+        self,
+        webhook_id: "Snowflake_Type",
+        webhook_token: str,
+        message_id: "Snowflake_Type",
+        payload: dict,
+        files: None | list["UPLOADABLE_TYPE"] = None,
     ) -> discord_typings.MessageData:
         """
         Edits a previously-sent webhook message from the same token.
@@ -171,13 +177,16 @@ class WebhookRequests:
             webhook_token: The token for the webhook
             message_id: The ID of a message sent by this webhook
             payload: The JSON payload for the message
+            files: The files to send in this message
 
         Returns:
             The updated message on success
 
         """
         return await self.request(
-            Route("PATCH", f"/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}"), data=payload
+            Route("PATCH", f"/webhooks/{webhook_id}/{webhook_token}/messages/{message_id}"),
+            payload=payload,
+            files=files,
         )
 
     async def delete_webhook_message(

--- a/naff/api/http/http_requests/webhooks.py
+++ b/naff/api/http/http_requests/webhooks.py
@@ -122,6 +122,7 @@ class WebhookRequests:
         payload: dict,
         wait: bool = False,
         thread_id: "Snowflake_Type" = None,
+        files: list["UPLOADABLE_TYPE"] | None = None,
     ) -> Optional[discord_typings.MessageData]:
         """
         Execute a webhook. Basically send a message as the webhook.
@@ -133,6 +134,7 @@ class WebhookRequests:
             wait: Waits for server confirmation of message send before response
             thread_id: Send a message to the specified thread
             suffix: An optional suffix to add to the end of the endpoint address
+            files: The files to send with this message
 
         Returns:
             The sent `message`, if `wait` is True else None
@@ -142,6 +144,7 @@ class WebhookRequests:
             Route("POST", f"/webhooks/{webhook_id}/{webhook_token}"),
             params=dict_filter_none({"wait": "true" if wait else "false", "thread_id": thread_id}),
             payload=payload,
+            files=files,
         )
 
     async def get_webhook_message(

--- a/naff/client/mixins/send.py
+++ b/naff/client/mixins/send.py
@@ -4,8 +4,6 @@ import naff.client.errors as errors
 import naff.models as models
 
 if TYPE_CHECKING:
-    from aiohttp.formdata import FormData
-
     from naff.client import Client
     from naff.models.discord.file import UPLOADABLE_TYPE
     from naff.models.discord.components import BaseComponent
@@ -21,7 +19,7 @@ __all__ = ("SendMixin",)
 class SendMixin:
     _client: "Client"
 
-    async def _send_http_request(self, message_payload: Union[dict, "FormData"]) -> dict:
+    async def _send_http_request(self, message_payload: dict, files: list["UPLOADABLE_TYPE"] | None = None) -> dict:
         raise NotImplementedError
 
     async def send(
@@ -80,12 +78,11 @@ class SendMixin:
             stickers=stickers,
             allowed_mentions=allowed_mentions,
             reply_to=reply_to,
-            files=files or file,
             tts=tts,
             flags=flags,
             **kwargs,
         )
 
-        message_data = await self._send_http_request(message_payload)
+        message_data = await self._send_http_request(message_payload, files=files or file)
         if message_data:
             return self._client.cache.place_message_data(message_data)

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -198,8 +198,10 @@ class MessageableMixin(SendMixin):
     last_pin_timestamp: Optional["models.Timestamp"] = field(default=None, converter=optional_c(timestamp_converter))
     """When the last pinned message was pinned. This may be None when a message is not pinned."""
 
-    async def _send_http_request(self, message_payload: Union[dict, "FormData"]) -> dict:
-        return await self._client.http.create_message(message_payload, self.id)
+    async def _send_http_request(
+        self, message_payload: Union[dict, "FormData"], files: list["UPLOADABLE_TYPE"] | None = None
+    ) -> dict:
+        return await self._client.http.create_message(message_payload, self.id, files=files)
 
     async def fetch_message(self, message_id: Snowflake_Type) -> Optional["models.Message"]:
         """

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -4,7 +4,6 @@ import time
 from collections import namedtuple
 from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
 
-from aiohttp import FormData
 
 import naff.models as models
 from naff.client.const import MISSING, PREMIUM_GUILD_LIMITS, logger_name, Absent
@@ -1189,20 +1188,13 @@ class Guild(BaseGuild):
             New Sticker instance
 
         """
-        payload = FormData()
-        payload.add_field("name", name)
-
-        file_buffer = models.open_file(imagefile)
-        if isinstance(imagefile, models.File):
-            payload.add_field("file", file_buffer, filename=imagefile.file_name)
-        else:
-            payload.add_field("file", file_buffer)
+        payload = {"name": name}
 
         if description:
-            payload.add_field("description", description)
+            payload["description"] = description
 
         if tags:
-            payload.add_field("tags", tags)
+            payload["tags"] = tags
 
         sticker_data = await self._client.http.create_guild_sticker(payload, self.id, reason)
         return models.Sticker.from_dict(sticker_data, self._client)

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -2,7 +2,6 @@ import asyncio
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
-from aiohttp import FormData
 
 import naff.models as models
 from naff.client.const import GUILD_WELCOME_MESSAGES, MISSING, Absent
@@ -11,7 +10,6 @@ from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import optional as optional_c
 from naff.client.utils.attr_converters import timestamp_converter
-from naff.client.utils.input_utils import OverriddenJson
 from naff.client.utils.serializer import dict_filter_none
 from naff.models.discord.file import UPLOADABLE_TYPE
 from .base import DiscordObject
@@ -527,7 +525,6 @@ class Message(BaseMessage):
             components=components,
             allowed_mentions=allowed_mentions,
             attachments=attachments,
-            files=files or file,
             tts=tts,
             flags=flags,
         )
@@ -535,7 +532,7 @@ class Message(BaseMessage):
         if self.flags == MessageFlags.EPHEMERAL:
             raise EphemeralEditException
 
-        message_data = await self._client.http.edit_message(message_payload, self._channel_id, self.id)
+        message_data = await self._client.http.edit_message(message_payload, self._channel_id, self.id, files=files)
         if message_data:
             return self._client.cache.place_message_data(message_data)
 
@@ -799,11 +796,10 @@ def process_message_payload(
     allowed_mentions: Optional[Union[AllowedMentions, dict]] = None,
     reply_to: Optional[Union[MessageReference, Message, dict, "Snowflake_Type"]] = None,
     attachments: Optional[List[Union[Attachment, dict]]] = None,
-    files: Optional[Union[UPLOADABLE_TYPE, List[UPLOADABLE_TYPE]]] = None,
     tts: bool = False,
     flags: Optional[Union[int, MessageFlags]] = None,
     **kwargs,
-) -> Union[Dict, FormData]:
+) -> dict:
     """
     Format message content for it to be ready to send discord.
 
@@ -815,12 +811,11 @@ def process_message_payload(
         allowed_mentions: Allowed mentions for the message.
         reply_to: Message to reference, must be from the same channel.
         attachments: The attachments to keep, only used when editing message.
-        files: Files to send, defaults to None. You may send up to 10 files.
         tts: Should this message use Text To Speech.
         flags: Message flags to apply.
 
     Returns:
-        Dictionary or multipart data form.
+        Dictionary
 
     """
     embeds = models.process_embeds(embeds)
@@ -835,7 +830,7 @@ def process_message_payload(
     if attachments:
         attachments = [attachment.to_dict() for attachment in attachments]
 
-    message_data = dict_filter_none(
+    return dict_filter_none(
         {
             "content": content,
             "embeds": embeds,
@@ -849,22 +844,3 @@ def process_message_payload(
             **kwargs,
         }
     )
-
-    if files:
-        # We need to use multipart/form-data for file sending here.
-        form = FormData()
-        form.add_field("payload_json", OverriddenJson.dumps(message_data))
-
-        if not isinstance(files, list):
-            files = [files]
-
-        for index, file in enumerate(files):
-            file_buffer = models.open_file(file)
-            if isinstance(file, models.File):
-                form.add_field(f"files[{index}]", file_buffer, filename=file.file_name)
-            else:
-                form.add_field(f"files[{index}]", file_buffer)
-
-        return form
-    else:
-        return message_data

--- a/naff/models/discord/thread.py
+++ b/naff/models/discord/thread.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from naff.models.discord.user import User
     from naff.models.discord.channel import TYPE_THREAD_CHANNEL
     from naff.models.discord.snowflake import Snowflake_Type
+    from naff import UPLOADABLE_TYPE
 
 __all__ = ("ThreadMember", "ThreadList")
 
@@ -70,9 +71,11 @@ class ThreadMember(DiscordObject, SendMixin):
         """
         return self._client.cache.get_user(self._user_id)
 
-    async def _send_http_request(self, message_payload: Union[dict, "FormData"]) -> dict:
+    async def _send_http_request(
+        self, message_payload: Union[dict, "FormData"], files: list["UPLOADABLE_TYPE"] | None = None
+    ) -> dict:
         dm_id = await self._client.cache.fetch_dm_channel_id(self._user_id)
-        return await self._client.http.create_message(message_payload, dm_id)
+        return await self._client.http.create_message(message_payload, dm_id, files=files)
 
 
 @define()

--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -36,9 +36,11 @@ log = logging.getLogger(logger_name)
 class _SendDMMixin(SendMixin):
     id: "Snowflake_Type"
 
-    async def _send_http_request(self, message_payload: Union[dict, "FormData"]) -> dict:
+    async def _send_http_request(
+        self, message_payload: Union[dict, "FormData"], files: list["UPLOADABLE_TYPE"] | None = None
+    ) -> dict:
         dm_id = await self._client.cache.fetch_dm_channel_id(self.id)
-        return await self._client.http.create_message(message_payload, dm_id)
+        return await self._client.http.create_message(message_payload, dm_id, files=files)
 
 
 @define()

--- a/naff/models/discord/webhooks.py
+++ b/naff/models/discord/webhooks.py
@@ -230,7 +230,6 @@ class Webhook(DiscordObject, SendMixin):
             stickers=stickers,
             allowed_mentions=allowed_mentions,
             reply_to=reply_to,
-            files=files or file,
             tts=tts,
             flags=flags,
             username=username,
@@ -239,7 +238,7 @@ class Webhook(DiscordObject, SendMixin):
         )
 
         message_data = await self._client.http.execute_webhook(
-            self.id, self.token, message_payload, wait, to_optional_snowflake(thread)
+            self.id, self.token, message_payload, wait, to_optional_snowflake(thread), files=files or [file]
         )
         if message_data:
             return self._client.cache.place_message_data(message_data)
@@ -287,12 +286,11 @@ class Webhook(DiscordObject, SendMixin):
             stickers=stickers,
             allowed_mentions=allowed_mentions,
             reply_to=reply_to,
-            files=files or file,
             tts=tts,
             flags=flags,
         )
         msg_data = await self._client.http.edit_webhook_message(
-            self.id, self.token, to_snowflake(message), message_payload
+            self.id, self.token, to_snowflake(message), message_payload, files=files or file
         )
         if msg_data:
             return self._client.cache.place_message_data(msg_data)

--- a/naff/models/discord/webhooks.py
+++ b/naff/models/discord/webhooks.py
@@ -238,7 +238,7 @@ class Webhook(DiscordObject, SendMixin):
         )
 
         message_data = await self._client.http.execute_webhook(
-            self.id, self.token, message_payload, wait, to_optional_snowflake(thread), files=files or [file]
+            self.id, self.token, message_payload, wait, to_optional_snowflake(thread), files=files or file
         )
         if message_data:
             return self._client.cache.place_message_data(message_data)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Internally breaking for all http methods as `data` kwarg for `http_client.request` has been renamed to `payload`. 

This pr primarily moves **all** FormData processing into the `http_client`. The main reason for this, is the fact that you cannot re-send `FormData`, instead you must reconstruct it, by moving processing to the client itself, we create it on demand, and for reattempts (primarily due to server errors), we dont have to do jank reconstruction like some other libs 👀. This has the added side-effect of reducing code duplication, as we were generating `FormData` objects in identical ways, in multiple files. 

Note: This pr has not been tested

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Rename `http_client.request` `data` kwarg -> `payload`
- Move `FormData` construction to `http_client`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
