### PR TITLE
fix: use to_snowflake for remove_role

### DIFF
--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -490,8 +490,7 @@ class Member(DiscordObject, _SendDMMixin):
             reason: The reason for this removal
 
         """
-        if isinstance(role, Role):
-            role = role.id
+        role = to_snowflake(role)
         await self._client.http.remove_guild_member_role(self._guild_id, self.id, role, reason=reason)
         try:
             self._role_ids.remove(role)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This makes `Member.remove_role` use `to_snowflake` instead of getting the ID directly, which can result in getting a `SnowflakeObject` which obviously isn't ideal.


## Changes
- Replace the `isinstance` check with a `to_snowflake` call in `remove_role`.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
