### PR TITLE
feat: Allow audio pre-buffering 

### DIFF
--- a/naff/api/voice/audio.py
+++ b/naff/api/voice/audio.py
@@ -182,8 +182,16 @@ class Audio(BaseAudio):
                     self.buffer.initialised.set()
                 time.sleep(0.1)
 
-    def pre_buffer(self) -> None:
-        """Start pre-buffering the audio."""
+    def pre_buffer(self, duration: None | float = None) -> None:
+        """
+        Start pre-buffering the audio.
+
+        Args:
+            duration: The duration of audio to pre-buffer.
+        """
+        if duration:
+            self.buffer_seconds = duration
+
         if self.process and self.process.poll() is None:
             raise RuntimeError("Cannot pre-buffer an already running process")
         # sanity value enforcement to prevent audio weirdness

--- a/naff/api/voice/player.py
+++ b/naff/api/voice/player.py
@@ -84,10 +84,7 @@ class Player(threading.Thread):
         """Start playing."""
         self._stop_event.clear()
         self._resume.set()
-        try:
-            self.start()
-        finally:
-            self.current_audio.cleanup()
+        self.start()
 
     def run(self) -> None:
         """The main player loop to send audio to the voice websocket."""


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR allows for pre-buffering audio before playing. This is a very niche use, and most of the time shouldn't be necessary.

*requested* by @Catalyst4222 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Allow `create_process` not to block
- Add check for buffer initialisation in `read` task
- Add `pre_buffer` method
- Remove unnecessary audio cleanup from player `start`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
