### PR TITLE
feat: min-max length on string options

### DIFF
--- a/docs/src/Guides/03 Creating Commands.md
+++ b/docs/src/Guides/03 Creating Commands.md
@@ -164,6 +164,21 @@ async def my_command_function(ctx: InteractionContext, integer_option: int):
     await ctx.send(f"You input {integer_option} which is always between 10 and 15")
 ```
 
+The same can be done with the length of an option when using `OptionTypes.STRING` by setting `min_length` and `max_length`:
+```python
+@slash_command(name="my_command", ...)
+@slash_option(
+    name="string_option",
+    description="String Option",
+    required=True,
+    opt_type=OptionTypes.STRING,
+    min_length=5,
+    max_length=10
+)
+async def my_command_function(ctx: InteractionContext, string_option: str):
+    await ctx.send(f"You input `{string_option}` which is between 5 and 10 characters long")
+```
+
 !!! danger "Option Names"
     Be aware that the option `name` and the function parameter need to be the same (In this example both are `integer_option`).
 

--- a/naff/models/naff/annotations/slash.py
+++ b/naff/models/naff/annotations/slash.py
@@ -27,6 +27,8 @@ def slash_str_option(
     required: bool = False,
     autocomplete: bool = False,
     choices: List[Union["SlashCommandChoice", dict]] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
 ) -> Type[str]:
     """
     Annotates an argument as a string type slash command option.
@@ -36,6 +38,8 @@ def slash_str_option(
         required: Is this option required?
         autocomplete: Use autocomplete for this option
         choices: The choices allowed by this command
+        min_length: The minimum length of text a user can input.
+        max_length: The maximum length of text a user can input.
 
     """
     option = SlashCommandOption(
@@ -44,6 +48,8 @@ def slash_str_option(
         required=required,
         autocomplete=autocomplete,
         choices=choices or [],
+        max_length=max_length,
+        min_length=min_length,
         type=models.OptionTypes.STRING,
     )
     return option  # type: ignore

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -292,6 +292,8 @@ class SlashCommandOption(DictSerializationMixin):
         channel_types: The channel types permitted. The option needs to be a channel
         min_value: The minimum value permitted. The option needs to be an integer or float
         max_value: The maximum value permitted. The option needs to be an integer or float
+        min_length: The minimum length of text a user can input. The option needs to be a string
+        max_length: The maximum length of text a user can input. The option needs to be a string
 
     """
 
@@ -304,6 +306,8 @@ class SlashCommandOption(DictSerializationMixin):
     channel_types: Optional[list[Union[ChannelTypes, int]]] = field(default=None)
     min_value: Optional[float] = field(default=None)
     max_value: Optional[float] = field(default=None)
+    min_length: Optional[int] = field(default=None)
+    max_length: Optional[int] = field(default=None)
 
     @type.validator
     def _type_validator(self, attribute: str, value: int) -> None:
@@ -351,6 +355,32 @@ class SlashCommandOption(DictSerializationMixin):
             if self.max_value and self.min_value:
                 if self.max_value < self.min_value:
                     raise ValueError("`min_value` needs to be <= than `max_value`")
+
+    @min_length.validator
+    def _min_length_validator(self, attribute: str, value: Optional[int]) -> None:
+        if value is not None:
+            if self.type != OptionTypes.STRING:
+                raise ValueError("`min_length` can only be supplied with string options")
+
+            if self.max_length is not None and self.min_length is not None:
+                if self.max_length < self.min_length:
+                    raise ValueError("`min_length` needs to be <= than `max_length`")
+
+            if self.min_length < 0:
+                raise ValueError("`min_length` needs to be >= 0")
+
+    @max_length.validator
+    def _max_length_validator(self, attribute: str, value: Optional[int]) -> None:
+        if value is not None:
+            if self.type != OptionTypes.STRING:
+                raise ValueError("`max_length` can only be supplied with string options")
+
+            if self.min_length is not None and self.max_length is not None:
+                if self.max_length < self.min_length:
+                    raise ValueError("`min_length` needs to be <= than `max_length`")
+
+            if self.max_length < 1:
+                raise ValueError("`max_length` needs to be >= 1")
 
     def as_dict(self) -> dict:
         data = attrs.asdict(self)
@@ -801,6 +831,8 @@ def slash_option(
     channel_types: Optional[list[Union[ChannelTypes, int]]] = None,
     min_value: Optional[float] = None,
     max_value: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
 ) -> Any:
     r"""
     A decorator to add an option to a slash command.
@@ -814,6 +846,8 @@ def slash_option(
         channel_types: The channel types permitted. The option needs to be a channel
         min_value: The minimum value permitted. The option needs to be an integer or float
         max_value: The maximum value permitted. The option needs to be an integer or float
+        min_length: The minimum length of text a user can input. The option needs to be a string
+        max_length: The maximum length of text a user can input. The option needs to be a string
     """
 
     def wrapper(func: Coroutine) -> Coroutine:
@@ -830,6 +864,8 @@ def slash_option(
             channel_types=channel_types,
             min_value=min_value,
             max_value=max_value,
+            min_length=min_length,
+            max_length=max_length,
         )
         if not hasattr(func, "options"):
             func.options = []


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
![image](https://user-images.githubusercontent.com/58155937/178088798-c4cce11d-8213-488f-b3f5-6b74958c62ab.png)
Wonder why they only waited a week to tell us. IMO should have just not told us /s
https://discord.com/developers/docs/change-log#min-and-max-length-for-command-options


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `min_length` arg to slash command options (for STRING)
- Add `max_length` arg to slash command options (for STRING)


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
