### PR TITLE
fix: get guild before deleting it from cache

### DIFF
--- a/naff/api/events/processors/guild_events.py
+++ b/naff/api/events/processors/guild_events.py
@@ -69,12 +69,14 @@ class GuildEvents(EventMixinTemplate):
                 # noinspection PyProtectedMember
                 self._user._guild_ids.remove(guild_id)
 
+            # get the guild right before deleting it
+            guild = self.cache.get_guild(guild_id)
             self.cache.delete_guild(guild_id)
 
             self.dispatch(
                 events.GuildLeft(
                     guild_id,
-                    self.cache.get_guild(guild_id) or MISSING,
+                    guild or MISSING,
                 )
             )
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This fixes a *very* long lasting issue with the `GuildLeft` event not having the `guild` ever. Turns out, we were deleting it before getting it 😅.


## Changes
- Get the guild from the cache (suggesting it exists) and use that for `GuildLeft`.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
