### PR TITLE
feat: Implement CursedIntEnum

### DIFF
--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -717,7 +717,7 @@ class WebhookMixin:
 class BaseChannel(DiscordObject):
     name: Optional[str] = field(repr=True, default=None)
     """The name of the channel (1-100 characters)"""
-    type: Union[ChannelTypes, int] = field(repr=True, converter=ChannelTypes.converter)
+    type: Union[ChannelTypes, int] = field(repr=True, converter=ChannelTypes)
     """The channel topic (0-1024 characters)"""
 
     @classmethod

--- a/naff/models/discord/enums.py
+++ b/naff/models/discord/enums.py
@@ -80,10 +80,19 @@ class DiscordIntFlag(IntFlag, metaclass=DistinctFlag):
 SELF = TypeVar("SELF")
 
 
+def _log_type_mismatch(cls, value) -> None:
+    _log.error(
+        f"Class `{cls.__name__}` received an invalid and unexpected value `{value}`. Please update NAFF or report this issue on GitHub - https://github.com/NAFTeam/NAFF/issues"
+    )
+
+
 class CursedIntEnum(IntEnum):
     @classmethod
     def _missing_(cls: Type[SELF], value) -> SELF:
         """Construct a new enum item to represent this new unknown type - without losing the value"""
+        # log mismatch
+        _log_type_mismatch(cls, value)
+
         new = int.__new__(cls)
         new._name_ = f"UNKNOWN-TYPE-{value}"
         new._value_ = value

--- a/naff/models/discord/enums.py
+++ b/naff/models/discord/enums.py
@@ -77,7 +77,23 @@ class DiscordIntFlag(IntFlag, metaclass=DistinctFlag):
         yield from _decompose(self.__class__, self)[0]
 
 
-class WebSocketOPCodes(IntEnum):
+class CursedIntEnum(IntEnum):
+    @classmethod
+    def converter(cls, value) -> Enum:
+        """A converter to handle discord creating new types that the lib isn't aware of, without losing type info"""
+        try:
+            out = cls(value)
+            return out
+        except ValueError:
+            # construct a new enum item to represent this new unknown type - without losing the value
+            new = int.__new__(cls)
+            new._name_ = f"UNKNOWN-TYPE-{value}"
+            new._value_ = value
+
+            return cls._value2member_map_.setdefault(value, new)
+
+
+class WebSocketOPCodes(CursedIntEnum):
     """Codes used by the Gateway to signify events."""
 
     DISPATCH = 0
@@ -246,14 +262,14 @@ class ApplicationFlags(DiscordIntFlag):  # type: ignore
     """Application is a voice channel activity (ie YouTube Together)"""
 
 
-class TeamMembershipState(IntEnum):
+class TeamMembershipState(CursedIntEnum):
     """Status of membership in the team."""
 
     INVITED = 1
     ACCEPTED = 2
 
 
-class PremiumTypes(IntEnum):
+class PremiumTypes(CursedIntEnum):
     """Types of premium membership."""
 
     NONE = 0
@@ -264,7 +280,7 @@ class PremiumTypes(IntEnum):
     """Full Nitro membership"""
 
 
-class MessageTypes(IntEnum):
+class MessageTypes(CursedIntEnum):
     """Types of message."""
 
     DEFAULT = 0
@@ -305,7 +321,7 @@ class EmbedTypes(Enum):
     AUTOMOD_MESSAGE = "auto_moderation_message"
 
 
-class MessageActivityTypes(IntEnum):
+class MessageActivityTypes(CursedIntEnum):
     """An activity object, similar to an embed."""
 
     JOIN = 1
@@ -458,7 +474,7 @@ class Permissions(DiscordIntFlag):  # type: ignore
     ALL = AntiFlag()
 
 
-class ChannelTypes(IntEnum):
+class ChannelTypes(CursedIntEnum):
     """Types of channel."""
 
     GUILD_TEXT = 0
@@ -484,20 +500,6 @@ class ChannelTypes(IntEnum):
     GUILD_FORUM = 15
     """A Forum channel"""
 
-    @classmethod
-    def converter(cls, value) -> "ChannelTypes":
-        """A converter to handle discord creating new channel types that the lib isn't aware of, without losing type info"""
-        try:
-            out = cls(value)
-            return out
-        except ValueError:
-            # construct a new enum item to represent this new unknown type - without losing the value
-            new = int.__new__(cls)
-            new._name_ = f"UNKNOWN-TYPE-{value}"
-            new._value_ = value
-
-            return cls._value2member_map_.setdefault(value, new)
-
     @property
     def guild(self) -> bool:
         """Whether this channel is a guild channel."""
@@ -509,7 +511,7 @@ class ChannelTypes(IntEnum):
         return self.value in {2, 13}
 
 
-class ComponentTypes(IntEnum):
+class ComponentTypes(CursedIntEnum):
     """The types of components supported by discord."""
 
     ACTION_ROW = 1
@@ -522,7 +524,7 @@ class ComponentTypes(IntEnum):
     """Text input object"""
 
 
-class CommandTypes(IntEnum):
+class CommandTypes(CursedIntEnum):
     """The interaction commands supported by discord."""
 
     CHAT_INPUT = 1
@@ -533,7 +535,7 @@ class CommandTypes(IntEnum):
     """A UI-based command that shows up when you right click or tap on a message"""
 
 
-class InteractionTypes(IntEnum):
+class InteractionTypes(CursedIntEnum):
     """The type of interaction received by discord."""
 
     PING = 1
@@ -543,7 +545,7 @@ class InteractionTypes(IntEnum):
     MODAL_RESPONSE = 5
 
 
-class ButtonStyles(IntEnum):
+class ButtonStyles(CursedIntEnum):
     """The styles of buttons supported."""
 
     # Based on discord api
