### PR TITLE
Private channel fix

### DIFF
--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -442,8 +442,12 @@ class GlobalCache:
         channel_id = to_snowflake(channel_id)
         channel = self.channel_cache.get(channel_id)
         if channel is None:
-            data = await self._client.http.get_channel(channel_id)
-            channel = self.place_channel_data(data)
+            try:
+                data = await self._client.http.get_channel(channel_id)
+                channel = self.place_channel_data(data)
+            except Forbidden:
+                log.warning(f"Forbidden access to channel {channel_id}. Generating fallback channel object")
+                channel = BaseChannel.from_dict({"id": channel_id, "type": MISSING}, self._client)
         return channel
 
     def get_channel(self, channel_id: Optional["Snowflake_Type"]) -> Optional["TYPE_ALL_CHANNEL"]:

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -835,7 +835,10 @@ class DMChannel(BaseChannel, MessageableMixin):
     def _process_dict(cls, data: Dict[str, Any], client: "Client") -> Dict[str, Any]:
         data = super()._process_dict(data, client)
         if recipients := data.get("recipients", None):
-            data["recipients"] = [client.cache.place_user_data(recipient) for recipient in recipients]
+            data["recipients"] = [
+                client.cache.place_user_data(recipient) if isinstance(recipient, dict) else recipient
+                for recipient in recipients
+            ]
         return data
 
     @property

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -23,6 +23,7 @@ from .enums import (
     AutoArchiveDuration,
 )
 from .snowflake import to_snowflake, Snowflake_Type, to_snowflake_list, to_optional_snowflake
+from naff.models.discord.channel import BaseChannel
 
 if TYPE_CHECKING:
     from naff.client import Client
@@ -241,7 +242,14 @@ class BaseMessage(DiscordObject):
     @property
     def channel(self) -> "models.TYPE_MESSAGEABLE_CHANNEL":
         """The channel the message was sent in"""
-        return self._client.cache.get_channel(self._channel_id)
+        channel = self._client.cache.get_channel(self._channel_id)
+
+        if not self._guild_id and not channel:
+            # allow dm operations without fetching a dm channel from API
+            channel = BaseChannel.from_dict_factory({"id": self._channel_id, "type": ChannelTypes.DM}, self._client)
+            if self.author:
+                channel.recipients = [self.author]
+        return channel
 
     @property
     def thread(self) -> "models.TYPE_THREAD_CHANNEL":


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Another potential fix for the forbidden channel issue. This time its a dummy channel object. I appreciate this isnt an ideal solution, but as this dummy channel object is never cached, it won't cause future api calls to be skipped. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- On forbidden, `cache.fetch_channel` will generate a `BaseChannel` of type MISSING with only the ID field populated
- If a user needs a DM channel reference, and its not cached, a dummy DM channel object will be instantiated 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
