### PR TITLE
feat: Make `Extension.name` public

### DIFF
--- a/naff/models/naff/extension.py
+++ b/naff/models/naff/extension.py
@@ -44,7 +44,7 @@ class Extension:
     """
 
     bot: "Client"
-    __name: str
+    name: str
     extension_name: str
     description: str
     extension_checks: List
@@ -58,7 +58,7 @@ class Extension:
     def __new__(cls, bot: "Client", *args, **kwargs) -> "Extension":
         new_cls = super().__new__(cls)
         new_cls.bot = bot
-        new_cls.__name = cls.__name__
+        new_cls.name = cls.__name__
         new_cls.extension_checks = []
         new_cls.extension_prerun = []
         new_cls.extension_postrun = []
@@ -129,11 +129,6 @@ class Extension:
     def listeners(self) -> List["Listener"]:
         """Get the listeners from this Extension."""
         return self._listeners
-
-    @property
-    def name(self) -> str:
-        """Get the name of this Extension."""
-        return self.__name
 
     def drop(self) -> None:
         """Called when this Extension is being removed."""


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Breaking if someone was daft enoug to be using a private attribute when public aliases exist. 

This PR makes `Extension.__name` public under `Extension.name` at the request of @Astrea49 
![image](https://user-images.githubusercontent.com/22540825/169399653-629b34a6-8d8c-4af8-84be-b1f1a545cf32.png)

As far as i can tell this breaks nothing

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Remove `Extension.name` property 
- Rename `Extension.__name` -> `Extension.name`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
