### PR TITLE
fix: proeperly remove alias for prefixed cmd's remove_command

### DIFF
--- a/naff/models/naff/prefixed_commands.py
+++ b/naff/models/naff/prefixed_commands.py
@@ -505,7 +505,11 @@ class PrefixedCommand(BaseCommand):
         """
         command = self.subcommands.pop(name, None)
 
-        if command is None or name in command.aliases:
+        if command is None:
+            return
+
+        if name in command.aliases:
+            command.aliases.remove(name)
             return
 
         for alias in command.aliases:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change (okay, technically this *is* breaking, but this wasn't intended anyways)
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Adjusts `PrefixedCommand.remove_command` so that, if an alias is passed, it also removes the alias from the main command itself (instead of only removing the alias entry from the dict of subcommands).


## Changes
...see above.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
