### PR TITLE
feat: add Typing context manager

### DIFF
--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -29,6 +29,7 @@ from .enums import (
     MessageFlags,
     InviteTargetTypes,
 )
+from naff.models.misc.context_manager import Typing
 
 if TYPE_CHECKING:
     from aiohttp import FormData
@@ -421,6 +422,11 @@ class MessageableMixin(SendMixin):
     async def trigger_typing(self) -> None:
         """Trigger a typing animation in this channel."""
         await self._client.http.trigger_typing_indicator(self.id)
+
+    @property
+    def typing(self) -> Typing:
+        """A context manager to send a typing state to a given channel as long as long as the wrapped operation takes."""
+        return Typing(self)
 
 
 @define(slots=False)

--- a/naff/models/misc/__init__.py
+++ b/naff/models/misc/__init__.py
@@ -1,3 +1,4 @@
 from .iterator import AsyncIterator
+from .context_manager import Typing
 
-__all__ = ("AsyncIterator",)
+__all__ = ("AsyncIterator", "Typing")

--- a/naff/models/misc/context_manager.py
+++ b/naff/models/misc/context_manager.py
@@ -1,0 +1,31 @@
+from asyncio import sleep, Task, create_task
+
+from naff import Absent, MISSING, MessageableMixin
+
+__all__ = ("Typing",)
+
+
+class Typing:
+    """
+    A context manager to send a typing state to a given channel as long as long as the wrapped operation takes.
+
+    Args:
+        channel: The channel to send the typing state to
+    """
+
+    def __init__(self, channel: MessageableMixin) -> None:
+        self._task: Absent[Task] = MISSING
+        self.channel: MessageableMixin = channel
+        self._stop: bool = False
+
+    async def _typing_task(self) -> None:
+        while not self._stop:
+            await self.channel.trigger_typing()
+            await sleep(5)
+
+    async def __aenter__(self) -> None:
+        self.task = create_task(self._typing_task())
+
+    async def __aexit__(self, *_) -> None:
+        self._stop = True
+        self.task.cancel()

--- a/naff/models/misc/context_manager.py
+++ b/naff/models/misc/context_manager.py
@@ -1,6 +1,10 @@
 from asyncio import sleep, Task, create_task
+from typing import TYPE_CHECKING
 
-from naff import Absent, MISSING, MessageableMixin
+from naff.client.const import Absent, MISSING
+
+if TYPE_CHECKING:
+    from naff import MessageableMixin
 
 __all__ = ("Typing",)
 
@@ -13,9 +17,9 @@ class Typing:
         channel: The channel to send the typing state to
     """
 
-    def __init__(self, channel: MessageableMixin) -> None:
+    def __init__(self, channel: "MessageableMixin") -> None:
         self._task: Absent[Task] = MISSING
-        self.channel: MessageableMixin = channel
+        self.channel: "MessageableMixin" = channel
         self._stop: bool = False
 
     async def _typing_task(self) -> None:


### PR DESCRIPTION
At the request of Astrea

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
![image](https://user-images.githubusercontent.com/22540825/169396869-69d75cad-ea39-4263-a3f2-d7d9a5226cbe.png)
Adds the afforementioned typing context manager

Syntax: 
```py
channel = await self.fetch_channel(948781911948558388)

async with Typing(channel):
    await asyncio.sleep(30)
    await channel.("test")
```
Alternate syntax:
```py
channel = await self.fetch_channel(948781911948558388)

async with channel.typing:
    await asyncio.sleep(3)
    await channel.send("test")
```

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Adds `models/misc/context_manager.py`
- Adds `Typing` model
- Adds `Typing` model to root namespace
- Add `typing` property to `MessagableMixin`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
