### PR TITLE
fix: Stop deleting empty list payloads

### DIFF
--- a/naff/api/http/http_client.py
+++ b/naff/api/http/http_client.py
@@ -210,7 +210,7 @@ class HTTPClient(
         Returns:
             Either a dictionary or multipart data form
         """
-        if not payload:
+        if payload in (None, MISSING):
             return None
 
         if isinstance(payload, dict):


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR stops the HTTPClient disgarding empty lists/dicts as payloads when passed. This broke deleting all commands in a given scope as reported by @ABaddlesmere here https://canary.discord.com/channels/870046872864165888/893158404237979688/987829287098925057

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Check if payload within `(None, MISSING)` instead of a straight boolean evaluation 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
