### PR TITLE
feat: Prevent processors from modifying payloads

### DIFF
--- a/naff/api/gateway/gateway.py
+++ b/naff/api/gateway/gateway.py
@@ -219,8 +219,7 @@ class GatewayClient(WebsocketClient):
                 return
 
             case "GUILD_MEMBERS_CHUNK":
-                asyncio.create_task(self._process_member_chunk(data))
-                return
+                asyncio.create_task(self._process_member_chunk(data.copy()))
 
             case _:
                 # the above events are "special", and are handled by the gateway itself, the rest can be dispatched
@@ -228,14 +227,14 @@ class GatewayClient(WebsocketClient):
                 processor = self.state.client.processors.get(event_name)
                 if processor:
                     try:
-                        asyncio.create_task(processor(events.RawGatewayEvent(data, override_name=event_name)))
+                        asyncio.create_task(processor(events.RawGatewayEvent(data.copy(), override_name=event_name)))
                     except Exception as ex:
                         log.error(f"Failed to run event processor for {event_name}: {ex}")
                 else:
                     log.debug(f"No processor for `{event_name}`")
 
-        self.state.client.dispatch(events.RawGatewayEvent(data, override_name="raw_gateway_event"))
-        self.state.client.dispatch(events.RawGatewayEvent(data, override_name=f"raw_{event.lower()}"))
+        self.state.client.dispatch(events.RawGatewayEvent(data.copy(), override_name="raw_gateway_event"))
+        self.state.client.dispatch(events.RawGatewayEvent(data.copy(), override_name=f"raw_{event.lower()}"))
 
     def close(self) -> None:
         """Shutdown the websocket connection."""


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
While developing [Sentry](https://github.com/LordOfPolls/Sentry) I found that the Processors were modifying the json payloads, meaning that all subsiquent listeners would be missing data, or have modified data. This resolves this. 

This also allows hooking into the `GUILD_MEMBERS_CHUNK` event

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Dispatch a copy of the json data, rather than the original to listeners
- Remove `return` preventing listening to the `GUILD_MEMBERS_CHUNK` event

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
