### PR TITLE
fix: make ignore_extra work for no param prefixed cmds

### DIFF
--- a/naff/models/naff/prefixed_commands.py
+++ b/naff/models/naff/prefixed_commands.py
@@ -599,6 +599,8 @@ class PrefixedCommand(BaseCommand):
         """
         # sourcery skip: remove-empty-nested-block, remove-redundant-if, remove-unnecessary-else
         if len(self.parameters) == 0:
+            if ctx.args and not self.ignore_extra:
+                raise BadArgument(f"Too many arguments passed to {self.name}.")
             return await self.call_with_binding(callback, ctx)
         else:
             # this is slightly costly, but probably worth it


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
What the title says - makes it so if the prefixed command has no functions and has `ignore_extra` turned off, then it'll error out as intended.

## Changes
- Add in an extra check when there are no parameters to see if there are arguments while `ignore_extra` is off.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
