### PR TITLE
feat: Add granular control to sync_interactions

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1112,14 +1112,18 @@ class Client(
                         f"{'global' if scope == GLOBAL_SCOPE else scope}"
                     )
 
-    async def synchronise_interactions(self, *, scopes: list["Snowflake_Type"] = MISSING) -> None:
+    async def synchronise_interactions(
+        self, *, scopes: list["Snowflake_Type"] = MISSING, delete_commands: Absent[bool] = MISSING
+    ) -> None:
         """
         Synchronise registered interactions with discord.
 
         Args:
             scopes: Optionally specify which scopes are to be synced
+            delete_commands: Override the client setting and delete commands
         """
         s = time.perf_counter()
+        _delete_cmds = self.del_unused_app_cmd if delete_commands is MISSING else delete_commands
         await self._cache_interactions()
 
         if scopes is not MISSING:
@@ -1160,17 +1164,17 @@ class Client(
                         # determine if the local and remote commands are out-of-sync
                         sync_needed_flag = True
                         sync_payload.append(local_cmd_json)
-                    elif not self.del_unused_app_cmd and remote_cmd_json:
+                    elif not _delete_cmds and remote_cmd_json:
                         _remote_payload = {
                             k: v for k, v in remote_cmd_json.items() if k not in ("id", "application_id", "version")
                         }
                         sync_payload.append(_remote_payload)
-                    elif self.del_unused_app_cmd:
+                    elif _delete_cmds:
                         sync_payload.append(local_cmd_json)
 
                 sync_payload = [json.loads(_dump) for _dump in {json.dumps(_cmd) for _cmd in sync_payload}]
 
-                if sync_needed_flag or (self.del_unused_app_cmd and len(sync_payload) < len(remote_commands)):
+                if sync_needed_flag or (_delete_cmds and len(sync_payload) < len(remote_commands)):
                     # synchronise commands if flag is set, or commands are to be deleted
                     log.info(f"Overwriting {cmd_scope} with {len(sync_payload)} application commands")
                     sync_response: list[dict] = await self.http.overwrite_application_commands(

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1112,12 +1112,19 @@ class Client(
                         f"{'global' if scope == GLOBAL_SCOPE else scope}"
                     )
 
-    async def synchronise_interactions(self) -> None:
-        """Synchronise registered interactions with discord."""
+    async def synchronise_interactions(self, *, scopes: list["Snowflake_Type"] = MISSING) -> None:
+        """
+        Synchronise registered interactions with discord.
+
+        Args:
+            scopes: Optionally specify which scopes are to be synced
+        """
         s = time.perf_counter()
         await self._cache_interactions()
 
-        if self.del_unused_app_cmd:
+        if scopes is not MISSING:
+            cmd_scopes = scopes
+        elif self.del_unused_app_cmd:
             # if we're deleting unused commands, we check all scopes
             cmd_scopes = [to_snowflake(g_id) for g_id in self._user._guild_ids] + [GLOBAL_SCOPE]
         else:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR allows more granular control of `client.synchronise_interactions`

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Adds `scopes` as a keyword argument
  - This allows you to override the default scopes to sync with your own
- Adds `delete_commands` as a keyword argument 
   - This allows you to overide the default command delation behaviour for this invocation
   
## Checklist
<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
