### PR TITLE
docs: adjust various namings to reflect NAFF

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async def user_context(ctx):
 
 bot.start("TOKEN")
 ```
-For more examples check out [our examples repo](https://github.com/Discord-Snake-Pit/examples) or the [docs](https://dis-snek.readthedocs.io/). You also can [explore projects with the dis-snek topic](https://github.com/topics/dis-snek).
+For more examples check out [our examples repo](https://github.com/Discord-Snake-Pit/examples) or the [docs](https://dis-snek.readthedocs.io/). You also can [explore projects with the dis-snek topic](https://github.com/topics/naff).
 
 If you get stuck join our [Discord server](https://discord.gg/dis-snek).
 

--- a/docs/_snippets/github_link.md
+++ b/docs/_snippets/github_link.md
@@ -1,1 +1,1 @@
-[:fontawesome-brands-github: GitHub Repo](https://github.com/Discord-Snake-Pit/Dis-Snek)
+[:fontawesome-brands-github: GitHub Repo](https://github.com/Discord-Snake-Pit/NAFF)

--- a/docs/src/Guides/01 Getting Started.md
+++ b/docs/src/Guides/01 Getting Started.md
@@ -1,13 +1,13 @@
 # Introduction
 
-Hi! So you want to make a bot powered by snakes. This guide aims to get you started as fast as possible, for more advanced use-cases check out the other guides.
+Hi! So you want to make a bot starting from naffing. This guide aims to get you started as fast as possible, for more advanced use-cases check out the other guides.
 
 ### Requirements
 
 - [x] Python 3.10 or greater
 - [x] Know how to use `pip`
 - [x] [A bot account](02 Creating Your Bot.md)
-- [ ] An aversion to snakes
+- [ ] An aversion to puns
 
 ## Installation Methods
 
@@ -83,9 +83,9 @@ There are two different ways to install this library and create your bot.
     Now let's get a basic bot going, for your code, you'll want something like this:
 
     ```python
-    from naff import Snake, Intents, listen
+    from naff import Client, Intents, listen
 
-    bot = Snake(intents=Intents.DEFAULT)
+    bot = Client(intents=Intents.DEFAULT)
     # intents are what events we want to receive from discord, `DEFAULT` is usually fine
 
     @listen()  # this decorator tells snek that it needs to listen for the corresponding event, and run this coroutine

--- a/docs/src/Guides/03 Creating Commands.md
+++ b/docs/src/Guides/03 Creating Commands.md
@@ -37,7 +37,7 @@ async def my_command_function(ctx: InteractionContext):
     await ctx.send("Hello World")
 ```
 
-For more information, please visit the API reference [here](/API Reference/models/Snek/application_commands/#naff.models.snek.application_commands.slash_command).
+For more information, please visit the API reference [here](/API Reference/models/Naff/application_commands/#naff.models.naff.application_commands.slash_command).
 
 ## Subcommands
 
@@ -85,7 +85,7 @@ This will show up in discord as `/base group command`. There are two ways to add
 
 ## But I Need More Options
 
-Interactions can also have options. There are a bunch of different [types of options](/API Reference/models/Snek/application_commands/#naff.models.snek.application_commands.OptionTypes):
+Interactions can also have options. There are a bunch of different [types of options](/API Reference/models/Naff/application_commands/#naff.models.naff.application_commands.OptionTypes):
 
 | Option Type               | Return Type                                | Description                                                                                 |
 |---------------------------|--------------------------------------------|---------------------------------------------------------------------------------------------|
@@ -129,7 +129,7 @@ async def my_command_function(ctx: InteractionContext, integer_option: int = 5):
     await ctx.send(f"You input {integer_option}")
 ```
 
