### PR TITLE
fix: check min/max value in sync comparison

### DIFF
--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1054,6 +1054,8 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "name_localized": ("name_localizations", {}),
         "description_localized": ("description_localizations", {}),
         "choices": ("choices", []),
+        "max_value": ("max_value", None),
+        "min_value": ("min_value", None),
     }
 
     if local_opt_list != remote_opt_list:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Resolves #557 by chceking the min and max attributes for options. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Adds `min_value` and `max_value` to the attributes that are compared in sync detection 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
