### PR TITLE
feat: add RoleColors

### DIFF
--- a/naff/models/discord/color.py
+++ b/naff/models/discord/color.py
@@ -286,7 +286,7 @@ class RoleColors(Color, Enum):
 
     # a certain other lib called the yellows this
     # i honestly cannot decide if they are or not
-    # so why not satify everyone here?
+    # so why not satisfy everyone here?
     GOLD = YELLOW
     DARK_GOLD = DARK_YELLOW
 

--- a/naff/models/discord/color.py
+++ b/naff/models/discord/color.py
@@ -273,8 +273,8 @@ class RoleColors(Color, Enum):
     DARK_PURPLE = "#71368A"
     MAGENTA = "#E91E63"
     DARK_MAGENTA = "#AD1457"
-    GOLD = "#F1C40F"
-    DARK_GOLD = "#C27C0E"
+    YELLOW = "#F1C40F"
+    DARK_YELLOW = "#C27C0E"
     ORANGE = "#E67E22"
     DARK_ORANGE = "#A84300"
     RED = "#E74C3C"
@@ -283,6 +283,12 @@ class RoleColors(Color, Enum):
     LIGHT_GRAY = "#979C9F"
     DARK_GRAY = "#607D8B"
     DARKER_GRAY = "#546E7A"
+
+    # a certain other lib called the yellows this
+    # i honestly cannot decide if they are or not
+    # so why not satify everyone here?
+    GOLD = YELLOW
+    DARK_GOLD = DARK_YELLOW
 
     # aliases
     LIGHT_GREY = LIGHT_GRAY

--- a/naff/models/discord/color.py
+++ b/naff/models/discord/color.py
@@ -11,11 +11,13 @@ __all__ = (
     "BrandColors",
     "MaterialColors",
     "FlatUIColors",
+    "RoleColors",
     "process_color",
     "Colour",
     "BrandColours",
     "MaterialColours",
     "FlatUIColours",
+    "RoleColours",
     "process_colour",
 )
 
@@ -258,6 +260,37 @@ class FlatUIColors(Color, Enum):
     ASBESTOS = "#7F8C8D"
 
 
+class RoleColors(Color, Enum):
+    """A collection of the default role colors Discord provides."""
+
+    TEAL = "#1ABC9C"
+    DARK_TEAL = "#11806A"
+    GREEN = "#2ECC71"
+    DARK_GREEN = "#1F8B4C"
+    BLUE = "#3498DB"
+    DARK_BLUE = "#206694"
+    PURPLE = "#9B59B6"
+    DARK_PURPLE = "#71368A"
+    MAGENTA = "#E91E63"
+    DARK_MAGENTA = "#AD1457"
+    GOLD = "#F1C40F"
+    DARK_GOLD = "#C27C0E"
+    ORANGE = "#E67E22"
+    DARK_ORANGE = "#A84300"
+    RED = "#E74C3C"
+    DARK_RED = "#992D22"
+    LIGHTER_GRAY = "#95A5A6"
+    LIGHT_GRAY = "#979C9F"
+    DARK_GRAY = "#607D8B"
+    DARKER_GRAY = "#546E7A"
+
+    # aliases
+    LIGHT_GREY = LIGHT_GRAY
+    LIGHTER_GREY = LIGHTER_GRAY
+    DARK_GREY = DARK_GRAY
+    DARKER_GREY = DARKER_GRAY
+
+
 def process_color(color: Optional[Union[Color, dict, tuple, list, str, int]]) -> Optional[int]:
     """
     Process color to a format that can be used by discord.
@@ -286,4 +319,5 @@ Colour = Color
 BrandColours = BrandColors
 MaterialColours = MaterialColors
 FlatUIColours = FlatUIColors
+RoleColours = RoleColors
 process_colour = process_color


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This adds the default Discord role colors as a nice `Enum`. See below as a reference.

![The default role colors.](https://user-images.githubusercontent.com/25420078/172213168-99fbeb29-b245-4017-b159-d68f6b2972f2.png)


## Changes

- Add `RoleColors`.
  - These values are taken directly from inspect-elementing the colors.
  - Admittedly, I did decide to name them similarly to `discord.py` and its naming scheme, but it makes sense anyways. The only slightly controversial thing is the `YELLOW` vs. `GOLD` thing, so I decided to satisfy both sides of this possible debate.
  - Of course, aliases for the `Colour`ing were done. The `GRAY` vs. `GREY` thing is also accounted for.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
