### PR TITLE
fix: add protected attribs to user.pyi

### DIFF
--- a/naff/models/discord/user.pyi
+++ b/naff/models/discord/user.pyi
@@ -13,7 +13,7 @@ from naff.models.discord.role import Role
 from naff.models.discord.snowflake import Snowflake_Type
 from naff.models.discord.timestamp import Timestamp
 from naff.models.discord.voice_state import VoiceState
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Set
 
 class _SendDMMixin(SendMixin):
     id: Snowflake_Type
@@ -52,6 +52,7 @@ class NaffUser(User):
     locale: Optional[str]
     bio: Optional[str]
     flags: UserFlags
+    _guild_ids: Set[Snowflake_Type]
     @property
     def guilds(self) -> List[Guild]: ...
     async def edit(self, username: Absent[str] = ..., avatar: Absent[UPLOADABLE_TYPE] = ...) -> None: ...
@@ -65,6 +66,8 @@ class Member(User):  # for typehinting purposes, we can lie
     pending: Optional[bool]
     guild_avatar: Asset
     communication_disabled_until: Optional[Timestamp]
+    _guild_id: Snowflake_Type
+    _role_ids: List[Snowflake_Type]
     def update_from_dict(self, data) -> None: ...
     @property
     def user(self) -> User: ...


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Just adding back some protected attributes to `user.pyi` that the generator I used ignored. While these weren't really used by a typical user, it's still useful to typehint them.


## Changes
Both of these are for `user.pyi`.
- Add `_guild_ids` to `User`. I used `Set` over `set` to keep in line with `user.py`.
- Add `_guild_id` and `_role_ids` to `Member`.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
