### PR TITLE
feat: Add delete_after field to SendMixin.send (#507)

### DIFF
--- a/naff/client/mixins/send.py
+++ b/naff/client/mixins/send.py
@@ -38,6 +38,7 @@ class SendMixin:
         tts: bool = False,
         suppress_embeds: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
+        delete_after: Optional[float] = None,
         **kwargs,
     ) -> "Message":
         """
@@ -56,6 +57,7 @@ class SendMixin:
             tts: Should this message use Text To Speech.
             suppress_embeds: Should embeds be suppressed on this send
             flags: Message flags to apply.
+            delete_after: Delete message after this many seconds.
 
         Returns:
             New message object that was sent.
@@ -85,4 +87,7 @@ class SendMixin:
 
         message_data = await self._send_http_request(message_payload, files=files or file)
         if message_data:
-            return self._client.cache.place_message_data(message_data)
+            message = self._client.cache.place_message_data(message_data)
+            if delete_after:
+                await message.delete(delay=delete_after)
+            return message

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -569,7 +569,7 @@ class Message(BaseMessage):
                 except Exception:  # noqa: S110
                     pass  # No real way to handle this
 
-            asyncio.ensure_future(delayed_delete())
+            asyncio.create_task(delayed_delete())
 
         else:
             await self._client.http.delete_message(self._channel_id, self.id)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR adds an argument to `SendMixin.send` called `delete_after`. This simply adds a feature to delete a message `delete_after` seconds after it was sent. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `delete_after` argument to `SendMixin.send`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
