### PR TITLE
fix: Gateway spawns unnecessary tasks

### DIFF
--- a/naff/api/gateway/websocket.py
+++ b/naff/api/gateway/websocket.py
@@ -63,6 +63,7 @@ class WebsocketClient:
         self._acknowledged.set()  # Initialize it as set
 
         self._close_gateway = asyncio.Event()
+        self._stopping: asyncio.Task | None = None
 
         # Sanity check, it is extremely important that an instance isn't reused.
         self._entered = False

--- a/naff/api/voice/voice_gateway.py
+++ b/naff/api/voice/voice_gateway.py
@@ -71,19 +71,19 @@ class VoiceGateway(WebsocketClient):
     async def run(self) -> None:
         """Start receiving events from the websocket."""
         while True:
-            stopping = asyncio.create_task(self._close_gateway.wait())
+            if self._stopping is None:
+                self._stopping = asyncio.create_task(self._close_gateway.wait())
             receiving = asyncio.create_task(self.receive())
-            done, _ = await asyncio.wait({stopping, receiving}, return_when=asyncio.FIRST_COMPLETED)
+            done, _ = await asyncio.wait({self._stopping, receiving}, return_when=asyncio.FIRST_COMPLETED)
 
             if receiving in done:
                 # Note that we check for a received message first, because if both completed at
                 # the same time, we don't want to discard that message.
                 msg = await receiving
-                stopping.cancel()
             else:
                 # This has to be the stopping task, which we join into the current task (even
                 # though that doesn't give any meaningful value in the return).
-                await stopping
+                await self._stopping
                 receiving.cancel()
                 return
 


### PR DESCRIPTION
fixes #239

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Resolves #239 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Impliments verbatum what was requested in #239 
- Add an optional (potentially None) attribute ~~to __slots__~~ and initialize it as None
- In the receive() (or if it was the run()) method check for this task and use it in asyncio.wait(), if it doesn't exist create it.
- Edit the code to stop cancelling the task when the WebSocket receive suceeds

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
