### PR TITLE
feat: Add gui_position to channel objects

### DIFF
--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -491,7 +491,7 @@ class GlobalCache:
                 channel = BaseChannel.from_dict_factory(data, self._client)
             else:
                 channel.update_from_dict(data)
-                if guild := getattr(channel, "guild"):
+                if guild := getattr(channel, "guild", None):
                     guild._channel_gui_positions = {}
 
         return channel

--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -482,6 +482,7 @@ class GlobalCache:
                     guild._thread_ids.add(channel.id)
                 elif isinstance(channel, GuildChannel):
                     guild._channel_ids.add(channel.id)
+                guild._channel_gui_positions = {}
         else:
             # Create entire new channel object if the type changes
             channel_type = data.get("type", None)
@@ -490,6 +491,8 @@ class GlobalCache:
                 channel = BaseChannel.from_dict_factory(data, self._client)
             else:
                 channel.update_from_dict(data)
+                if guild := getattr(channel, "guild"):
+                    guild._channel_gui_positions = {}
 
         return channel
 

--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -562,6 +562,7 @@ class GlobalCache:
                 guild._thread_ids.discard(channel.id)
             elif isinstance(channel, GuildChannel):
                 guild._channel_ids.discard(channel.id)
+            guild._channel_gui_positions = {}
 
     # endregion Channel cache
 

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -955,6 +955,11 @@ class GuildChannel(BaseChannel):
         """The parent category of this channel."""
         return self._client.cache.get_channel(self.parent_id)
 
+    @property
+    def gui_position(self) -> int:
+        """The position of this channel in the Discord interface."""
+        return self.guild.get_channel_gui_position(self.id)
+
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Client") -> Dict[str, Any]:
         if overwrites := data.get("permission_overwrites"):

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -1855,6 +1855,15 @@ class Guild(BaseGuild):
         ]
 
     def get_channel_gui_position(self, channel_id: "Snowflake_Type") -> int:
+        """
+        Get a given channels gui position.
+
+        Args:
+            channel_id: The ID of the channel to get the gui position for.
+
+        Returns:
+            The gui position of the channel.
+        """
         if not self._channel_gui_positions:
             self._calculate_gui_channel_positions()
         return self._channel_gui_positions.get(to_snowflake(channel_id), 0)

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import time
 from collections import namedtuple
+from functools import cmp_to_key
 from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
 
 
@@ -195,6 +196,7 @@ class Guild(BaseGuild):
     _member_ids: Set[Snowflake_Type] = field(factory=set)
     _role_ids: Set[Snowflake_Type] = field(factory=set)
     _chunk_cache: list = field(factory=list)
+    _channel_gui_positions: Dict[Snowflake_Type, int] = field(factory=dict)
 
     @classmethod
     def _process_dict(cls, data: Dict[str, Any], client: "Client") -> Dict[str, Any]:
@@ -1840,6 +1842,69 @@ class Guild(BaseGuild):
         regions_data = await self._client.http.get_guild_voice_regions(self.id)
         regions = models.VoiceRegion.from_list(regions_data)
         return regions
+
+    @property
+    def gui_sorted_channels(self) -> list["models.TYPE_GUILD_CHANNEL"]:
+        """Return this guilds channels sorted by their gui positions"""
+        # create a sorted list of objects by their gui position
+        if not self._channel_gui_positions:
+            self._calculate_gui_channel_positions()
+        return [
+            self._client.get_channel(k)
+            for k, v in sorted(self._channel_gui_positions.items(), key=lambda item: item[1])
+        ]
+
+    def get_channel_gui_position(self, channel_id: "Snowflake_Type") -> int:
+        if not self._channel_gui_positions:
+            self._calculate_gui_channel_positions()
+        return self._channel_gui_positions.get(to_snowflake(channel_id), 0)
+
+    def _calculate_gui_channel_positions(self) -> list["models.TYPE_GUILD_CHANNEL"]:
+        """
+        Calculates the GUI position for all known channels within this guild.
+
+        Note this is an expensive operation and should only be run when actually required.
+
+        Returns:
+            The list of channels in this guild, sorted by their GUI position.
+        """
+        # sorting is based on this https://github.com/discord/discord-api-docs/issues/4613#issuecomment-1059997612
+        sort_map = {
+            ChannelTypes.GUILD_NEWS_THREAD: 1,
+            ChannelTypes.GUILD_PUBLIC_THREAD: 1,
+            ChannelTypes.GUILD_PRIVATE_THREAD: 1,
+            ChannelTypes.GUILD_TEXT: 2,
+            ChannelTypes.GUILD_CATEGORY: 2,
+            ChannelTypes.GUILD_NEWS: 2,
+            ChannelTypes.GUILD_FORUM: 2,  # assumed value
+            ChannelTypes.GUILD_VOICE: 3,
+            ChannelTypes.GUILD_STAGE_VOICE: 3,
+        }
+
+        def channel_sort_func(a, b) -> int:
+            a_sorting = sort_map.get(a.type, 0)
+            b_sorting = sort_map.get(b.type, 0)
+
+            if a_sorting != b_sorting:
+                return a_sorting - b_sorting
+            return a.position - b.position or a.id - b.id
+
+        sorted_channels = sorted(self.channels, key=cmp_to_key(channel_sort_func))
+
+        for channel in sorted_channels[::-1]:
+            if channel.parent_id:
+                # sort channels under their respective categories
+                sorted_channels.remove(channel)
+                parent_index = sorted_channels.index(channel.category)
+                sorted_channels.insert(parent_index + 1, channel)
+            elif channel.type != ChannelTypes.GUILD_CATEGORY:
+                # move non-category channels to the top
+                sorted_channels.remove(channel)
+                sorted_channels.insert(0, channel)
+
+        self._channel_gui_positions = {channel.id: i for i, channel in enumerate(sorted_channels)}
+
+        return sorted_channels
 
 
 @define()


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This monstrosity allows users to get the position of channels as shown in the discord interface, as opposed to the ~~insanity~~ value offered by the discord api named `position`. 

The biggest issue with this implementation is that it is only as accurate as the cached channel list that the client has, there is no solution to this... so ¯\_(ツ)_/¯. In order to save on performance, the client will only calculate GUI positions when requested, and then caches the result. Then whenever the channel cache is modified, the respective guild resets its gui pos cache. 


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `gui_position` property to `GuildChannel`
- Add `_channel_gui_positions` to `Guild`
- Add `_calculate_gui_channel_positions` to `Guild`
- Add `get_channel_gui_position` to `Guild`
- Add `gui_sorted_channels` property to `Guild`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
