### PR TITLE
fix: Allow dispatch in a channel the bot has no data on channel

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -87,10 +87,11 @@ from naff.models import (
     VoiceRegion,
 )
 from naff.models import Wait
+from naff.models.discord.channel import BaseChannel
 from naff.models.discord.color import BrandColors
 from naff.models.discord.components import get_components_ids, BaseComponent
 from naff.models.discord.embed import Embed
-from naff.models.discord.enums import ComponentTypes, Intents, InteractionTypes, Status
+from naff.models.discord.enums import ComponentTypes, Intents, InteractionTypes, Status, ChannelTypes
 from naff.models.discord.file import UPLOADABLE_TYPE
 from naff.models.discord.modal import Modal
 from naff.models.naff.active_voice_state import ActiveVoiceState
@@ -1300,7 +1301,12 @@ class Client(
                     cls = self.interaction_context.from_dict(data, self)
 
             if not cls.channel:
-                cls.channel = await self.cache.fetch_channel(data["channel_id"])
+                try:
+                    cls.channel = await self.cache.fetch_channel(data["channel_id"])
+                except Forbidden:
+                    cls.channel = BaseChannel.from_dict_factory(
+                        {"id": data["channel_id"], "type": ChannelTypes.GUILD_TEXT}, self
+                    )
 
         else:
             cls = self.prefixed_context.from_message(self, data)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
@KAJdev noticed that the library was unable to dispatch interactions to private channels. This PR resolves that. 

This is acheived by creating a dummy channel object, and suppressing the Forbidden exception raised when the bot attempts to fetch the private channel. 

The dummy channel is of type 0, GuildText, as this is the information that can be inferred aside from the ID. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Create dummy channel on `Forbidden` when fetching the context channel 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
