### PR TITLE
fix: Allow slash commands to run in DMs

### DIFF
--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -227,7 +227,7 @@ class InteractionCommand(BaseCommand):
     async def _permission_enforcer(self, ctx: "Context") -> bool:
         """A check that enforces Discord permissions."""
         # I wish this wasn't needed, but unfortunately Discord permissions cant be trusted to actually prevent usage
-        if self.dm_permission:
+        if self.dm_permission is False:
             return ctx.guild is not None
         return True
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
*sigh*


## Changes
Checks that the property that *allows* the command is False before blocking DMs, rather than checking if it was True.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
