### PR TITLE
fix: channel_mention regex no longer assumes max length

### DIFF
--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -43,7 +43,7 @@ __all__ = (
     "process_message_payload",
 )
 
-channel_mention = re.compile(r"<#(?P<id>[0-9]{17,18})>")
+channel_mention = re.compile(r"<#(?P<id>[0-9]{17,})>")
 
 
 @define()


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Discord ID lengths have changed, this broke this regex. This is also why tests have been failing 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Regex no longer assumes max length 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
