### PR TITLE
feat: support nsfw field in app cmds

### DIFF
--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -965,10 +965,9 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
                 raise ValueError(f"Conflicting `default_member_permissions` values found in `{cmd_list[0].name}`")
             if not all(c.dm_permission == cmd_list[0].dm_permission for c in cmd_list):
                 raise ValueError(f"Conflicting `dm_permission` values found in `{cmd_list[0].name}`")
-            if hasattr(cmd_list[0], "nsfw"):
-                if not all(c.nsfw == nsfw for c in cmd_list):
-                    log.warning(f"Conflicting `nsfw` values found in `{cmd_list[0].name} - `True` will be used")
-                    nsfw = True
+            if not all(c.nsfw == nsfw for c in cmd_list):
+                log.warning(f"Conflicting `nsfw` values found in {cmd_list[0].name} - `True` will be used")
+                nsfw = True
 
             for cmd in cmd_list:
                 cmd.scopes = list(scopes)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Source https://github.com/discord/discord-api-docs/pull/4965

This adds support for the NSFW attribute of application commands. The functionality appears to work on desktop and browser, but not mobile. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add NSFW attribute to InteractionCommand
- Check for value conflicts for NSFW
- Check for nsfw in sync

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
