### PR TITLE
feat: system content for automod message

### DIFF
--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -469,6 +469,14 @@ class Message(BaseMessage):
                 if referenced_message := self.get_referenced_message():
                     return referenced_message.content
                 return "Sorry, we couldn't load the first message in this thread"
+            case MessageTypes.AUTO_MODERATION_ACTION:
+                keyword_matched_content = self.embeds[0].fields[4].value  # The words that triggered the action
+                message_content = self.embeds[0].description.replace(
+                    keyword_matched_content, f"**{keyword_matched_content}**"
+                )
+                rule = self.embeds[0].fields[0].value  # What rule was triggered
+                channel = self.embeds[0].fields[1].value  # Channel that the action took place in
+                return f'AutoMod has blocked a message. "{message_content}" from {self.author.mention} in <#{channel}>. Rule: {rule}.'                
             case _:
                 return None
 

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -476,7 +476,7 @@ class Message(BaseMessage):
                 )
                 rule = self.embeds[0].fields[0].value  # What rule was triggered
                 channel = self.embeds[0].fields[1].value  # Channel that the action took place in
-                return f'AutoMod has blocked a message. "{message_content}" from {self.author.mention} in <#{channel}>. Rule: {rule}.'                
+                return f'AutoMod has blocked a message. "{message_content}" from {self.author.mention} in <#{channel}>. Rule: {rule}.'
             case _:
                 return None
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
![image](https://user-images.githubusercontent.com/58155937/168453557-b26635e0-37f0-43f4-b4b4-920db5a0f1d7.png)
system content would return:
`AutoMod has blocked a message. "can you just shut the **<trigger word>** up" from <@1234> in <#4321>. Rule: <triggered rule>`

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- AUTO_MODERATION_ACTION system content type

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
