### PR TITLE
fix: give defaults to content vars for automod actions

### DIFF
--- a/naff/models/discord/auto_mod.py
+++ b/naff/models/discord/auto_mod.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union, Any
+from typing import TYPE_CHECKING, Union, Any, Optional
 
 import attrs
 
@@ -283,8 +283,8 @@ class AutoModerationAction(ClientObject):
     action: BaseAction = field(default=MISSING, repr=True)
 
     matched_keyword: str = field(repr=True)
-    matched_content: str = field()
-    content: str = field()
+    matched_content: Optional[str] = field(default=None)
+    content: Optional[str] = field(default=None)
 
     _message_id: Union["Snowflake_Type", None] = field(default=None)
     _alert_system_message_id: "Snowflake_Type" = field()


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
![Error](https://user-images.githubusercontent.com/25420078/184259710-09174097-6e9f-4675-a37f-79631417c47f.png)
![Discord note](https://user-images.githubusercontent.com/25420078/184259731-948342c3-3537-4708-b144-79c95984172a.png)

## Changes
- Make `matched_content` and `content` in `AutoModerationAction` default to `None`, and adjust their typehints accordingly.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
