### PR TITLE
feat: add support for getting a threads message

### DIFF
--- a/naff/api/events/processors/thread_events.py
+++ b/naff/api/events/processors/thread_events.py
@@ -14,10 +14,7 @@ __all__ = ("ThreadEvents",)
 class ThreadEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_thread_create(self, event: "RawGatewayEvent") -> None:
-        thread = self.cache.place_channel_data(event.data)
-        if message := self.cache.get_message(event.data["parent_id"], event.data["id"]):
-            message.thread = thread
-        self.dispatch(events.ThreadCreate(thread))
+        self.dispatch(events.ThreadCreate(self.cache.place_channel_data(event.data)))
 
     @Processor.define()
     async def _on_raw_thread_update(self, event: "RawGatewayEvent") -> None:

--- a/naff/api/events/processors/thread_events.py
+++ b/naff/api/events/processors/thread_events.py
@@ -14,7 +14,10 @@ __all__ = ("ThreadEvents",)
 class ThreadEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_thread_create(self, event: "RawGatewayEvent") -> None:
-        self.dispatch(events.ThreadCreate(self.cache.place_channel_data(event.data)))
+        thread = self.cache.place_channel_data(event.data)
+        if message := self.cache.get_message(event.data["parent_id"], event.data["id"]):
+            message.thread = thread
+        self.dispatch(events.ThreadCreate(thread))
 
     @Processor.define()
     async def _on_raw_thread_update(self, event: "RawGatewayEvent") -> None:

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -1803,6 +1803,11 @@ class ThreadChannel(BaseChannel, MessageableMixin, WebhookMixin):
         return self._client.cache.get_channel(self.parent_id)
 
     @property
+    def parent_message(self) -> Optional["Message"]:
+        """The message this thread is a child of."""
+        return self._client.cache.get_message(self.parent_id, self.id)
+
+    @property
     def mention(self) -> str:
         """Returns a string that would mention this thread."""
         return f"<#{self.id}>"

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -313,7 +313,6 @@ class Message(BaseMessage):
     """Sent if the message contains components like buttons, action rows, or other interactive components"""
     sticker_items: Optional[List["models.StickerItem"]] = field(default=None)
     """Sent if the message contains stickers"""
-    thread: Optional["models.ThreadChannel"] = field(default=None)
     _mention_ids: List["Snowflake_Type"] = field(factory=list)
     _mention_roles: List["Snowflake_Type"] = field(factory=list)
     _referenced_message_id: Optional["Snowflake_Type"] = field(default=None)
@@ -329,6 +328,11 @@ class Message(BaseMessage):
         """A generator of roles mentioned in this message"""
         for r_id in self._mention_roles:
             yield await self._client.cache.fetch_role(self._guild_id, r_id)
+
+    @property
+    def thread(self) -> "models.TYPE_THREAD_CHANNEL":
+        """The thread that was started from this message, if any"""
+        return self._client.cache.get_channel(self.id)
 
     async def fetch_referenced_message(self) -> Optional["Message"]:
         """

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -313,6 +313,7 @@ class Message(BaseMessage):
     """Sent if the message contains components like buttons, action rows, or other interactive components"""
     sticker_items: Optional[List["models.StickerItem"]] = field(default=None)
     """Sent if the message contains stickers"""
+    thread: Optional["models.ThreadChannel"] = field(default=None)
     _mention_ids: List["Snowflake_Type"] = field(factory=list)
     _mention_roles: List["Snowflake_Type"] = field(factory=list)
     _referenced_message_id: Optional["Snowflake_Type"] = field(default=None)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Allows a user to easily access the parent message for a thread, or the child thread of a message.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Determine parent message on thread create
- Add `parent_messsage` property to threads
- Add `thread` property to message 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
