### PR TITLE
fix: properly unload prefixed commands in exts

### DIFF
--- a/naff/models/naff/extension.py
+++ b/naff/models/naff/extension.py
@@ -146,9 +146,10 @@ class Extension:
                     if self.bot.interactions.get(scope):
                         self.bot.interactions[scope].pop(func.resolved_name, [])
             elif isinstance(func, naff.PrefixedCommand):
-                self.bot.prefixed_commands.pop(func.name, None)
-                for alias in func.aliases:
-                    self.bot.prefixed_commands.pop(alias, None)
+                if not func.is_subcommand:
+                    self.bot.prefixed_commands.pop(func.name, None)
+                    for alias in func.aliases:
+                        self.bot.prefixed_commands.pop(alias, None)
         for func in self.listeners:
             self.bot.listeners[func.event].remove(func)
 

--- a/naff/models/naff/extension.py
+++ b/naff/models/naff/extension.py
@@ -146,8 +146,9 @@ class Extension:
                     if self.bot.interactions.get(scope):
                         self.bot.interactions[scope].pop(func.resolved_name, [])
             elif isinstance(func, naff.PrefixedCommand):
-                if self.bot.prefixed_commands[func.name]:
-                    self.bot.prefixed_commands.pop(func.name)
+                self.bot.prefixed_commands.pop(func.name, None)
+                for alias in func.aliases:
+                    self.bot.prefixed_commands.pop(alias, None)
         for func in self.listeners:
             self.bot.listeners[func.event].remove(func)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Just a simple bug fix involving how prefixed commands were unloaded in `Extension`s. Or, rather, how they weren't doing it correctly.


## Changes
- Replace (invalid) check if the command exists with a `pop(name, None)`, basically ignoring the command if it doesn't exist.
- Unload aliases.
- Don't mistakenly unload subcommands as top-level commands - they'll get unloaded when the top-level command gets unloaded, anyways.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
