### PR TITLE
feat: make NoArgumentConverter covariant

### DIFF
--- a/naff/models/naff/annotations/argument.py
+++ b/naff/models/naff/annotations/argument.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from naff.models import Member, User, TYPE_MESSAGEABLE_CHANNEL
 
 
-class CMD_BODY(NoArgumentConverter):
+class CMD_BODY(NoArgumentConverter[str]):
     """
     This argument is for the body of the message.
 
@@ -43,7 +43,7 @@ class CMD_CHANNEL(NoArgumentConverter):
         return context.channel
 
 
-class CMD_ARGS(NoArgumentConverter):
+class CMD_ARGS(NoArgumentConverter[list[str]]):
     """This argument is all of the arguments sent with this context."""
 
     @staticmethod

--- a/naff/models/naff/converters.py
+++ b/naff/models/naff/converters.py
@@ -71,7 +71,7 @@ __all__ = (
 )
 
 
-class NoArgumentConverter(Converter):
+class NoArgumentConverter(Converter[T_co]):
     """
     An indicator class for special type of converters that only uses the Context.
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
A simple PR to make `NoArgumentConverter` covariant (not covarient, oops 😅). This also makes some of the converters using it take advantage of that.


## Changes
- Make `NoArgumentConverter` covariant.
- Make `CMD_BODY` and `CMD_ARGS` take advantage of that fact. The other two use string annotations (there's a more formal name for them, I know), which makes things a lot trickier to do... so I decided not to do it for them.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
