### PR TITLE
fix: parse `NoArgumentConverter` correctly

### DIFF
--- a/naff/models/naff/prefixed_commands.py
+++ b/naff/models/naff/prefixed_commands.py
@@ -651,6 +651,15 @@ class PrefixedCommand(BaseCommand):
 
             if param_index < len(self.parameters):
                 for param in self.parameters[param_index:]:
+                    if param.no_argument:
+                        converted, _ = await _convert(param, ctx, None)  # type: ignore
+                        if not param.consume_rest:
+                            new_args.append(converted)
+                        else:
+                            kwargs[param.name] = converted
+                            break
+                        continue
+
                     if not param.optional:
                         raise BadArgument(f"{param.name} is a required argument that is missing.")
                     else:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This PR fixes a number of issues that `NoArgumentConverter` has, detecting if it's a class and filling `NoArgumentConverter`s in even after all of the arguments have been exhausted.

...this is what hybrid commands do to you.


## Changes
- Move out `NoArgumentConverter` checking to its own function.
- Add in an extra check to see if the annotation was possibly a class and a subclass of `NoArgumentConverter`.
- Fill in `NoArgumentConverter` even after all of the parameters have been "exhausted".

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
