### PR TITLE
feat: add asset.as_url

### DIFF
--- a/naff/models/discord/asset.py
+++ b/naff/models/discord/asset.py
@@ -65,6 +65,9 @@ class Asset:
         """
         if not extension:
             extension = ".gif" if self.animated else ".png"
+        elif not extension.startswith("."):
+            extension = f".{extension}"
+
         return f"{self._url}{extension}?size={size}"
 
     @property

--- a/naff/models/discord/asset.py
+++ b/naff/models/discord/asset.py
@@ -52,6 +52,21 @@ class Asset:
         ext = ".gif" if self.animated else ".png"
         return f"{self._url}{ext}?size=4096"
 
+    def as_url(self, *, extension: str | None = None, size: int = 4096) -> str:
+        """
+        Get the url of this asset.
+
+        args:
+            extension: The extension to override the assets default with
+            size: The size of asset to return
+
+        returns:
+            A url for this asset with the given parameters
+        """
+        if not extension:
+            extension = ".gif" if self.animated else ".png"
+        return f"{self._url}{extension}?size={size}"
+
     @property
     def animated(self) -> bool:
         """True if this asset is animated."""


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Adds `asset.as_url` which allows the user to override the extension or size of an asset, rather than using the default `Asset.url` method.

Req by @Astrea49 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `asset.as_url` method

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
