### PR TITLE
feat: new automod system content

### DIFF
--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -482,7 +482,7 @@ class Message(BaseMessage):
                 )
                 rule = self.embeds[0].fields[0].value  # What rule was triggered
                 channel = self.embeds[0].fields[1].value  # Channel that the action took place in
-                return f'AutoMod has blocked a message. "{message_content}" from {self.author.mention} in <#{channel}>. Rule: {rule}.'
+                return f'AutoMod has blocked a message in <#{channel}>. "{message_content}" from {self.author.mention}. Rule: {rule}.'
             case _:
                 return None
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58155937/180621033-ade20389-b2d6-48bc-aa2c-c1111de0dc71.png)
discord now puts the channel in the message instead of in the embed