### PR TITLE
fix: Ensure subprocess is killed on linux

### DIFF
--- a/naff/api/voice/audio.py
+++ b/naff/api/voice/audio.py
@@ -153,6 +153,10 @@ class Audio(BaseAudio):
         while self.process:
             if self.process.poll() is not None:
                 # ffmpeg has exited, stop reading ahead
+                if not self.buffer.initialised.is_set():
+                    # assume this is a small file and initialise the buffer
+                    self.buffer.initialised.set()
+
                 return
             if not len(self.buffer) >= self._max_buffer_size:
                 self.buffer.extend(self.process.stdout.read(3840))


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
On Linux the Audio subproccess was not exiting successfully, resulting in zombie processes being left behind. This *should* resolve this, without impacting Windows. 

I also found that the `read_ahead` task was not being cancelled either, this fixes that too.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Set subprocess `stdin` to `DEVNULL`
- Check if child process is runnning in `_read_ahead`
- Add check for child process state in `cleanup`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
