### PR TITLE
fix: guilds get 5 free stickers

### DIFF
--- a/naff/client/const.py
+++ b/naff/client/const.py
@@ -171,7 +171,7 @@ MISSING = Missing()
 MENTION_PREFIX = MentionPrefix()
 
 PREMIUM_GUILD_LIMITS = defaultdict(
-    lambda: {"emoji": 50, "stickers": 0, "bitrate": 96000, "filesize": 8388608},
+    lambda: {"emoji": 50, "stickers": 5, "bitrate": 96000, "filesize": 8388608},
     {
         1: {"emoji": 100, "stickers": 15, "bitrate": 128000, "filesize": 8388608},
         2: {"emoji": 150, "stickers": 30, "bitrate": 256000, "filesize": 52428800},


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Updates the default guild limits to account for the ~~new~~ free stickers guilds have.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Change a `0` to a `5`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
