### PR TITLE
Feat: Logging alternative to #547

### DIFF
--- a/docs/src/Guides/90 Example.md
+++ b/docs/src/Guides/90 Example.md
@@ -6,18 +6,15 @@
 
 import logging
 
-import naff.const
-from naff.client import Client
-from naff.models.context import ComponentContext
-from naff.models.enums import Intents
-from naff.models.events import Component
-from naff.models.listener import listen
+from naff import Client, Intents, listen
+from naff.api.events import Component
 
+# define your own logger with custom logging settings
 logging.basicConfig()
-cls_log = logging.getLogger(naff.const.logger_name)
+cls_log = logging.getLogger("MyLogger")
 cls_log.setLevel(logging.DEBUG)
 
-bot = Client(intents=Intents.DEFAULT, sync_interactions=True, asyncio_debug=True)
+bot = Client(intents=Intents.DEFAULT, sync_interactions=True, asyncio_debug=True, logger=cls_log)
 
 
 @listen()
@@ -92,8 +89,7 @@ def setup(bot):
 
 ```python
 
-from naff import slash_command, slash_option, InteractionContext, context_menu, CommandTypes, Button, ActionRow,
-    ButtonStyles, Extension
+from naff import slash_command, slash_option, InteractionContext, context_menu, CommandTypes, Button, ActionRow, ButtonStyles, Extension
 
 
 class CommandsExampleSkin(Extension):

--- a/naff/api/events/processors/_template.py
+++ b/naff/api/events/processors/_template.py
@@ -1,10 +1,9 @@
 import asyncio
 import functools
 import inspect
-import logging
 from typing import TYPE_CHECKING, Callable, Coroutine
 
-from naff.client.const import logger_name, MISSING, Absent
+from naff.client.const import Absent, MISSING
 
 from naff.models.discord.user import NaffUser
 
@@ -13,8 +12,6 @@ if TYPE_CHECKING:
     from naff.api.events.internal import BaseEvent
 
 __all__ = ("Processor", "EventMixinTemplate")
-
-log = logging.getLogger(logger_name)
 
 
 class Processor:

--- a/naff/api/events/processors/auto_mod.py
+++ b/naff/api/events/processors/auto_mod.py
@@ -1,7 +1,5 @@
-import logging
 from typing import TYPE_CHECKING
 
-from naff.client.const import logger_name
 from naff.models.discord.auto_mod import AutoModerationAction, AutoModRule
 from ._template import EventMixinTemplate, Processor
 from ... import events
@@ -10,8 +8,6 @@ if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("AutoModEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class AutoModEvents(EventMixinTemplate):

--- a/naff/api/events/processors/channel_events.py
+++ b/naff/api/events/processors/channel_events.py
@@ -1,18 +1,15 @@
 import copy
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 from naff.models.discord.invite import Invite
-from naff.client.const import MISSING, logger_name
+from naff.client.const import MISSING
 from ._template import EventMixinTemplate, Processor
 
 if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("ChannelEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class ChannelEvents(EventMixinTemplate):

--- a/naff/api/events/processors/guild_events.py
+++ b/naff/api/events/processors/guild_events.py
@@ -1,10 +1,9 @@
 import copy
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name, MISSING
+from naff.client.const import MISSING
 from ._template import EventMixinTemplate, Processor
 from naff.models import GuildIntegration, Sticker, to_snowflake
 from naff.api.events.discord import (
@@ -22,8 +21,6 @@ if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("GuildEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class GuildEvents(EventMixinTemplate):

--- a/naff/api/events/processors/member_events.py
+++ b/naff/api/events/processors/member_events.py
@@ -1,18 +1,15 @@
 import copy
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name, MISSING
+from naff.client.const import MISSING
 from ._template import EventMixinTemplate, Processor
 
 if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("MemberEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class MemberEvents(EventMixinTemplate):

--- a/naff/api/events/processors/message_events.py
+++ b/naff/api/events/processors/message_events.py
@@ -1,10 +1,9 @@
 import copy
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name
+from naff.client.const import logger
 from ._template import EventMixinTemplate, Processor
 from naff.models import to_snowflake, BaseMessage
 
@@ -12,8 +11,6 @@ if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("MessageEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class MessageEvents(EventMixinTemplate):
@@ -58,7 +55,7 @@ class MessageEvents(EventMixinTemplate):
         if not message:
             message = BaseMessage.from_dict(event.data, self)
         self.cache.delete_message(event.data["channel_id"], event.data["id"])
-        log.debug(f"Dispatching Event: {event.resolved_name}")
+        logger.debug(f"Dispatching Event: {event.resolved_name}")
         self.dispatch(events.MessageDelete(message))
 
     @Processor.define()

--- a/naff/api/events/processors/reaction_events.py
+++ b/naff/api/events/processors/reaction_events.py
@@ -1,9 +1,7 @@
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name
 from ._template import EventMixinTemplate, Processor
 from naff.models import PartialEmoji, Reaction
 
@@ -11,8 +9,6 @@ if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("ReactionEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class ReactionEvents(EventMixinTemplate):

--- a/naff/api/events/processors/role_events.py
+++ b/naff/api/events/processors/role_events.py
@@ -1,18 +1,15 @@
 import copy
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name, MISSING
+from naff.client.const import MISSING
 from ._template import EventMixinTemplate, Processor
 
 if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("RoleEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class RoleEvents(EventMixinTemplate):

--- a/naff/api/events/processors/stage_events.py
+++ b/naff/api/events/processors/stage_events.py
@@ -1,9 +1,7 @@
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name
 from ._template import EventMixinTemplate, Processor
 from naff.models import StageInstance
 
@@ -11,8 +9,6 @@ if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("StageEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class StageEvents(EventMixinTemplate):

--- a/naff/api/events/processors/thread_events.py
+++ b/naff/api/events/processors/thread_events.py
@@ -1,9 +1,7 @@
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name
 from ._template import EventMixinTemplate, Processor
 from naff.models import to_snowflake
 
@@ -11,8 +9,6 @@ if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("ThreadEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class ThreadEvents(EventMixinTemplate):

--- a/naff/api/events/processors/user_events.py
+++ b/naff/api/events/processors/user_events.py
@@ -1,8 +1,6 @@
-import logging
 from typing import Union, TYPE_CHECKING
 import naff.api.events as events
 
-from naff.client.const import logger_name
 from ._template import EventMixinTemplate, Processor
 from naff.models import User, Member, BaseChannel, Timestamp, to_snowflake, Activity
 from naff.models.discord.enums import Status
@@ -11,8 +9,6 @@ if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("UserEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class UserEvents(EventMixinTemplate):

--- a/naff/api/events/processors/voice_events.py
+++ b/naff/api/events/processors/voice_events.py
@@ -1,18 +1,14 @@
 import copy
-import logging
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
 
-from naff.client.const import logger_name
 from ._template import EventMixinTemplate, Processor
 
 if TYPE_CHECKING:
     from naff.api.events import RawGatewayEvent
 
 __all__ = ("VoiceEvents",)
-
-log = logging.getLogger(logger_name)
 
 
 class VoiceEvents(EventMixinTemplate):

--- a/naff/api/gateway/gateway.py
+++ b/naff/api/gateway/gateway.py
@@ -1,6 +1,5 @@
 """This file outlines the interaction between naff and Discord's Gateway API."""
 import asyncio
-import logging
 import sys
 import time
 import zlib
@@ -8,7 +7,7 @@ from types import TracebackType
 from typing import TypeVar, TYPE_CHECKING
 
 from naff.api import events
-from naff.client.const import logger_name
+from naff.client.const import logger
 from naff.client.utils.input_utils import OverriddenJson
 from naff.client.utils.serializer import dict_filter_none
 from naff.models.discord.enums import Status
@@ -22,8 +21,6 @@ if TYPE_CHECKING:
     from naff.models.discord.snowflake import Snowflake_Type
 
 __all__ = ("GatewayClient",)
-
-log = logging.getLogger(logger_name)
 
 
 SELF = TypeVar("SELF", bound="WebsocketClient")
@@ -184,24 +181,24 @@ class GatewayClient(WebsocketClient):
                 self.latency.append(time.perf_counter() - self._last_heartbeat)
 
                 if self._last_heartbeat != 0 and self.latency[-1] >= 15:
-                    log.warning(
+                    logger.warning(
                         f"High Latency! shard ID {self.shard[0]} heartbeat took {self.latency[-1]:.1f}s to be acknowledged!"
                     )
                 else:
-                    log.debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
+                    logger.debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
 
                 return self._acknowledged.set()
 
             case OPCODE.RECONNECT:
-                log.info("Gateway requested reconnect. Reconnecting...")
+                logger.info("Gateway requested reconnect. Reconnecting...")
                 return await self.reconnect(resume=True)
 
             case OPCODE.INVALIDATE_SESSION:
-                log.warning("Gateway has invalidated session! Reconnecting...")
+                logger.warning("Gateway has invalidated session! Reconnecting...")
                 return await self.reconnect(resume=data)
 
             case _:
-                return log.debug(f"Unhandled OPCODE: {op} = {OPCODE(op).name}")
+                return logger.debug(f"Unhandled OPCODE: {op} = {OPCODE(op).name}")
 
     async def dispatch_event(self, data, seq, event) -> None:
         match event:
@@ -209,12 +206,12 @@ class GatewayClient(WebsocketClient):
                 self._trace = data.get("_trace", [])
                 self.sequence = seq
                 self.session_id = data["session_id"]
-                log.info("Connected to gateway!")
-                log.debug(f"Session ID: {self.session_id} Trace: {self._trace}")
+                logger.info("Connected to gateway!")
+                logger.debug(f"Session ID: {self.session_id} Trace: {self._trace}")
                 return self.state.client.dispatch(events.WebsocketReady(data))
 
             case "RESUMED":
-                log.info(f"Successfully resumed connection! Session_ID: {self.session_id}")
+                logger.info(f"Successfully resumed connection! Session_ID: {self.session_id}")
                 self.state.client.dispatch(events.Resume())
                 return
 
@@ -230,9 +227,9 @@ class GatewayClient(WebsocketClient):
                     try:
                         asyncio.create_task(processor(events.RawGatewayEvent(data, override_name=event_name)))
                     except Exception as ex:
-                        log.error(f"Failed to run event processor for {event_name}: {ex}")
+                        logger.error(f"Failed to run event processor for {event_name}: {ex}")
                 else:
-                    log.debug(f"No processor for `{event_name}`")
+                    logger.debug(f"No processor for `{event_name}`")
 
         self.state.client.dispatch(events.RawGatewayEvent(data, override_name="raw_gateway_event"))
         self.state.client.dispatch(events.RawGatewayEvent(data, override_name=f"raw_{event.lower()}"))
@@ -261,7 +258,7 @@ class GatewayClient(WebsocketClient):
         serialized = OverriddenJson.dumps(payload)
         await self.ws.send_str(serialized)
 
-        log.debug(
+        logger.debug(
             f"Shard ID {self.shard[0]} has identified itself to Gateway, requesting intents: {self.state.intents}!"
         )
 
@@ -278,11 +275,11 @@ class GatewayClient(WebsocketClient):
         serialized = OverriddenJson.dumps(payload)
         await self.ws.send_str(serialized)
 
-        log.debug("Client is attempting to resume a connection")
+        logger.debug("Client is attempting to resume a connection")
 
     async def send_heartbeat(self) -> None:
         await self.send_json({"op": OPCODE.HEARTBEAT, "d": self.sequence}, True)
-        log.debug(f"❤ Shard {self.shard[0]} is sending a Heartbeat")
+        logger.debug(f"❤ Shard {self.shard[0]} is sending a Heartbeat")
 
     async def change_presence(self, activity=None, status: Status = Status.ONLINE, since=None) -> None:
         """Update the bot's presence status."""

--- a/naff/api/http/http_client.py
+++ b/naff/api/http/http_client.py
@@ -1,6 +1,5 @@
 """This file handles the interaction with discords http endpoints."""
 import asyncio
-import logging
 from typing import Any, Optional
 from urllib.parse import quote as _uriquote
 from weakref import WeakValueDictionary
@@ -29,7 +28,7 @@ from naff.client.const import (
     __py_version__,
     __repo_url__,
     __version__,
-    logger_name,
+    logger,
     MISSING,
     Absent,
     __api_version__,
@@ -42,8 +41,6 @@ from naff.models.discord.file import UPLOADABLE_TYPE
 from .route import Route
 
 __all__ = ("HTTPClient",)
-
-log = logging.getLogger(logger_name)
 
 
 class GlobalLock:
@@ -194,7 +191,7 @@ class HTTPClient(
 
         if bucket_lock.bucket_hash:
             # We only ever try and cache the bucket if the bucket hash has been set (ignores unlimited endpoints)
-            log.debug(f"Caching ingested rate limit data for: {bucket_lock.bucket_hash}")
+            logger.debug(f"Caching ingested rate limit data for: {bucket_lock.bucket_hash}")
             self._endpoints[route.rl_bucket] = bucket_lock.bucket_hash
             self.ratelimit_locks[bucket_lock.bucket_hash] = bucket_lock
 
@@ -295,7 +292,7 @@ class HTTPClient(
 
                             if result.get("global", False):
                                 # if we get a global, that's pretty bad, this would usually happen if the user is hitting the api from 2 clients sharing a token
-                                log.error(
+                                logger.error(
                                     f"Bot has exceeded global ratelimit, locking REST API for {result.get('retry_after')} seconds"
                                 )
                                 await self.global_lock.lock(float(result.get("retry_after")))
@@ -303,21 +300,21 @@ class HTTPClient(
                             else:
                                 # 429's are unfortunately unavoidable, but we can attempt to avoid them
                                 # so long as these are infrequent we're doing well
-                                log.warning(
+                                logger.warning(
                                     f"{route.endpoint} Has exceeded it's ratelimit ({lock.limit})! Reset in {lock.delta} seconds"
                                 )
                                 await lock.defer_unlock()  # lock this route and wait for unlock
                                 continue
                         elif lock.remaining == 0:
                             # Last call available in the bucket, lock until reset
-                            log.debug(
+                            logger.debug(
                                 f"{route.endpoint} Has exhausted its ratelimit ({lock.limit})! Locking route for {lock.delta} seconds"
                             )
                             await lock.blind_defer_unlock()  # lock this route, but continue processing the current response
 
                         elif response.status in {500, 502, 504}:
                             # Server issues, retry
-                            log.warning(
+                            logger.warning(
                                 f"{route.endpoint} Received {response.status}... retrying in {1 + attempt * 2} seconds"
                             )
                             await asyncio.sleep(1 + attempt * 2)
@@ -326,7 +323,7 @@ class HTTPClient(
                         if not 300 > response.status >= 200:
                             await self._raise_exception(response, route, result)
 
-                        log.debug(
+                        logger.debug(
                             f"{route.endpoint} Received {response.status} :: [{lock.remaining}/{lock.limit} calls remaining]"
                         )
                         return result
@@ -337,7 +334,7 @@ class HTTPClient(
                     raise
 
     async def _raise_exception(self, response, route, result) -> None:
-        log.error(f"{route.method}::{route.url}: {response.status}")
+        logger.error(f"{route.method}::{route.url}: {response.status}")
 
         if response.status == 403:
             raise Forbidden(response, response_data=result, route=route)
@@ -349,7 +346,7 @@ class HTTPClient(
             raise HTTPException(response, response_data=result, route=route)
 
     async def request_cdn(self, url, asset) -> bytes:
-        log.debug(f"{asset} requests {url} from CDN")
+        logger.debug(f"{asset} requests {url} from CDN")
         async with self.__session.get(url) as response:
             if response.status == 200:
                 return await response.read()

--- a/naff/api/voice/player.py
+++ b/naff/api/voice/player.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import shutil
 import threading
 from asyncio import AbstractEventLoop, run_coroutine_threadsafe
@@ -8,13 +7,11 @@ from typing import Optional, TYPE_CHECKING
 
 from naff.api.voice.audio import BaseAudio, AudioVolume
 from naff.api.voice.opus import Encoder
-from naff.client.const import logger_name
+from naff.client.const import logger
 
 if TYPE_CHECKING:
     from naff.models.naff.active_voice_state import ActiveVoiceState
 __all__ = ("Player",)
-
-log = logging.getLogger(logger_name)
 
 
 class Player(threading.Thread):
@@ -105,14 +102,14 @@ class Player(threading.Thread):
         self._stopped.clear()
 
         asyncio.run_coroutine_threadsafe(self.state.ws.speaking(True), self.loop)
-        log.debug(f"Now playing {self.current_audio!r}")
+        logger.debug(f"Now playing {self.current_audio!r}")
         start = None
 
         try:
             while not self._stop_event.is_set():
                 if not self.state.ws.ready.is_set() or not self._resume.is_set():
                     run_coroutine_threadsafe(self.state.ws.speaking(False), self.loop)
-                    log.debug("Voice playback has been suspended!")
+                    logger.debug("Voice playback has been suspended!")
 
                     wait_for = []
 
@@ -128,7 +125,7 @@ class Player(threading.Thread):
                         continue
 
                     run_coroutine_threadsafe(self.state.ws.speaking(), self.loop)
-                    log.debug("Voice playback has been resumed!")
+                    logger.debug("Voice playback has been resumed!")
                     start = None
                     loops = 0
 

--- a/naff/api/voice/voice_gateway.py
+++ b/naff/api/voice/voice_gateway.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import random
 import socket
 import struct
@@ -11,13 +10,11 @@ from aiohttp import WSMsgType
 
 from naff.api.gateway.websocket import WebsocketClient
 from naff.api.voice.encryption import Encryption
-from naff.client.const import logger_name
+from naff.client.const import logger
 from naff.client.errors import VoiceWebSocketClosed
 from naff.client.utils.input_utils import OverriddenJson
 
 __all__ = ("VoiceGateway",)
-
-log = logging.getLogger(logger_name)
 
 
 class OP(IntEnum):
@@ -109,7 +106,7 @@ class VoiceGateway(WebsocketClient):
             resp = await self.ws.receive()
 
             if resp.type == WSMsgType.CLOSE:
-                log.debug(f"Disconnecting from voice gateway! Reason: {resp.data}::{resp.extra}")
+                logger.debug(f"Disconnecting from voice gateway! Reason: {resp.data}::{resp.extra}")
                 if resp.data in (4006, 4009, 4014, 4015):
                     # these are all recoverable close codes, anything else means we're foobared
                     # codes: session expired, session timeout, disconnected, server crash
@@ -162,7 +159,7 @@ class VoiceGateway(WebsocketClient):
             try:
                 msg = OverriddenJson.loads(msg)
             except Exception as e:
-                log.error(e)
+                logger.error(e)
 
             return msg
 
@@ -172,26 +169,26 @@ class VoiceGateway(WebsocketClient):
                 self.latency.append(time.perf_counter() - self._last_heartbeat)
 
                 if self._last_heartbeat != 0 and self.latency[-1] >= 15:
-                    log.warning(f"High Latency! Voice heartbeat took {self.latency[-1]:.1f}s to be acknowledged!")
+                    logger.warning(f"High Latency! Voice heartbeat took {self.latency[-1]:.1f}s to be acknowledged!")
                 else:
-                    log.debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
+                    logger.debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
 
                 return self._acknowledged.set()
 
             case OP.READY:
-                log.debug("Discord send VC Ready! Establishing a socket connection...")
+                logger.debug("Discord send VC Ready! Establishing a socket connection...")
                 self.voice_ip = data["ip"]
                 self.voice_port = data["port"]
                 self.ssrc = data["ssrc"]
                 self.voice_modes = [mode for mode in data["modes"] if mode in Encryption.SUPPORTED]
 
                 if len(self.voice_modes) == 0:
-                    log.critical("NO VOICE ENCRYPTION MODES SHARED WITH GATEWAY!")
+                    logger.critical("NO VOICE ENCRYPTION MODES SHARED WITH GATEWAY!")
 
                 await self.establish_voice_socket()
 
             case OP.SESSION_DESCRIPTION:
-                log.info(f"Voice connection established; using {data['mode']}")
+                logger.info(f"Voice connection established; using {data['mode']}")
                 self.encryptor = Encryption(data["secret_key"])
                 self.ready.set()
                 if self.cond:
@@ -199,7 +196,7 @@ class VoiceGateway(WebsocketClient):
                         self.cond.notify()
 
             case _:
-                return log.debug(f"Unhandled OPCODE: {op} = {data = }")
+                return logger.debug(f"Unhandled OPCODE: {op} = {data = }")
 
     async def reconnect(self, *, resume: bool = False, code: int = 1012) -> None:
         async with self._race_lock:
@@ -211,13 +208,13 @@ class VoiceGateway(WebsocketClient):
             self.ws = None
 
             if not resume:
-                log.debug("Waiting for updated server information...")
+                logger.debug("Waiting for updated server information...")
                 try:
                     await asyncio.wait_for(self._voice_server_update.wait(), timeout=5)
                 except asyncio.TimeoutError:
                     self._kill_bee_gees.set()
                     self.close()
-                    log.debug("Terminating VoiceGateway due to disconnection")
+                    logger.debug("Terminating VoiceGateway due to disconnection")
                     return
 
                 self._voice_server_update.clear()
@@ -251,7 +248,7 @@ class VoiceGateway(WebsocketClient):
 
     async def establish_voice_socket(self) -> None:
         """Establish the socket connection to discord"""
-        log.debug("IP Discovery in progress...")
+        logger.debug("IP Discovery in progress...")
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.socket.setblocking(False)
@@ -263,14 +260,14 @@ class VoiceGateway(WebsocketClient):
 
         self.socket.sendto(packet, (self.voice_ip, self.voice_port))
         resp = await self.loop.sock_recv(self.socket, 70)
-        log.debug(f"Voice Initial Response Received: {resp}")
+        logger.debug(f"Voice Initial Response Received: {resp}")
 
         ip_start = 4
         ip_end = resp.index(0, ip_start)
         self.me_ip = resp[ip_start:ip_end].decode("ascii")
 
         self.me_port = struct.unpack_from(">H", resp, len(resp) - 2)[0]
-        log.debug(f"IP Discovered: {self.me_ip} #{self.me_port}")
+        logger.debug(f"IP Discovered: {self.me_ip} #{self.me_port}")
 
         await self._select_protocol()
 
@@ -304,7 +301,7 @@ class VoiceGateway(WebsocketClient):
 
     async def send_heartbeat(self) -> None:
         await self.send_json({"op": OP.HEARTBEAT, "d": random.uniform(0.0, 1.0)})
-        log.debug("❤ Voice Connection is sending Heartbeat")
+        logger.debug("❤ Voice Connection is sending Heartbeat")
 
     async def _identify(self) -> None:
         """Send an identify payload to the voice gateway."""
@@ -320,7 +317,7 @@ class VoiceGateway(WebsocketClient):
         serialized = OverriddenJson.dumps(payload)
         await self.ws.send_str(serialized)
 
-        log.debug("Voice Connection has identified itself to Voice Gateway")
+        logger.debug("Voice Connection has identified itself to Voice Gateway")
 
     async def _select_protocol(self) -> None:
         """Inform Discord of our chosen protocol."""

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -153,7 +153,7 @@ class Client(
         total_shards: int: The total number of shards in use
         shard_id: int: The zero based int ID of this shard
 
-        logger: logging.Logger: The logger NAFF should use
+        logger: logging.Logger: The logger NAFF should use. Note: Different loggers with multiple clients are not supported
         debug_scope: Snowflake_Type: Force all application commands to be registered within this scope
         asyncio_debug: bool: Enable asyncio debug features
 
@@ -197,7 +197,7 @@ class Client(
 
         # Set Up logger and overwrite the constant
         self.logger = logger
-        """The logger NAFF should use"""
+        """The logger NAFF should use. Note: Different loggers with multiple clients are not supported"""
         constants.logger = logger
 
         # Configuration

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -32,6 +32,7 @@ from discord_typings.interactions.receiving import (
 )
 
 import naff.api.events as events
+import naff.client.const as constants
 from naff.api.events import RawGatewayEvent, MessageCreate
 from naff.api.events import processors
 from naff.api.events.internal import Component, BaseEvent
@@ -39,7 +40,7 @@ from naff.api.gateway.gateway import GatewayClient
 from naff.api.gateway.state import ConnectionState
 from naff.api.http.http_client import HTTPClient
 from naff.client import errors
-from naff.client.const import logger_name, GLOBAL_SCOPE, MISSING, MENTION_PREFIX, Absent, EMBED_MAX_DESC_LENGTH
+from naff.client.const import GLOBAL_SCOPE, MISSING, MENTION_PREFIX, Absent, EMBED_MAX_DESC_LENGTH, logger
 from naff.client.errors import (
     BotException,
     ExtensionLoadException,
@@ -102,7 +103,6 @@ from naff.models.naff.tasks import Task
 if TYPE_CHECKING:
     from naff.models import Snowflake_Type, TYPE_ALL_CHANNEL
 
-log = logging.getLogger(logger_name)
 
 __all__ = ("Client",)
 
@@ -153,6 +153,7 @@ class Client(
         total_shards: int: The total number of shards in use
         shard_id: int: The zero based int ID of this shard
 
+        logger: logging.Logger: The logger NAFF should use
         debug_scope: Snowflake_Type: Force all application commands to be registered within this scope
         asyncio_debug: bool: Enable asyncio debug features
 
@@ -182,6 +183,7 @@ class Client(
         global_pre_run_callback: Absent[Callable[..., Coroutine]] = MISSING,
         intents: Union[int, Intents] = Intents.DEFAULT,
         interaction_context: Type[InteractionContext] = InteractionContext,
+        logger: logging.Logger = logger,
         modal_context: Type[ModalContext] = ModalContext,
         prefixed_context: Type[PrefixedContext] = PrefixedContext,
         send_command_tracebacks: bool = True,
@@ -193,8 +195,12 @@ class Client(
         **kwargs,
     ) -> None:
 
-        # Configuration
+        # Set Up logger and overwrite the constant
+        self.logger = logger
+        """The logger NAFF should use"""
+        constants.logger = logger
 
+        # Configuration
         self.sync_interactions = sync_interactions
         """Should application commands be synced"""
         self.del_unused_app_cmd: bool = delete_unused_application_cmds
@@ -392,7 +398,7 @@ class Client(
 
     def _sanity_check(self) -> None:
         """Checks for possible and common errors in the bot's configuration."""
-        log.debug("Running client sanity checks...")
+        self.logger.debug("Running client sanity checks...")
         contexts = {
             self.interaction_context: InteractionContext,
             self.prefixed_context: PrefixedContext,
@@ -405,20 +411,20 @@ class Client(
                 raise TypeError(f"{obj.__name__} must inherit from {expected.__name__}")
 
         if self.del_unused_app_cmd:
-            log.warning(
+            self.logger.warning(
                 "As `delete_unused_application_cmds` is enabled, the client must cache all guilds app-commands, this could take a while."
             )
 
         if Intents.GUILDS not in self._connection_state.intents:
-            log.warning("GUILD intent has not been enabled; this is very likely to cause errors")
+            self.logger.warning("GUILD intent has not been enabled; this is very likely to cause errors")
 
         if self.fetch_members and Intents.GUILD_MEMBERS not in self._connection_state.intents:
             raise BotException("Members Intent must be enabled in order to use fetch members")
         elif self.fetch_members:
-            log.warning("fetch_members enabled; startup will be delayed")
+            self.logger.warning("fetch_members enabled; startup will be delayed")
 
         if len(self.processors) == 0:
-            log.warning("No Processors are loaded! This means no events will be processed!")
+            self.logger.warning("No Processors are loaded! This means no events will be processed!")
 
     async def generate_prefixes(self, bot: "Client", message: Message) -> str | Iterable[str]:
         """
@@ -474,7 +480,7 @@ class Client(
             except Exception:  # noqa : S110
                 pass
 
-        log.error(
+        logger.error(
             "Ignoring exception in {}:{}{}".format(source, "\n" if len(out) > 1 else " ", "".join(out)),
         )
 
@@ -552,7 +558,7 @@ class Client(
             symbol = "/"
         else:
             symbol = "?"  # likely custom context
-        log.info(f"Command Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
+        self.logger.info(f"Command Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     async def on_component_error(self, ctx: ComponentContext, error: Exception, *args, **kwargs) -> None:
         """
@@ -576,7 +582,7 @@ class Client(
 
         """
         symbol = "¢"
-        log.info(f"Component Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
+        self.logger.info(f"Component Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     async def on_autocomplete_error(self, ctx: AutocompleteContext, error: Exception, *args, **kwargs) -> None:
         """
@@ -605,7 +611,7 @@ class Client(
 
         """
         symbol = "$"
-        log.info(f"Autocomplete Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
+        self.logger.info(f"Autocomplete Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     @Listener.create()
     async def on_resume(self) -> None:
@@ -631,11 +637,11 @@ class Client(
                     # ensure all guilds have completed chunking
                     for guild in self.guilds:
                         if guild and not guild.chunked.is_set():
-                            log.debug(f"Waiting for {guild.id} to chunk")
+                            self.logger.debug(f"Waiting for {guild.id} to chunk")
                             await guild.chunked.wait()
 
             except asyncio.TimeoutError:
-                log.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
+                self.logger.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
                 break
             self._guild_event.clear()
 
@@ -676,7 +682,7 @@ class Client(
         # so im gathering commands here
         self._gather_commands()
 
-        log.debug("Attempting to login")
+        self.logger.debug("Attempting to login")
         me = await self.http.login(token.strip())
         self._user = NaffUser.from_dict(me, self)
         self.cache.place_user_data(me)
@@ -727,7 +733,7 @@ class Client(
 
     async def stop(self) -> None:
         """Shutdown the bot."""
-        log.debug("Stopping the bot.")
+        self.logger.debug("Stopping the bot.")
         self._ready.clear()
         await self.http.close()
         await self._connection_state.stop()
@@ -742,7 +748,7 @@ class Client(
         """
         listeners = self.listeners.get(event.resolved_name, [])
         if listeners:
-            log.debug(f"Dispatching Event: {event.resolved_name}")
+            self.logger.debug(f"Dispatching Event: {event.resolved_name}")
             event.bot = self
             for _listen in listeners:
                 try:
@@ -1031,7 +1037,7 @@ class Client(
                 elif isinstance(func, Listener):
                     self.add_listener(func)
 
-            log.debug(f"{len(_cmds)} commands have been loaded from `__main__` and `client`")
+            self.logger.debug(f"{len(_cmds)} commands have been loaded from `__main__` and `client`")
 
         process(
             [obj for _, obj in inspect.getmembers(sys.modules["__main__"]) if isinstance(obj, (BaseCommand, Listener))]
@@ -1084,7 +1090,7 @@ class Client(
 
         for scope, remote_cmds in results.items():
             if remote_cmds == MISSING:
-                log.debug(f"Bot was not invited to guild {scope} with `application.commands` scope")
+                self.logger.debug(f"Bot was not invited to guild {scope} with `application.commands` scope")
                 continue
 
             remote_cmds = {cmd_data["name"]: cmd_data for cmd_data in remote_cmds}
@@ -1096,7 +1102,7 @@ class Client(
                     if cmd_data is MISSING:
                         if cmd_name not in found:
                             if warn_missing:
-                                log.error(
+                                self.logger.error(
                                     f'Detected yet to sync slash command "/{cmd_name}" for scope '
                                     f"{'global' if scope == GLOBAL_SCOPE else scope}"
                                 )
@@ -1108,7 +1114,7 @@ class Client(
 
             if warn_missing:
                 for cmd_data in remote_cmds.values():
-                    log.error(
+                    self.logger.error(
                         f"Detected unimplemented slash command \"/{cmd_data['name']}\" for scope "
                         f"{'global' if scope == GLOBAL_SCOPE else scope}"
                     )
@@ -1147,7 +1153,7 @@ class Client(
                 try:
                     remote_commands = await self.http.get_application_commands(self.app.id, cmd_scope)
                 except Forbidden:
-                    log.warning(f"Bot is lacking `application.commands` scope in {cmd_scope}!")
+                    self.logger.warning(f"Bot is lacking `application.commands` scope in {cmd_scope}!")
                     return
 
                 for local_cmd in self.interactions.get(cmd_scope, {}).values():
@@ -1177,13 +1183,13 @@ class Client(
 
                 if sync_needed_flag or (_delete_cmds and len(sync_payload) < len(remote_commands)):
                     # synchronise commands if flag is set, or commands are to be deleted
-                    log.info(f"Overwriting {cmd_scope} with {len(sync_payload)} application commands")
+                    self.logger.info(f"Overwriting {cmd_scope} with {len(sync_payload)} application commands")
                     sync_response: list[dict] = await self.http.overwrite_application_commands(
                         self.app.id, sync_payload, cmd_scope
                     )
                     self._cache_sync_response(sync_response, cmd_scope)
                 else:
-                    log.debug(f"{cmd_scope} is already up-to-date with {len(remote_commands)} commands.")
+                    self.logger.debug(f"{cmd_scope} is already up-to-date with {len(remote_commands)} commands.")
 
             except Forbidden as e:
                 raise InteractionMissingAccess(cmd_scope) from e
@@ -1193,7 +1199,7 @@ class Client(
         await asyncio.gather(*[sync_scope(scope) for scope in cmd_scopes])
 
         t = time.perf_counter() - s
-        log.debug(f"Sync of {len(cmd_scopes)} scopes took {t} seconds")
+        self.logger.debug(f"Sync of {len(cmd_scopes)} scopes took {t} seconds")
 
     def get_application_cmd_by_id(self, cmd_id: "Snowflake_Type") -> Optional[InteractionCommand]:
         """
@@ -1223,9 +1229,9 @@ class Client(
                     output = e.search_for_message(e.errors[cmd_num], cmd)
                     if len(output) > 1:
                         output = "\n".join(output)
-                        log.error(f"Multiple Errors found in command `{cmd['name']}`:\n{output}")
+                        logger.error(f"Multiple Errors found in command `{cmd['name']}`:\n{output}")
                     else:
-                        log.error(f"Error in command `{cmd['name']}`: {output[0]}")
+                        logger.error(f"Error in command `{cmd['name']}`: {output[0]}")
             else:
                 raise e from None
         except Exception:
@@ -1363,7 +1369,7 @@ class Client(
                 ctx = await self.get_context(interaction_data, True)
 
                 ctx.command: SlashCommand = self.interactions[scope][ctx.invoke_target]  # type: ignore
-                log.debug(f"{scope} :: {ctx.command.name} should be called")
+                self.logger.debug(f"{scope} :: {ctx.command.name} should be called")
 
                 if ctx.command.auto_defer:
                     auto_defer = ctx.command.auto_defer
@@ -1392,7 +1398,7 @@ class Client(
                     finally:
                         await self.on_command(ctx)
             else:
-                log.error(f"Unknown cmd_id received:: {interaction_id} ({name})")
+                self.logger.error(f"Unknown cmd_id received:: {interaction_id} ({name})")
 
         elif interaction_data["type"] == InteractionTypes.MESSAGE_COMPONENT:
             # Buttons, Selects, ContextMenu::Message
@@ -1588,7 +1594,7 @@ class Client(
             raise ExtensionLoadException(f"Unexpected Error loading {name}") from e
 
         else:
-            log.debug(f"Loaded Extension: {name}")
+            self.logger.debug(f"Loaded Extension: {name}")
             self.__modules[name] = module
 
             if self.sync_ext and self._ready.is_set():
@@ -1651,7 +1657,7 @@ class Client(
         module = self.__modules.get(name)
 
         if module is None:
-            log.warning("Attempted to reload extension thats not loaded. Loading extension instead")
+            self.logger.warning("Attempted to reload extension thats not loaded. Loading extension instead")
             return self.load_extension(name, package)
 
         if not load_kwargs:

--- a/naff/client/const.py
+++ b/naff/client/const.py
@@ -5,7 +5,7 @@ Attributes:
     __version__ str: The version of the library.
     __repo_url__ str: The URL of the repository.
     __py_version__ str: The python version in use.
-    logger logging.Logger: The logger name used by NAFF. Updates from the default logger if a custom logger is passed to `Client`.
+    logger logging.Logger: The logger used throughout NAFF. If a custom logger is passed to `Client`, this obj is replaced with the new logger.
     kwarg_spam bool: Should ``unused kwargs`` be logged.
 
     ACTION_ROW_MAX_ITEMS int: The maximum number of items in an action row.

--- a/naff/client/const.py
+++ b/naff/client/const.py
@@ -5,6 +5,7 @@ Attributes:
     __version__ str: The version of the library.
     __repo_url__ str: The URL of the repository.
     __py_version__ str: The python version in use.
+    logger_name str: The name of NAFFs default logger. Invalid if a custom logger is passed to `Client` to replace the default logger.
     logger logging.Logger: The logger used throughout NAFF. If a custom logger is passed to `Client`, this obj is replaced with the new logger.
     kwarg_spam bool: Should ``unused kwargs`` be logged.
 
@@ -45,6 +46,7 @@ __all__ = (
     "__py_version__",
     "__api_version__",
     "logger",
+    "logger_name",
     "kwarg_spam",
     "DISCORD_EPOCH",
     "ACTION_ROW_MAX_ITEMS",
@@ -83,7 +85,8 @@ except Exception:
 __repo_url__ = "https://github.com/Discord-Snake-Pit/NAFF"
 __py_version__ = f"{_ver_info[0]}.{_ver_info[1]}"
 __api_version__ = 10
-logger = logging.getLogger("dis.naff")
+logger_name = "dis.naff"
+logger = logging.getLogger(logger_name)
 default_locale = "english_us"
 kwarg_spam = False
 

--- a/naff/client/const.py
+++ b/naff/client/const.py
@@ -5,7 +5,7 @@ Attributes:
     __version__ str: The version of the library.
     __repo_url__ str: The URL of the repository.
     __py_version__ str: The python version in use.
-    logger_name str: The logger name used by NAFF.
+    logger logging.Logger: The logger name used by NAFF. Updates from the default logger if a custom logger is passed to `Client`.
     kwarg_spam bool: Should ``unused kwargs`` be logged.
 
     ACTION_ROW_MAX_ITEMS int: The maximum number of items in an action row.
@@ -33,6 +33,7 @@ Attributes:
 
 """
 import inspect
+import logging
 import sys
 from collections import defaultdict
 from importlib.metadata import version as _v
@@ -43,7 +44,7 @@ __all__ = (
     "__repo_url__",
     "__py_version__",
     "__api_version__",
-    "logger_name",
+    "logger",
     "kwarg_spam",
     "DISCORD_EPOCH",
     "ACTION_ROW_MAX_ITEMS",
@@ -82,7 +83,7 @@ except Exception:
 __repo_url__ = "https://github.com/Discord-Snake-Pit/NAFF"
 __py_version__ = f"{_ver_info[0]}.{_ver_info[1]}"
 __api_version__ = 10
-logger_name = "dis.naff"
+logger = logging.getLogger("dis.naff")
 default_locale = "english_us"
 kwarg_spam = False
 

--- a/naff/client/mixins/serialization.py
+++ b/naff/client/mixins/serialization.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict, List, Type
 
 import attrs
@@ -8,8 +7,6 @@ from naff.client.utils.attr_utils import define
 import naff.client.utils.serializer as serializer
 
 __all__ = ("DictSerializationMixin",)
-
-log = logging.getLogger(const.logger_name)
 
 
 @define(slots=False)
@@ -33,7 +30,7 @@ class DictSerializationMixin:
     def _filter_kwargs(cls, kwargs_dict: dict, keys: frozenset) -> dict:
         if const.kwarg_spam:
             unused = {k: v for k, v in kwargs_dict.items() if k not in keys}
-            log.debug(f"Unused kwargs: {cls.__name__}: {unused}")  # for debug
+            const.logger.debug(f"Unused kwargs: {cls.__name__}: {unused}")  # for debug
         return {k: v for k, v in kwargs_dict.items() if k in keys}
 
     @classmethod

--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -1,10 +1,9 @@
-import logging
 from contextlib import suppress
 from typing import TYPE_CHECKING, List, Dict, Any, Optional, Union
 
 import discord_typings
 
-from naff.client.const import MISSING, logger_name, Absent
+from naff.client.const import MISSING, logger, Absent
 from naff.client.errors import NotFound, Forbidden
 from naff.client.utils.attr_utils import define, field
 from naff.client.utils.cache import TTLCache
@@ -25,8 +24,6 @@ if TYPE_CHECKING:
     from naff.client import Client
     from naff.models.discord.channel import DM, TYPE_ALL_CHANNEL
     from naff.models.discord.snowflake import Snowflake_Type
-
-log = logging.getLogger(logger_name)
 
 
 def create_cache(
@@ -80,7 +77,7 @@ class GlobalCache:
 
     def __attrs_post_init__(self) -> None:
         if not isinstance(self.message_cache, TTLCache):
-            log.warning(
+            logger.warning(
                 "Disabling cache limits for message_cache is not recommended! This can result in very high memory usage"
             )
 
@@ -446,7 +443,7 @@ class GlobalCache:
                 data = await self._client.http.get_channel(channel_id)
                 channel = self.place_channel_data(data)
             except Forbidden:
-                log.warning(f"Forbidden access to channel {channel_id}. Generating fallback channel object")
+                logger.warning(f"Forbidden access to channel {channel_id}. Generating fallback channel object")
                 channel = BaseChannel.from_dict({"id": channel_id, "type": MISSING}, self._client)
         return channel
 

--- a/naff/client/utils/attr_utils.py
+++ b/naff/client/utils/attr_utils.py
@@ -1,15 +1,13 @@
-import logging
 from functools import partial
 from typing import Any, Dict, Callable
 
 import attrs
 from attr import Attribute
 
-from naff.client.const import MISSING, logger_name
+from naff.client.const import MISSING, logger
 
 __all__ = ("define", "field", "docs", "str_validator")
 
-log = logging.getLogger(logger_name)
 
 class_defaults = {
     "eq": False,
@@ -44,7 +42,7 @@ def str_validator(self, attribute: attrs.Attribute, value: Any) -> None:
         if value is MISSING:
             return
         setattr(self, attribute.name, str(value))
-        log.warning(
+        logger.warning(
             f"Value of {attribute.name} has been automatically converted to a string. Please use strings in future.\n"
             "Note: Discord will always return value as a string"
         )

--- a/naff/client/utils/deserialise_app_cmds.py
+++ b/naff/client/utils/deserialise_app_cmds.py
@@ -12,7 +12,7 @@ __all__ = ("deserialize_app_cmds",)
 
 def deserialize_app_cmds(data: list[dict]) -> list["InteractionCommand"]:
     """
-    Deserializes the application_commands field of the audit log.
+    Deserializes the application_commands field of the audit logger.
 
     Args:
         data: The application commands data

--- a/naff/client/utils/deserialise_app_cmds.py
+++ b/naff/client/utils/deserialise_app_cmds.py
@@ -12,7 +12,7 @@ __all__ = ("deserialize_app_cmds",)
 
 def deserialize_app_cmds(data: list[dict]) -> list["InteractionCommand"]:
     """
-    Deserializes the application_commands field of the audit logger.
+    Deserializes the application_commands field of the audit log.
 
     Args:
         data: The application commands data

--- a/naff/client/utils/input_utils.py
+++ b/naff/client/utils/input_utils.py
@@ -1,19 +1,17 @@
-import logging
 import re
 from typing import Any, Dict, Union, Optional
 
 import aiohttp  # type: ignore
 
-from naff.client.const import logger_name
+
+from naff.client.const import logger
 
 __all__ = ("OverriddenJson", "response_decode", "get_args", "get_first_word")
-
-log = logging.getLogger(logger_name)
 
 try:
     import orjson as json
 except ImportError:
-    log.warning("orjson not installed, built-in json library will be used")
+    logger.warning("orjson not installed, built-in json library will be used")
     import json
 
 

--- a/naff/ext/debug_extension/__init__.py
+++ b/naff/ext/debug_extension/__init__.py
@@ -2,7 +2,7 @@ import logging
 import platform
 
 from naff import Client, Extension, listen, slash_command, InteractionContext, Timestamp, TimestampStyles, Intents
-from naff.client.const import logger_name, __version__, __py_version__
+from naff.client.const import logger, __version__, __py_version__
 from naff.models.naff import checks
 from .debug_application_cmd import DebugAppCMD
 from .debug_exec import DebugExec
@@ -11,21 +11,19 @@ from .utils import get_cache_state, debug_embed, strf_delta
 
 __all__ = ("DebugExtension",)
 
-log = logging.getLogger(logger_name)
-
 
 class DebugExtension(DebugExec, DebugAppCMD, DebugExts, Extension):
     def __init__(self, bot: Client) -> None:
         super().__init__(bot)
         self.add_ext_check(checks.is_owner())
 
-        log.info("Debug Extension is growing!")
+        logger.info("Debug Extension is growing!")
 
     @listen()
     async def on_startup(self) -> None:
-        log.info(f"Started {self.bot.user.tag} [{self.bot.user.id}] in Debug Mode")
+        logger.info(f"Started {self.bot.user.tag} [{self.bot.user.id}] in Debug Mode")
 
-        log.info(f"Caching System State: \n{get_cache_state(self.bot)}")
+        logger.info(f"Caching System State: \n{get_cache_state(self.bot)}")
 
     @slash_command(
         "debug",

--- a/naff/ext/prefixed_help.py
+++ b/naff/ext/prefixed_help.py
@@ -1,10 +1,9 @@
 import functools
-import logging
 from typing import TYPE_CHECKING
 
 import attrs
 from naff import Embed
-from naff.client.const import logger_name
+from naff.client.const import logger
 from naff.ext.paginators import Paginator
 from naff.models.discord.color import BrandColors, Color
 from naff.models.naff.context import PrefixedContext
@@ -14,8 +13,6 @@ if TYPE_CHECKING:
     from naff.client import Client
 
 __all__ = ("PrefixedHelpCommand",)
-
-log = logging.getLogger(logger_name)
 
 
 @attrs.define(slots=True)
@@ -65,7 +62,7 @@ class PrefixedHelpCommand:
 
         # replace existing help command if found
         if "help" in self.client.prefixed_commands:
-            log.warning("Replacing existing help command.")
+            logger.warning("Replacing existing help command.")
             del self.client.prefixed_commands["help"]
 
         self.client.add_prefixed_command(self._cmd)  # type: ignore

--- a/naff/models/discord/auto_mod.py
+++ b/naff/models/discord/auto_mod.py
@@ -1,9 +1,8 @@
-import logging
 from typing import TYPE_CHECKING, Union, Any
 
 import attrs
 
-from naff.client.const import logger_name, MISSING, Absent
+from naff.client.const import logger, MISSING, Absent
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils import list_converter, optional
 from naff.client.utils.attr_utils import define, field, docs
@@ -23,8 +22,6 @@ if TYPE_CHECKING:
 
 __all__ = ("AutoModerationAction", "AutoModRule")
 
-log = logging.getLogger(logger_name)
-
 
 @define()
 class BaseAction(DictSerializationMixin):
@@ -40,7 +37,7 @@ class BaseAction(DictSerializationMixin):
     def from_dict_factory(cls, data: dict) -> "BaseAction":
         action_class = ACTION_MAPPING.get(data.get("type"))
         if not action_class:
-            log.error(f"Unknown action type for {data}")
+            logger.error(f"Unknown action type for {data}")
             action_class = cls
 
         return action_class.from_dict({"type": data.get("type")} | data["metadata"])
@@ -76,7 +73,7 @@ class BaseTrigger(DictSerializationMixin):
         trigger_class = TRIGGER_MAPPING.get(data.get("trigger_type"))
         meta = data.get("trigger_metadata", {})
         if not trigger_class:
-            log.error(f"Unknown trigger type for {data}")
+            logger.error(f"Unknown trigger type for {data}")
             trigger_class = cls
 
         payload = {"type": data.get("trigger_type"), "trigger_metadata": meta}

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from collections import namedtuple
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Callable
@@ -6,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Callable
 import attrs
 
 import naff.models as models
-from naff.client.const import MISSING, DISCORD_EPOCH, Absent, logger_name
+from naff.client.const import MISSING, DISCORD_EPOCH, Absent, logger
 from naff.client.errors import NotFound, VoiceNotConnected
 from naff.client.mixins.send import SendMixin
 from naff.client.mixins.serialization import DictSerializationMixin
@@ -70,8 +69,6 @@ __all__ = (
     "TYPE_CHANNEL_MAPPING",
     "TYPE_MESSAGEABLE_CHANNEL",
 )
-
-log = logging.getLogger(logger_name)
 
 
 class ChannelHistory(AsyncIterator):
@@ -736,7 +733,7 @@ class BaseChannel(DiscordObject):
         channel_type = data.get("type", None)
         channel_class = TYPE_CHANNEL_MAPPING.get(channel_type, None)
         if not channel_class:
-            log.error(f"Unsupported channel type for {data} ({channel_type}).")
+            logger.error(f"Unsupported channel type for {data} ({channel_type}).")
             channel_class = BaseChannel
 
         return channel_class.from_dict(data, client)

--- a/naff/models/discord/enums.py
+++ b/naff/models/discord/enums.py
@@ -1,12 +1,10 @@
-import logging
 from enum import Enum, EnumMeta, IntEnum, IntFlag, _decompose
 from functools import reduce
 from operator import or_
 from typing import Iterator, Tuple, TypeVar, Type
 
-from naff.client.const import logger_name
+from naff.client.const import logger
 
-_log = logging.getLogger(logger_name)
 
 __all__ = (
     "WebSocketOPCodes",
@@ -85,7 +83,7 @@ SELF = TypeVar("SELF")
 
 
 def _log_type_mismatch(cls, value) -> None:
-    _log.error(
+    logger.error(
         f"Class `{cls.__name__}` received an invalid and unexpected value `{value}`. Please update NAFF or report this issue on GitHub - https://github.com/NAFTeam/NAFF/issues"
     )
 

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -1,12 +1,11 @@
 import asyncio
-import logging
 import time
 from collections import namedtuple
 from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
 
 
 import naff.models as models
-from naff.client.const import MISSING, PREMIUM_GUILD_LIMITS, logger_name, Absent
+from naff.client.const import MISSING, PREMIUM_GUILD_LIMITS, logger, Absent
 from naff.client.errors import EventLocationNotProvided, NotFound
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_converters import optional
@@ -56,8 +55,6 @@ __all__ = (
     "AuditLog",
     "AuditLogHistory",
 )
-
-log = logging.getLogger(logger_name)
 
 
 @define()
@@ -540,10 +537,10 @@ class Guild(BaseGuild):
             self._chunk_cache = self._chunk_cache + chunk.get("members")
 
         if chunk.get("chunk_index") != chunk.get("chunk_count") - 1:
-            return log.debug(f"Cached chunk of {len(chunk.get('members'))} members for {self.id}")
+            return logger.debug(f"Cached chunk of {len(chunk.get('members'))} members for {self.id}")
         else:
             members = self._chunk_cache
-            log.info(f"Processing {len(members)} members for {self.id}")
+            logger.info(f"Processing {len(members)} members for {self.id}")
 
             s = time.monotonic()
             start_time = time.perf_counter()
@@ -559,7 +556,7 @@ class Guild(BaseGuild):
 
             total_time = time.perf_counter() - start_time
             self.chunk_cache = []
-            log.info(f"Cached members for {self.id} in {total_time:.2f} seconds")
+            logger.info(f"Cached members for {self.id} in {total_time:.2f} seconds")
             self.chunked.set()
 
     async def fetch_audit_log(
@@ -596,7 +593,7 @@ class Guild(BaseGuild):
         limit: int = 100,
     ) -> "AuditLogHistory":
         """
-        Get an async iterator for the history of the audit log.
+        Get an async iterator for the history of the audit logger.
 
         Args:
             guild (:class:`Guild`): The guild to search through.
@@ -671,7 +668,7 @@ class Guild(BaseGuild):
             public_updates_channel: The text channel where updates from discord should appear.
             preferred_locale: The new preferred locale of the guild. Must be an ISO 639 code.
             features: The enabled guild features
-            reason: An optional reason for the audit log.
+            reason: An optional reason for the audit logger.
 
         """
         await self._client.http.modify_guild(
@@ -713,7 +710,7 @@ class Guild(BaseGuild):
             name: Name of the emoji
             imagefile: The emoji image. (Supports PNG, JPEG, WebP, GIF)
             roles: Roles allowed to use this emoji.
-            reason: An optional reason for the audit log.
+            reason: An optional reason for the audit logger.
 
         Returns:
             The new custom emoji created.
@@ -1340,7 +1337,7 @@ class Guild(BaseGuild):
             icon: Can be either a bytes like object or a path to an image, or a unicode emoji which is supported by discord.
             hoist: Whether the role is shown separately in the members list. `Default: False`
             mentionable: Whether the role can be mentioned. `Default: False`
-            reason: An optional reason for the audit log.
+            reason: An optional reason for the audit logger.
 
         Returns:
             A role object or None if the role is not found.

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -593,7 +593,7 @@ class Guild(BaseGuild):
         limit: int = 100,
     ) -> "AuditLogHistory":
         """
-        Get an async iterator for the history of the audit logger.
+        Get an async iterator for the history of the audit log.
 
         Args:
             guild (:class:`Guild`): The guild to search through.
@@ -668,7 +668,7 @@ class Guild(BaseGuild):
             public_updates_channel: The text channel where updates from discord should appear.
             preferred_locale: The new preferred locale of the guild. Must be an ISO 639 code.
             features: The enabled guild features
-            reason: An optional reason for the audit logger.
+            reason: An optional reason for the audit log.
 
         """
         await self._client.http.modify_guild(
@@ -710,7 +710,7 @@ class Guild(BaseGuild):
             name: Name of the emoji
             imagefile: The emoji image. (Supports PNG, JPEG, WebP, GIF)
             roles: Roles allowed to use this emoji.
-            reason: An optional reason for the audit logger.
+            reason: An optional reason for the audit log.
 
         Returns:
             The new custom emoji created.
@@ -1337,7 +1337,7 @@ class Guild(BaseGuild):
             icon: Can be either a bytes like object or a path to an image, or a unicode emoji which is supported by discord.
             hoist: Whether the role is shown separately in the members list. `Default: False`
             mentionable: Whether the role can be mentioned. `Default: False`
-            reason: An optional reason for the audit logger.
+            reason: An optional reason for the audit log.
 
         Returns:
             A role object or None if the role is not found.

--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -1,8 +1,7 @@
-import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Set, Dict, List, Optional, Union
 
-from naff.client.const import MISSING, logger_name, Absent
+from naff.client.const import MISSING, logger, Absent
 from naff.client.errors import HTTPException, TooManyChanges
 from naff.client.mixins.send import SendMixin
 from naff.client.utils.attr_utils import define, field, docs
@@ -29,8 +28,6 @@ if TYPE_CHECKING:
     from naff.models.discord.voice_state import VoiceState
 
 __all__ = ("BaseUser", "User", "NaffUser", "Member")
-
-log = logging.getLogger(logger_name)
 
 
 class _SendDMMixin(SendMixin):
@@ -274,7 +271,9 @@ class Member(DiscordObject, _SendDMMixin):
                     client, f"guilds/{data['guild_id']}/users/{data['id']}/avatars/{{}}", data.pop("avatar", None)
                 )
             except Exception as e:
-                log.warning(f"[DEBUG NEEDED - REPORT THIS] Incomplete dictionary has been passed to member object: {e}")
+                logger.warning(
+                    f"[DEBUG NEEDED - REPORT THIS] Incomplete dictionary has been passed to member object: {e}"
+                )
                 raise
 
         data["role_ids"] = data.pop("roles", [])

--- a/naff/models/naff/active_voice_state.py
+++ b/naff/models/naff/active_voice_state.py
@@ -1,12 +1,11 @@
 import asyncio
-import logging
 from typing import Optional, TYPE_CHECKING
 
 from discord_typings import VoiceStateData
 
 from naff.api.voice.player import Player
 from naff.api.voice.voice_gateway import VoiceGateway
-from naff.client.const import logger_name, MISSING
+from naff.client.const import logger, MISSING
 from naff.client.errors import VoiceAlreadyConnected, VoiceConnectionTimeout
 from naff.client.utils import optional
 from naff.client.utils.attr_utils import define, field
@@ -18,8 +17,6 @@ if TYPE_CHECKING:
 
 
 __all__ = ("ActiveVoiceState",)
-
-log = logging.getLogger(logger_name)
 
 
 @define()
@@ -141,7 +138,7 @@ class ActiveVoiceState(VoiceState):
 
         await self._client.ws.voice_state_update(self._guild_id, self._channel_id, self.self_mute, self.self_deaf)
 
-        log.debug("Waiting for voice connection data...")
+        logger.debug("Waiting for voice connection data...")
 
         try:
             self._voice_state, self._voice_server = await asyncio.gather(
@@ -151,7 +148,7 @@ class ActiveVoiceState(VoiceState):
         except asyncio.TimeoutError:
             raise VoiceConnectionTimeout from None
 
-        log.debug("Attempting to initialise voice gateway...")
+        logger.debug("Attempting to initialise voice gateway...")
         await self.ws_connect()
 
     async def disconnect(self) -> None:
@@ -176,7 +173,7 @@ class ActiveVoiceState(VoiceState):
             self._channel_id = target_channel
             await self._client.ws.voice_state_update(self._guild_id, self._channel_id, self.self_mute, self.self_deaf)
 
-            log.debug("Waiting for voice connection data...")
+            logger.debug("Waiting for voice connection data...")
             try:
                 await self._client.wait_for("raw_voice_state_update", self._guild_predicate, timeout=timeout)
             except asyncio.TimeoutError:
@@ -246,7 +243,7 @@ class ActiveVoiceState(VoiceState):
         """
         if after is None:
             # bot disconnected
-            log.info(f"Disconnecting from voice channel {self._channel_id}")
+            logger.info(f"Disconnecting from voice channel {self._channel_id}")
             await self._close_connection()
             self._client.cache.delete_bot_voice_state(self._guild_id)
             return

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1,6 +1,5 @@
 import asyncio
 import inspect
-import logging
 import re
 import typing
 from enum import IntEnum
@@ -16,7 +15,7 @@ from naff.client.const import (
     SLASH_CMD_MAX_OPTIONS,
     SLASH_CMD_MAX_DESC_LENGTH,
     MISSING,
-    logger_name,
+    logger,
     Absent,
 )
 from naff.client.mixins.serialization import DictSerializationMixin
@@ -60,8 +59,6 @@ __all__ = (
     "LocalizedDesc",
     "LocalisedDesc",
 )
-
-log = logging.getLogger(logger_name)
 
 
 def name_validator(_: Any, attr: Attribute, value: str) -> None:
@@ -958,7 +955,7 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
             nsfw = cmd_list[0].nsfw
 
             if not all(str(c.description) in (str(base_description), "No Description Set") for c in cmd_list):
-                log.warning(
+                logger.warning(
                     f"Conflicting descriptions found in `{cmd_list[0].name}` subcommands; `{str(base_description)}` will be used"
                 )
             if not all(c.default_member_permissions == cmd_list[0].default_member_permissions for c in cmd_list):
@@ -966,7 +963,7 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
             if not all(c.dm_permission == cmd_list[0].dm_permission for c in cmd_list):
                 raise ValueError(f"Conflicting `dm_permission` values found in `{cmd_list[0].name}`")
             if not all(c.nsfw == nsfw for c in cmd_list):
-                log.warning(f"Conflicting `nsfw` values found in {cmd_list[0].name} - `True` will be used")
+                logger.warning(f"Conflicting `nsfw` values found in {cmd_list[0].name} - `True` will be used")
                 nsfw = True
 
             for cmd in cmd_list:

--- a/naff/models/naff/command.py
+++ b/naff/models/naff/command.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 import asyncio
 import copy
 import functools
-import logging
 import re
 import typing
 from typing import Annotated, Awaitable, Callable, Coroutine, Optional, Tuple, Any, TYPE_CHECKING
 
-from naff.client.const import MISSING, logger_name
+from naff.client.const import MISSING
 from naff.client.errors import CommandOnCooldown, CommandCheckFailure, MaxConcurrencyReached
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_utils import define, field, docs
@@ -21,7 +20,6 @@ if TYPE_CHECKING:
 
 __all__ = ("BaseCommand", "check", "cooldown", "max_concurrency")
 
-log = logging.getLogger(logger_name)
 
 kwargs_reg = re.compile(r"^\*\*\w")
 args_reg = re.compile(r"^\*\w")

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -1,12 +1,11 @@
 import datetime
-import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from aiohttp import FormData
 
 import naff.models.discord.message as message
 from naff.models.discord.timestamp import Timestamp
-from naff.client.const import MISSING, logger_name, Absent
+from naff.client.const import MISSING, logger, Absent
 from naff.client.errors import AlreadyDeferred
 from naff.client.mixins.send import SendMixin
 from naff.client.utils.attr_utils import define, field, docs
@@ -42,8 +41,6 @@ __all__ = (
     "ModalContext",
     "PrefixedContext",
 )
-
-log = logging.getLogger(logger_name)
 
 
 @define()
@@ -417,7 +414,7 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
                 caches = ((self._client.cache.get_message, (self.channel.id, self.target_id)),)
             case _:
                 # Most likely a new context type, check all rational caches for the target_id
-                log.warning(f"New Context Type Detected. Please Report: {self._context_type}")
+                logger.warning(f"New Context Type Detected. Please Report: {self._context_type}")
                 caches = (
                     (self._client.cache.get_message, (self.channel.id, self.target_id)),
                     (self._client.cache.get_member, (self.guild_id, self.target_id)),
@@ -530,7 +527,7 @@ class ComponentContext(InteractionContext):
         message_data = None
         if self.deferred:
             if not self.defer_edit_origin:
-                log.warning(
+                logger.warning(
                     "If you want to edit the original message, and need to defer, you must set the `edit_origin` kwarg to True!"
                 )
 

--- a/naff/models/naff/extension.py
+++ b/naff/models/naff/extension.py
@@ -1,10 +1,9 @@
 import asyncio
 import inspect
-import logging
 from typing import Awaitable, List, TYPE_CHECKING, Callable, Coroutine, Optional
 
 import naff.models.naff as naff
-from naff.client.const import logger_name, MISSING
+from naff.client.const import logger, MISSING
 from naff.client.utils.misc_utils import wrap_partial
 from naff.models.naff.tasks import Task
 
@@ -13,7 +12,6 @@ if TYPE_CHECKING:
     from naff.models.naff import AutoDefer, BaseCommand, Listener
     from naff.models.naff import Context
 
-log = logging.getLogger(logger_name)
 
 __all__ = ("Extension",)
 
@@ -100,7 +98,7 @@ class Extension:
             elif isinstance(val, Task):
                 wrap_partial(val, new_cls)
 
-        log.debug(
+        logger.debug(
             f"{len(new_cls._commands)} commands and {len(new_cls.listeners)} listeners"
             f" have been loaded from `{new_cls.name}`"
         )
@@ -154,7 +152,7 @@ class Extension:
             self.bot.listeners[func.event].remove(func)
 
         self.bot.ext.pop(self.name, None)
-        log.debug(f"{self.name} has been drop")
+        logger.debug(f"{self.name} has been drop")
 
     def add_ext_auto_defer(self, ephemeral: bool = False, time_until_defer: float = 0.0) -> None:
         """
@@ -262,5 +260,5 @@ class Extension:
             raise TypeError("Callback must be a coroutine")
 
         if self.extension_error:
-            log.warning("Extension error callback has been overridden!")
+            logger.warning("Extension error callback has been overridden!")
         self.extension_error = coroutine

--- a/naff/models/naff/tasks/task.py
+++ b/naff/models/naff/tasks/task.py
@@ -1,15 +1,13 @@
 import asyncio
 import inspect
-import logging
 from asyncio import Task as _Task
 from datetime import datetime, timedelta
 from typing import Callable, Optional
 
 import naff
-from naff.client.const import logger_name, MISSING
+from naff.client.const import logger, MISSING
 from .triggers import BaseTrigger
 
-log = logging.getLogger(logger_name)
 
 __all__ = ("Task",)
 
@@ -95,7 +93,7 @@ class Task:
             self._stop.clear()
             self.task = asyncio.create_task(self._task_loop())
         except RuntimeError:
-            log.error(
+            logger.error(
                 "Unable to start task without a running event loop! We recommend starting tasks within an `on_startup` event."
             )
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This is an alternative solution to #547, attempting to solve the logging problem.

This PR allows users to pass their own logger at client initialisation. The passed logger is saved in both the client and naff.constants.

This has several benefits;
1) users don't have to do nasty stuff at the very start of their code to overwrite the naff logger before naff does anything with it
2) custom loggers, like `rich.logging` or file handlers can be easily used
3) users have more direct and easier access to the logger via both `client.logger` and `naff.consts.logger`, instead of having to `logging.getLogger(logger_name)` every time they want to use it
4) naff devs have an easier time as well, since they can import the logger from anywhere as well


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- a logger obj is now defined in `naff.consts` which is overwritten by the logger the user passes to `Client`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
