### PR TITLE
feat: Convert `client.on_error` into a proper event

### DIFF
--- a/naff/api/events/internal.py
+++ b/naff/api/events/internal.py
@@ -168,8 +168,8 @@ class Select(Component):
 class Error(BaseEvent):
     """Dispatched when the library encounters an error."""
 
-    source: str
-    error: Exception
+    source: str = field(metadata=docs("The source of the error"))
+    error: Exception = field(metadata=docs("The error that was encountered"))
     args: tuple[Any] = field(factory=tuple)
     kwargs: dict[str, Any] = field(factory=dict)
-    ctx: Optional["Context"] = field(default=None)
+    ctx: Optional["Context"] = field(default=None, metadata=docs("The Context, if one was active"))

--- a/naff/api/events/internal.py
+++ b/naff/api/events/internal.py
@@ -21,7 +21,7 @@ These are events dispatched by the client. This is intended as a reference so yo
 
 """
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from naff.client.const import MISSING
 from naff.models.discord.snowflake import to_snowflake
@@ -33,6 +33,7 @@ __all__ = (
     "Component",
     "Connect",
     "Disconnect",
+    "Error",
     "ShardConnect",
     "ShardDisconnect",
     "GuildEvent",
@@ -47,7 +48,7 @@ __all__ = (
 
 if TYPE_CHECKING:
     from naff import Client
-    from naff.models.naff.context import ComponentContext
+    from naff.models.naff.context import ComponentContext, Context
     from naff.models.discord.snowflake import Snowflake_Type
     from naff.models.discord.guild import Guild
 
@@ -161,3 +162,12 @@ class Button(Component):
 @define(kw_only=False)
 class Select(Component):
     """Dispatched when a user uses a Select."""
+
+@define(kw_only=False)
+class Error(BaseEvent):
+    """Dispatched when the library encounters an error."""
+    source: str
+    error: Exception
+    args: tuple[Any] = field(factory=tuple)
+    kwargs: dict[str, Any] = field(factory=dict)
+    ctx: Optional["Context"] = field(default=None)

--- a/naff/api/events/internal.py
+++ b/naff/api/events/internal.py
@@ -163,9 +163,11 @@ class Button(Component):
 class Select(Component):
     """Dispatched when a user uses a Select."""
 
+
 @define(kw_only=False)
 class Error(BaseEvent):
     """Dispatched when the library encounters an error."""
+
     source: str
     error: Exception
     args: tuple[Any] = field(factory=tuple)

--- a/naff/client/auto_shard_client.py
+++ b/naff/client/auto_shard_client.py
@@ -149,7 +149,7 @@ class AutoShardedClient(Client):
             try:
                 await asyncio.gather(*self.async_startup_tasks)
             except Exception as e:
-                await self.on_error("async-extension-loader", e)
+                self.dispatch(events.Error("async-extension-loader", e))
 
         # cache slash commands
         if not self._startup:

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -460,7 +460,7 @@ class Client(
             except asyncio.CancelledError:
                 pass
             except Exception as e:
-                if isinstance(event, events.Error): 
+                if isinstance(event, events.Error):
                     # No infinite loops please
                     self.default_error_handler(repr(event), e)
                 else:
@@ -608,13 +608,15 @@ class Client(
         Override this to change error handling behavior
 
         """
-        return self.dispatch(events.Error(
-            f"Autocomplete Callback for /{ctx.invoke_target} - Option: {ctx.focussed_option}",
-            error,
-            args,
-            kwargs,
-            ctx
-        ))
+        return self.dispatch(
+            events.Error(
+                f"Autocomplete Callback for /{ctx.invoke_target} - Option: {ctx.focussed_option}",
+                error,
+                args,
+                kwargs,
+                ctx,
+            )
+        )
 
     async def on_autocomplete(self, ctx: AutocompleteContext) -> None:
         """


### PR DESCRIPTION
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This makes the error handler a dispatchable event, allowing Extensions listen to all events (prereq for #403)

## Changes
Adds new Internal Event `naff.api.events.internal.Error`
Changes all calls to `client.on_error` to dispatch that event instead
Adds a non-breaking listener `client._on_event` that calls the existing method.
Also fixes implausible bug when `on_command_error` is called without a valid bot token.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
