### PR TITLE
feat: support new ws resume url

### DIFF
--- a/naff/api/gateway/gateway.py
+++ b/naff/api/gateway/gateway.py
@@ -7,7 +7,7 @@ from types import TracebackType
 from typing import TypeVar, TYPE_CHECKING
 
 from naff.api import events
-from naff.client.const import logger
+from naff.client.const import logger, MISSING
 from naff.client.utils.input_utils import OverriddenJson
 from naff.client.utils.serializer import dict_filter_none
 from naff.models.discord.enums import Status
@@ -66,6 +66,7 @@ class GatewayClient(WebsocketClient):
         self.session_id = None
 
         self.ws_url = state.gateway_url
+        self.ws_resume_url = MISSING
 
         # This lock needs to be held to send something over the gateway, but is also held when
         # reconnecting. That way there's no race conditions between sending and reconnecting.
@@ -192,11 +193,11 @@ class GatewayClient(WebsocketClient):
 
             case OPCODE.RECONNECT:
                 logger.info("Gateway requested reconnect. Reconnecting...")
-                return await self.reconnect(resume=True)
+                return await self.reconnect(resume=True, url=self.ws_resume_url)
 
             case OPCODE.INVALIDATE_SESSION:
                 logger.warning("Gateway has invalidated session! Reconnecting...")
-                return await self.reconnect(resume=data)
+                return await self.reconnect(resume=data, url=self.ws_resume_url if data else None)
 
             case _:
                 return logger.debug(f"Unhandled OPCODE: {op} = {OPCODE(op).name}")
@@ -208,8 +209,10 @@ class GatewayClient(WebsocketClient):
                 self._trace = data.get("_trace", [])
                 self.sequence = seq
                 self.session_id = data["session_id"]
+                self.ws_resume_url = data["resume_gateway_url"]
                 logger.info(f"Shard {self.shard[0]} has connected to gateway!")
                 logger.debug(f"Session ID: {self.session_id} Trace: {self._trace}")
+                # todo: future polls, improve guild caching here. run the debugger. you'll see why
                 return self.state.client.dispatch(events.WebsocketReady(data))
 
             case "RESUMED":

--- a/naff/api/gateway/websocket.py
+++ b/naff/api/gateway/websocket.py
@@ -236,7 +236,7 @@ class WebsocketClient:
 
             return msg
 
-    async def reconnect(self, *, resume: bool = False, code: int = 1012) -> None:
+    async def reconnect(self, *, resume: bool = False, code: int = 1012, url: str | None = None) -> None:
         async with self._race_lock:
             self._closed.clear()
 
@@ -246,7 +246,7 @@ class WebsocketClient:
             self.ws = None
             self._zlib = zlib.decompressobj()
 
-            self.ws = await self.state.client.http.websocket_connect(self.ws_url)
+            self.ws = await self.state.client.http.websocket_connect(url or self.ws_url)
 
             hello = await self.receive(force=True)
             self.heartbeat_interval = hello["d"]["heartbeat_interval"] / 1000


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Discord decided they wanted to break gateway resumes. This fixes that. At least they gave warning this time 🙃

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- New gateway attribute `ws_resume_url`
- Add new parameter to `ws.reconnect` to make future meddling with ws urls easier 
- Set url param to `ws_resume_url` on reconnect 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
