### PR TITLE
fix: remove unnecessary Activity converter

### DIFF
--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -119,9 +119,7 @@ class User(BaseUser):
         converter=optional_c(Color),
         metadata=docs("The user's banner color"),
     )
-    activities: list[Activity] = field(
-        factory=list, converter=list_converter(optional(Activity)), metadata=docs("A list of activities the user is in")
-    )
+    activities: list[Activity] = field(factory=list, metadata=docs("A list of activities the user is in"))
     status: Absent[Status] = field(default=MISSING, metadata=docs("The user's status"), converter=optional(Status))
 
     @classmethod

--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -119,7 +119,11 @@ class User(BaseUser):
         converter=optional_c(Color),
         metadata=docs("The user's banner color"),
     )
-    activities: list[Activity] = field(factory=list, metadata=docs("A list of activities the user is in"))
+    activities: list[Activity] = field(
+        factory=list,
+        converter=list_converter(optional(Activity.from_dict)),
+        metadata=docs("A list of activities the user is in"),
+    )
     status: Absent[Status] = field(default=MISSING, metadata=docs("The user's status"), converter=optional(Status))
 
     @classmethod


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
So from what I was able to understand. It looked like we were converting an Activty object into an Activity object and it was breaking it lol. 
![image](https://user-images.githubusercontent.com/58155937/170642895-57153149-a48d-4714-ac8c-16a34f414f6e.png)
^ like this, it put all the data in the name.

So removing the converter from the user object seems to work.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Remove the broken converter from User object

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
