### PR TITLE
fix: Handle tags not being sent in channel payload

### DIFF
--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -2073,7 +2073,7 @@ class GuildForum(GuildChannel):
     def _process_dict(cls, data: Dict[str, Any], client: "Client") -> Dict[str, Any]:
         data["available_tags"] = [
             ThreadTag.from_dict(tag_data | {"parent_channel_id": data["id"]}, client)
-            for tag_data in data["available_tags"]
+            for tag_data in data.get("available_tags", [])
         ]
         return data
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Discord being discord and not being consistant with their payloads. This pr handles discord not sending the `available_tags` attribute of channels.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Adds a default value for available tags if not provided

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