-For more information, please visit the API reference [here](/API Reference/models/Snek/application_commands/#naff.models.snek.application_commands.slash_option).
+For more information, please visit the API reference [here](/API Reference/models/Naff/application_commands/#naff.models.naff.application_commands.slash_option).
 
 ## Restricting Options
 
@@ -190,7 +190,7 @@ async def my_command_function(ctx: InteractionContext, integer_option: int):
     await ctx.send(f"You input {integer_option} which is either 1 or 2")
 ```
 
-For more information, please visit the API reference [here](/API Reference/models/Snek/application_commands/#naff.models.snek.application_commands.SlashCommandChoice).
+For more information, please visit the API reference [here](/API Reference/models/Naff/application_commands/#naff.models.naff.application_commands.SlashCommandChoice).
 
 ## I Need More Than 25 Choices
 

--- a/docs/src/Guides/04 Context Menus.md
+++ b/docs/src/Guides/04 Context Menus.md
@@ -5,7 +5,7 @@ Context menus work off `ctx.target` which contains the object the user interacte
 
 You can also define `scopes` and `permissions` for them, just like with interactions.
 
-For more information, please visit the API reference [here](/API Reference/models/naff/application_commands/#naff.models.snek.application_commands.context_menu).
+For more information, please visit the API reference [here](/API Reference/models/Naff/application_commands/#naff.models.naff.application_commands.context_menu).
 
 ## Message Context Menus
 

--- a/docs/src/Guides/05 Components.md
+++ b/docs/src/Guides/05 Components.md
@@ -87,7 +87,7 @@ If you use `ButtonStyles.URL`, you can pass an url to the button with `url`. Use
 components = Button(
     style=ButtonStyles.URL,
     label="Click Me",
-    url="https://github.com/Discord-Snake-Pit/Dis-Snek",
+    url="https://github.com/Discord-Snake-Pit/NAFF",
 )
 
 await channel.send("Look a Button!", components=components)

--- a/docs/src/Guides/10 Events.md
+++ b/docs/src/Guides/10 Events.md
@@ -8,7 +8,7 @@ What events you subscribe to are defined at startup by setting your `Intents`.
 
 `Intents.DEFAULT` is a good place to start if your bot is new and small, otherwise, it is recommended to take your time and go through them one by one.
 ```python
-bot = Snake(intents=Intents.DEFAULT)
+bot = Client(intents=Intents.DEFAULT)
 bot.start("Put your token here")
 ```
 
@@ -33,7 +33,7 @@ There are two ways to register events. **Decorators** are the recommended way to
     To use decorators, they need to be in the same file where you defined your `bot = Client()`.
 
     ```python
-    bot = Snake(intents=Intents.DEFAULT)
+    bot = Client(intents=Intents.DEFAULT)
 
     @listen()
     async def on_channel_create(event: ChannelCreate):
@@ -73,7 +73,7 @@ There are two ways to register events. **Decorators** are the recommended way to
         print(f"Channel created with name: {event.channel.name}")
 
 
-    bot = Snake(intents=Intents.DEFAULT)
+    bot = Client(intents=Intents.DEFAULT)
     bot.add_listener(Listener(func=on_channel_create, event="on_channel_create"))
     bot.start("Put your token here")
     ```

--- a/docs/src/Guides/20 Extensions.md
+++ b/docs/src/Guides/20 Extensions.md
@@ -19,7 +19,7 @@ Below is an example of a bot, one with extensions, one without.
         import logging
 
         import naff.const
-        from naff.client import Snake
+        from naff.client import Client
         from naff.models.application_commands import slash_command, slash_option
         from naff.models.command import prefixed_command
         from naff.models.context import InteractionContext
@@ -33,7 +33,7 @@ Below is an example of a bot, one with extensions, one without.
         cls_log = logging.getLogger(naff.const.logger_name)
         cls_log.setLevel(logging.DEBUG)
 
-        bot = Snake(intents=Intents.DEFAULT, sync_interactions=True, asyncio_debug=True)
+        bot = Client(intents=Intents.DEFAULT, sync_interactions=True, asyncio_debug=True)
 
 
         @listen()
@@ -94,7 +94,7 @@ Below is an example of a bot, one with extensions, one without.
         import logging
 
         import naff.const
-        from naff.client import Snake
+        from naff.client import Client
         from naff.models.context import ComponentContext
         from naff.models.enums import Intents
         from naff.models.events import Component
@@ -105,7 +105,7 @@ Below is an example of a bot, one with extensions, one without.
         cls_log = logging.getLogger(naff.const.logger_name)
         cls_log.setLevel(logging.DEBUG)
 
-        bot = Snake(intents=Intents.DEFAULT, sync_interactions=True, asyncio_debug=True)
+        bot = Client(intents=Intents.DEFAULT, sync_interactions=True, asyncio_debug=True)
 
 
         @listen()

--- a/docs/src/Guides/21 Advanced Scale Usage.md
+++ b/docs/src/Guides/21 Advanced Scale Usage.md
@@ -13,7 +13,7 @@ Checks prohibit the interaction from running if they return `False`.
 You can add your own check to your extension. In this example, we only want a user whose name starts with "a" to run any command from this extension.
 ```python
 class MyExtension(Extension):
-    def __init__(self, client: Snake):
+    def __init__(self, client: Client):
         self.client = client
         self.add_ext_check(self.a_check)
 
@@ -35,7 +35,7 @@ Pre- and Post-Run events are similar to checks. They run before and after an int
 In this example, we are just printing some stats before and after the interaction.
 ```python
 class MyExt(Extension):
-    def __init__(self, client: Snake):
+    def __init__(self, client: Client):
         self.client = client
         self.add_extension_prerun(self.pre_run)
         self.add_extension_postrun(self.post_run)
@@ -65,7 +65,7 @@ By subclassing your own custom extension, your can still split your code into as
 ### File 1
 ```python
 class CustomExtension(Extension):
-    def __init__(self, client: Snake):
+    def __init__(self, client: Client):
         self.client = client
         self.add_ext_check(self.a_check)
 

--- a/naff/client/const.py
+++ b/naff/client/const.py
@@ -79,7 +79,7 @@ try:
     __version__ = _v("naff")
 except Exception:
     __version__ = "0.0.0"
-__repo_url__ = "https://github.com/Discord-Snake-Pit/Dis-Snek"
+__repo_url__ = "https://github.com/Discord-Snake-Pit/NAFF"
 __py_version__ = f"{_ver_info[0]}.{_ver_info[1]}"
 __api_version__ = 10
 logger_name = "dis.naff"

--- a/naff/ext/debug_extension/utils.py
+++ b/naff/ext/debug_extension/utils.py
@@ -15,7 +15,7 @@ def debug_embed(title: str, **kwargs) -> Embed:
     """Create a debug embed with a standard header and footer."""
     e = Embed(
         f"Naff Debug: {title}",
-        url="https://github.com/Discord-Snake-Pit/Dis-Snek/tree/master/dis_snek/ext/debug_extension",
+        url="https://github.com/Discord-Snake-Pit/NAFF/tree/master/naff/ext/debug_extension",
         color=MaterialColors.BLUE_GREY,
         **kwargs,
     )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description_content_type="text/markdown",
     author="LordOfPolls",
     author_email="lordofpolls.dev@gmail.com",
-    url="https://github.com/Discord-Snake-Pit/Dis-Snek",
+    url="https://github.com/Discord-Snake-Pit/NAFF",
     version=pyproject["tool"]["poetry"]["version"],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition
- [ ] Tests change

## Description
Just a bunch of renames that were needed with the NAFF rename.


## Changes

- ...just look in the files changed. It's mostly docs changes, though there is *one* instance where a variable was changed (a constant referencing the repo). It's too minor to really note, though.
  - `url="https://github.com/Discord-Snake-Pit/NAFF/tree/master/naff/ext/debug_extension"` is invalid, I'm aware, but it will be soon:tm:.
  - For the "Getting Started" page, I *did* attempt a pun. Not the best, I'll admit, but it's there 😅.
  - Anything referencing the PyPI package or the Discord link wasn't changed, though they probably *should* be changed soon. Let me know if you want to add that here!

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
