### PR TITLE
feat: add client.owner_ids

### DIFF
--- a/naff/models/naff/checks.py
+++ b/naff/models/naff/checks.py
@@ -62,7 +62,7 @@ def has_id(user_id: int) -> TYPE_CHECK_FUNCTION:
 
 def is_owner() -> TYPE_CHECK_FUNCTION:
     """
-    Is the author the owner of the bot.
+    Checks if the author is the owner of the bot. This respects the `client.owner_ids` list.
 
     Args:
         coro: the function to check
@@ -72,7 +72,7 @@ def is_owner() -> TYPE_CHECK_FUNCTION:
     async def check(ctx: Context) -> bool:
         if ctx.bot.app.team:
             return ctx.bot.app.team.is_in_team(ctx.author.id)
-        return ctx.author.id == ctx.bot.owner.id
+        return ctx.author.id in ctx.bot.owner_ids
 
     return check
 

--- a/naff/models/naff/checks.py
+++ b/naff/models/naff/checks.py
@@ -70,7 +70,7 @@ def is_owner() -> TYPE_CHECK_FUNCTION:
     """
 
     async def check(ctx: Context) -> bool:
-        _owner_ids: set = ctx.client.owner_ids.copy()
+        _owner_ids: set = ctx.bot.owner_ids.copy()
         if ctx.bot.app.team:
             [_owner_ids.add(m.id) for m in ctx.bot.app.team.members]
         return ctx.author.id in _owner_ids

--- a/naff/models/naff/checks.py
+++ b/naff/models/naff/checks.py
@@ -70,9 +70,10 @@ def is_owner() -> TYPE_CHECK_FUNCTION:
     """
 
     async def check(ctx: Context) -> bool:
+        _owner_ids: set = ctx.client.owner_ids.copy()
         if ctx.bot.app.team:
-            return ctx.bot.app.team.is_in_team(ctx.author.id)
-        return ctx.author.id in ctx.bot.owner_ids
+            [_owner_ids.add(m.id) for m in ctx.bot.app.team.members]
+        return ctx.author.id in _owner_ids
 
     return check
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Adds support for declaring owner ids in code. This allows users to add other users as owners, without creating a team. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `client.owner_ids` attribute
- Update `is_owner` check to respect `client.owner_ids`
- Add API-True owner to `owner_ids` on startup

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
