### PR TITLE
feat: add .reaction and .reaction_count to MessageReaction events

### DIFF
--- a/naff/api/events/discord.py
+++ b/naff/api/events/discord.py
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
     from naff.models.discord.stage_instance import StageInstance
     from naff.models.naff.context import ModalContext
     from naff.models.discord.auto_mod import AutoModerationAction, AutoModRule
+    from naff.models.discord.reaction import Reaction
 
 
 @define(kw_only=False)
@@ -452,6 +453,17 @@ class MessageReactionAdd(BaseEvent):
     message: "Message" = field(metadata=docs("The message that was reacted to"))
     emoji: "PartialEmoji" = field(metadata=docs("The emoji that was added to the message"))
     author: Union["Member", "User"] = field(metadata=docs("The user who added the reaction"))
+    # reaction can be None when the message is not in the cache, and it was the last reaction, and it was deleted in the event
+    reaction: Optional["Reaction"] = field(
+        default=None, metadata=docs("The reaction object corresponding to the emoji")
+    )
+
+    @property
+    def count(self) -> int:
+        """Times the emoji in the event has been used to react"""
+        if self.reaction is None:
+            return 0
+        return self.reaction.count
 
 
 @define(kw_only=False)

--- a/naff/api/events/discord.py
+++ b/naff/api/events/discord.py
@@ -459,7 +459,7 @@ class MessageReactionAdd(BaseEvent):
     )
 
     @property
-    def count(self) -> int:
+    def reaction_count(self) -> int:
         """Times the emoji in the event has been used to react"""
         if self.reaction is None:
             return 0

--- a/naff/api/events/processors/reaction_events.py
+++ b/naff/api/events/processors/reaction_events.py
@@ -38,18 +38,17 @@ class ReactionEvents(EventMixinTemplate):
                     reaction = r
                     break
             else:
-                message.reactions.append(
-                    Reaction.from_dict(
-                        {
-                            "count": 1,
-                            "me": author.id == self.user.id,  # type: ignore
-                            "emoji": emoji.to_dict(),
-                            "message_id": message.id,
-                            "channel_id": message._channel_id,
-                        },
-                        self,  # type: ignore
-                    )
+                reaction = Reaction.from_dict(
+                    {
+                        "count": 1,
+                        "me": author.id == self.user.id,  # type: ignore
+                        "emoji": emoji.to_dict(),
+                        "message_id": message.id,
+                        "channel_id": message._channel_id,
+                    },
+                    self,  # type: ignore
                 )
+                message.reactions.append(reaction)
 
         else:
             message = await self.cache.fetch_message(event.data.get("channel_id"), event.data.get("message_id"))

--- a/naff/api/events/processors/reaction_events.py
+++ b/naff/api/events/processors/reaction_events.py
@@ -20,6 +20,7 @@ class ReactionEvents(EventMixinTemplate):
 
         emoji = PartialEmoji.from_dict(event.data.get("emoji"))  # type: ignore
         message = self.cache.get_message(event.data.get("channel_id"), event.data.get("message_id"))
+        reaction = None
 
         if message:
             for i in range(len(message.reactions)):
@@ -34,6 +35,7 @@ class ReactionEvents(EventMixinTemplate):
                         message.reactions.pop(i)
                     else:
                         message.reactions[i] = r
+                    reaction = r
                     break
             else:
                 message.reactions.append(
@@ -51,11 +53,14 @@ class ReactionEvents(EventMixinTemplate):
 
         else:
             message = await self.cache.fetch_message(event.data.get("channel_id"), event.data.get("message_id"))
-
+            for r in message.reactions:
+                if r.emoji == emoji:
+                    reaction = r
+                    break
         if add:
-            self.dispatch(events.MessageReactionAdd(message=message, emoji=emoji, author=author))
+            self.dispatch(events.MessageReactionAdd(message=message, emoji=emoji, author=author, reaction=reaction))
         else:
-            self.dispatch(events.MessageReactionRemove(message=message, emoji=emoji, author=author))
+            self.dispatch(events.MessageReactionRemove(message=message, emoji=emoji, author=author, reaction=reaction))
 
     @Processor.define()
     async def _on_raw_message_reaction_add(self, event: "RawGatewayEvent") -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [X] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Makes working with reaction events easier.

## Changes
* Added `.reaction` attribute to `MessageReactionAdd` (`MessageReactionRemove` inherits it) event class
* Added `.reaction_count` property to `MessageReactionAdd`
* `_handle_message_reaction_change` processor will now attempt to get reaction obj if message was not in cache and was fetched

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [X] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.10.x`
- [X] I've tested my code
