### PR TITLE
fix: pass proper args for BaseAction.from_dict_factory

### DIFF
--- a/naff/models/discord/auto_mod.py
+++ b/naff/models/discord/auto_mod.py
@@ -294,7 +294,7 @@ class AutoModerationAction(ClientObject):
     @classmethod
     def _process_dict(cls, data: dict, client: "Client") -> dict:
         data = super()._process_dict(data, client)
-        data["action"] = BaseAction.from_dict_factory(data["action"], client)
+        data["action"] = BaseAction.from_dict_factory(data["action"])
         return data
 
     @property


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
We were accidentally passing an extra argument to `BaseAction.from_dict_factory` for `AutoModerationAction`. This PR fixes.


## Changes
- Remove the `client` argument for `BaseAction.from_dict_factory` in `AutoModerationAction`.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