@@ -576,21 +578,21 @@ class MentionTypes(str, Enum):
     USERS = "users"
 
 
-class OverwriteTypes(IntEnum):
+class OverwriteTypes(CursedIntEnum):
     """Types of permission overwrite."""
 
     ROLE = 0
     MEMBER = 1
 
 
-class DefaultNotificationLevels(IntEnum):
+class DefaultNotificationLevels(CursedIntEnum):
     """Default Notification levels for dms and guilds."""
 
     ALL_MESSAGES = 0
     ONLY_MENTIONS = 1
 
 
-class ExplicitContentFilterLevels(IntEnum):
+class ExplicitContentFilterLevels(CursedIntEnum):
     """Automatic filtering of explicit content."""
 
     DISABLED = 0
@@ -598,14 +600,14 @@ class ExplicitContentFilterLevels(IntEnum):
     ALL_MEMBERS = 2
 
 
-class MFALevels(IntEnum):
+class MFALevels(CursedIntEnum):
     """Does the user use 2FA."""
 
     NONE = 0
     ELEVATED = 1
 
 
-class VerificationLevels(IntEnum):
+class VerificationLevels(CursedIntEnum):
     """Levels of verification needed by a guild."""
 
     NONE = 0
@@ -620,7 +622,7 @@ class VerificationLevels(IntEnum):
     """Must have a verified phone number on their Discord Account"""
 
 
-class NSFWLevels(IntEnum):
+class NSFWLevels(CursedIntEnum):
     """A guilds NSFW Level."""
 
     DEFAULT = 0
@@ -629,7 +631,7 @@ class NSFWLevels(IntEnum):
     AGE_RESTRICTED = 3
 
 
-class PremiumTiers(IntEnum):
+class PremiumTiers(CursedIntEnum):
     """The boost level of a server."""
 
     NONE = 0
@@ -667,14 +669,14 @@ class ChannelFlags(DiscordIntFlag):
     NONE = 0
 
 
-class VideoQualityModes(IntEnum):
+class VideoQualityModes(CursedIntEnum):
     """Video quality settings."""
 
     AUTO = 1
     FULL = 2
 
 
-class AutoArchiveDuration(IntEnum):
+class AutoArchiveDuration(CursedIntEnum):
     """Thread archive duration, in minutes."""
 
     ONE_HOUR = 60
@@ -683,7 +685,7 @@ class AutoArchiveDuration(IntEnum):
     ONE_WEEK = 10080
 
 
-class ActivityType(IntEnum):
+class ActivityType(CursedIntEnum):
     """
     The types of presence activity that can be used in presences.
 
@@ -734,28 +736,28 @@ class Status(str, Enum):
     DO_NOT_DISTURB = DND
 
 
-class StagePrivacyLevel(IntEnum):
+class StagePrivacyLevel(CursedIntEnum):
     PUBLIC = 1
     GUILD_ONLY = 2
 
 
-class IntegrationExpireBehaviour(IntEnum):
+class IntegrationExpireBehaviour(CursedIntEnum):
     REMOVE_ROLE = 0
     KICK = 1
 
 
-class InviteTargetTypes(IntEnum):
+class InviteTargetTypes(CursedIntEnum):
     STREAM = 1
     EMBEDDED_APPLICATION = 2
 
 
-class ScheduledEventPrivacyLevel(IntEnum):
+class ScheduledEventPrivacyLevel(CursedIntEnum):
     """The privacy level of the scheduled event."""
 
     GUILD_ONLY = 2
 
 
-class ScheduledEventType(IntEnum):
+class ScheduledEventType(CursedIntEnum):
     """The type of entity that the scheduled event is attached to."""
 
     STAGE_INSTANCE = 1
@@ -766,7 +768,7 @@ class ScheduledEventType(IntEnum):
     """ External URL """
 
 
-class ScheduledEventStatus(IntEnum):
+class ScheduledEventStatus(CursedIntEnum):
     """The status of the scheduled event."""
 
     SCHEDULED = 1
@@ -775,7 +777,7 @@ class ScheduledEventStatus(IntEnum):
     CANCELED = 4
 
 
-class AuditLogEventType(IntEnum):
+class AuditLogEventType(CursedIntEnum):
     """The type of audit log entry type"""
 
     GUILD_UPDATE = 1

--- a/naff/models/discord/enums.py
+++ b/naff/models/discord/enums.py
@@ -82,7 +82,7 @@ SELF = TypeVar("SELF")
 
 class CursedIntEnum(IntEnum):
     @classmethod
-    def _missing_(cls, value) -> SELF:
+    def _missing_(cls: Type[SELF], value) -> SELF:
         """Construct a new enum item to represent this new unknown type - without losing the value"""
         new = int.__new__(cls)
         new._name_ = f"UNKNOWN-TYPE-{value}"

--- a/naff/models/discord/enums.py
+++ b/naff/models/discord/enums.py
@@ -2,7 +2,7 @@ import logging
 from enum import Enum, EnumMeta, IntEnum, IntFlag, _decompose
 from functools import reduce
 from operator import or_
-from typing import Iterator, Tuple, TypeVar
+from typing import Iterator, Tuple, TypeVar, Type
 
 from naff.client.const import logger_name
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR introduces the `CursedIntEnum` i threatened to add a short while ago. This modifies `IntEnum` to allow for any value to be passed without throwing an exception. The purpose of this is to prevent bots losing functionality when discord adds or changes something.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Move `ChannelTypes` cursed converter into its own class using the `_missing_` magic method
- Make all `intEnum` classes inherit from `cursedIntEnum`
- Remove `ChannelTypes` calls for `converter`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
