### PR TITLE
feat: add __bool__ to Embed

### DIFF
--- a/naff/models/discord/embed.py
+++ b/naff/models/discord/embed.py
@@ -266,6 +266,20 @@ class Embed(DictSerializationMixin):
             total += sum(map(len, self.fields))
         return total
 
+    def __bool__(self) -> bool:
+        return any(
+            (
+                self.title,
+                self.description,
+                self.fields,
+                self.author,
+                self.thumbnail,
+                self.footer,
+                self.image,
+                self.video,
+            )
+        )
+
     def set_author(
         self,
         name: str,


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This PR simply adds `__bool__` to embed. This allows values like `image` to affect the output.
This also allows embeds with no "text" to be sent, as the embed would otherwise be evaluated as `False` during the sanity check instead.

Why? Guessing `__len__` messed things up.


## Changes

- I mean, literally what the title says.
  - From really basic experimentation, these fields, if present, allow the embed to be sent without Discord throwing an error. Any field that resulted in an error was left out.
  - Of course, I couldn't test `video`, but it's a good guess on my part.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
