### PR TITLE
fix: channel edit error when ratelimited

### DIFF
--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -7,7 +7,7 @@ import attrs
 
 import naff.models as models
 from naff.client.const import MISSING, DISCORD_EPOCH, Absent, logger_name
-from naff.client.errors import NotFound, VoiceNotConnected
+from naff.client.errors import NotFound, VoiceNotConnected, TooManyChanges
 from naff.client.mixins.send import SendMixin
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_utils import define, field
@@ -821,6 +821,11 @@ class BaseChannel(DiscordObject):
             **kwargs,
         }
         channel_data = await self._client.http.modify_channel(self.id, payload, reason)
+        if not channel_data:
+            raise TooManyChanges(
+                "You have changed this channel too frequently, you need to wait a while before trying again."
+            ) from None
+
         return self._client.cache.place_channel_data(channel_data)
 
     async def delete(self, reason: Absent[Optional[str]] = MISSING) -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [X] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
fixes #[522](https://github.com/NAFTeam/NAFF/issues/522)

## Changes
BaseChannel.edit now raises `TooManyChanges` if you are being ratelimited hard instead of non-obvious None-related TypeError

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [X] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.10.x`
- [X ] I've tested my code
