### PR TITLE
fix: pass ctx for prefixed commands

### DIFF
--- a/naff/models/naff/prefixed_commands.py
+++ b/naff/models/naff/prefixed_commands.py
@@ -655,7 +655,7 @@ class PrefixedCommand(BaseCommand):
             elif not self.ignore_extra and not args.finished:
                 raise BadArgument(f"Too many arguments passed to {self.name}.")
 
-            return await self.call_with_binding(callback, *new_args, **kwargs)
+            return await self.call_with_binding(callback, ctx, *new_args, **kwargs)
 
 
 def prefixed_command(


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This PR just makes sure `Context` is passed for prefixed commands that have one or more parameters.

## Changes
- Pass in `ctx` for the `call_with_binding` call at the end of `call_callback` for `PrefixedCommand` for parameter handling.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
