### PR TITLE
ci: add ok-to-test to test pytest for PRs

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,38 @@
+# Source: https://github.com/imjohnbo/ok-to-test
+
+# If someone with write access comments "/ok-to-test" on a pull request, emit a repository_dispatch event
+name: Ok To Test
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ok-to-test:
+    runs-on: ubuntu-latest
+    # Only run for PRs, not issue comments
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+    # Generate a GitHub App installation access token from an App ID and private key
+    # To create a new GitHub App:
+    #   https://developer.github.com/apps/building-github-apps/creating-a-github-app/
+    # See app.yml for an example app manifest
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        private_key: ${{ secrets.PRIVATE_KEY }}
+
+    - name: Slash Command Dispatch
+      uses: peter-evans/slash-command-dispatch@v1
+      env:
+        TOKEN: ${{ steps.generate_token.outputs.token }}
+      with:
+        token: ${{ env.TOKEN }} # GitHub App installation access token
+        # token: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # PAT or OAuth token will also work
+        reaction-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-type: pull-request
+        commands: ok-to-test
+        named-args: true
+        permission: write

--- a/.github/workflows/pytest-pr.yml
+++ b/.github/workflows/pytest-pr.yml
@@ -28,6 +28,7 @@ jobs:
           extra: ${{ matrix.extras }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
           script: |
             const { data: pull } = await github.rest.pulls.get({
               ...context.repo,
@@ -39,7 +40,7 @@ jobs:
               head_sha: ref,
               name: `${process.env.job} (${process.env.extra})`
             });
-            return result;
+            return result.id;
 
       - name: Fork based /ok-to-test checkout
         uses: actions/checkout@v2
@@ -81,6 +82,7 @@ jobs:
           number: ${{ github.event.client_payload.pull_request.number }}
           job: ${{ github.job }}
           conclusion: ${{ job.status }}
+          check_id: ${{steps.create-check-run.outputs.result}}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -89,14 +91,9 @@ jobs:
               pull_number: process.env.number
             });
             const ref = pull.head.sha;
-            const { data: checks } = await github.rest.checks.listForRef({
-              ...context.repo,
-              ref
-            });
-            const check = checks.check_runs.filter(c => c.name === `${process.env.job} (${process.env.extra})`);
             const { data: result } = await github.rest.checks.update({
               ...context.repo,
-              check_run_id: check[0].id,
+              check_run_id: process.env.check_id,
               status: 'completed',
               conclusion: process.env.conclusion
             });

--- a/.github/workflows/pytest-pr.yml
+++ b/.github/workflows/pytest-pr.yml
@@ -1,4 +1,4 @@
-name: pytest PR
+name: Pytest PR
 on:
   repository_dispatch:
     types: [ok-to-test-command]

--- a/.github/workflows/pytest-pr.yml
+++ b/.github/workflows/pytest-pr.yml
@@ -18,6 +18,29 @@ jobs:
           - .[docs]
 
     steps:
+      - name: Create check run
+        uses: actions/github-script@v5
+        id: create-check-run
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          conclusion: ${{ job.status }}
+          extra: ${{ matrix.extras }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+            const { data: result } = await github.rest.checks.create({
+              ...context.repo,
+              head_sha: ref,
+              name: `${process.env.job} (${process.env.extra})`
+            });
+            return result;
+
       - name: Fork based /ok-to-test checkout
         uses: actions/checkout@v2
         with:
@@ -43,6 +66,13 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/TestResults.xml'
+          check_name: 'Pytest Results'
+
       - name: Update check run
         uses: actions/github-script@v5
         id: update-check-run
@@ -63,7 +93,7 @@ jobs:
               ...context.repo,
               ref
             });
-            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const check = checks.check_runs.filter(c => c.name === `${process.env.job} (${process.env.extra})`);
             const { data: result } = await github.rest.checks.update({
               ...context.repo,
               check_run_id: check[0].id,
@@ -71,9 +101,3 @@ jobs:
               conclusion: process.env.conclusion
             });
             return result;
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v2
-        if: always() # always run even if the previous step fails
-        with:
-          report_paths: '**/TestResults.xml'
-          check_name: 'Pytest Results'

--- a/.github/workflows/pytest-pr.yml
+++ b/.github/workflows/pytest-pr.yml
@@ -1,0 +1,79 @@
+name: pytest PR
+on:
+  repository_dispatch:
+    types: [ok-to-test-command]
+
+jobs:
+  pytest:
+    name: runner / pytest tests
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        extras:
+          - .
+          - .[speedup]
+          - .[voice]
+          - .[all]
+          - .[docs]
+
+    steps:
+      - name: Fork based /ok-to-test checkout
+        uses: actions/checkout@v2
+        with:
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2.3.1
+        with:
+          python-version: '3.10'
+      - name: Install ffmpeg & opus
+        run: sudo apt-get install ffmpeg libopus-dev
+      - name: Install pytest
+        run: |
+          pip install -e ${{ matrix.extras }}
+          pip install pytest pytest-recording pytest-asyncio pytest-cov
+      - name: Run Tests
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          pytest
+          coverage xml -i
+      - name: Upload Coverage
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov
+      - name: Update check run
+        uses: actions/github-script@v5
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+            return result;
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/TestResults.xml'
+          check_name: 'Pytest Results'

--- a/.github/workflows/pytest-push.yml
+++ b/.github/workflows/pytest-push.yml
@@ -4,7 +4,6 @@ jobs:
   pytest:
     name: runner / pytest tests
     runs-on: ubuntu-latest
-    if: ${{ secrets.BOT_TOKEN != null }}
     strategy:
       matrix:
         extras:

--- a/.github/workflows/pytest-push.yml
+++ b/.github/workflows/pytest-push.yml
@@ -4,6 +4,7 @@ jobs:
   pytest:
     name: runner / pytest tests
     runs-on: ubuntu-latest
+    if: ${{ secrets.BOT_TOKEN != null }}
     strategy:
       matrix:
         extras:

--- a/.github/workflows/pytest-push.yml
+++ b/.github/workflows/pytest-push.yml
@@ -1,5 +1,5 @@
 name: pytest
-on: [push, pull_request]
+on: push
 jobs:
   pytest:
     name: runner / pytest tests


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
As of right now, `naff`'s checks are failing due to PRs being unable to use secrets. This is for a pretty reasonable reason - we don't want just any random code to be running a bot - but GitHub blocking it entirely is... not great.

This PR [implements /ok-to-test](https://github.com/imjohnbo/ok-to-test), which allows a contributor with write permissions to use `/ok-to-test` as a comment on a PR to, well, run the bot tests.

## Important Notes

- @LordOfPolls will *need* to pick [one of the three authentication methods here](https://github.com/imjohnbo/ok-to-test#authentication) and set it up to make this work. If he decides to not use the GitHub App way, then the PR will need to be adjusted *slightly*, though it's as simple as commenting and uncommenting things.
- This is absolutely janky. It was not nice *at all* to make this work. A side effect of this jank is the fact that the checks run with `/ok-to-test` claim they're running under a random workflow. This does not affect its functionality in the slightest.
- I *did* test this, but due to how weird it is, there's likely bugs.
- Once `dev` gets merged, the bot test will need a quick PR to be skipped if there's no token variable. I'm still merging to `master` as this whole thing doesn't work if it isn't.


## Changes

- Add an `/ok-to-test` command that can be run by collaborators in PRs. This runs the test bot.
- Separate the `pytest` workflow into a file for the PR and push events to make things easier.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code