### PR TITLE
feat: implement REST chunking

### DIFF
--- a/naff/api/events/processors/guild_events.py
+++ b/naff/api/events/processors/guild_events.py
@@ -41,7 +41,7 @@ class GuildEvents(EventMixinTemplate):
 
         if self.fetch_members:  # noqa
             # delays events until chunking has completed
-            await guild.chunk_guild(presences=True)
+            await guild.chunk()
 
         self.dispatch(events.GuildJoin(guild))
 

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -728,13 +728,6 @@ class Client(
         while True:
             try:  # wait to let guilds cache
                 await asyncio.wait_for(self._guild_event.wait(), self.guild_event_timeout)
-                if self.fetch_members:
-                    # ensure all guilds have completed chunking
-                    for guild in self.guilds:
-                        if guild and not guild.chunked.is_set():
-                            logger.debug(f"Waiting for {guild.id} to chunk")
-                            await guild.chunked.wait()
-
             except asyncio.TimeoutError:
                 logger.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
                 break

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -527,7 +527,7 @@ class Guild(BaseGuild):
         self.chunked.set()
         logger.info(f"Cached {len(members)} members for {self.id} in {time.perf_counter() - start_time:.2f} seconds")
 
-    async def gateway_chunk(self, wait=True, presences=False) -> None:
+    async def gateway_chunk(self, wait=True, presences=True) -> None:
         """
         Trigger a gateway `get_members` event, populating this object with members.
 
@@ -544,7 +544,7 @@ class Guild(BaseGuild):
         """Populates all members of this guild using the REST API."""
         await self.http_chunk()
 
-    async def chunk_guild(self, wait=True, presences=False) -> None:
+    async def chunk_guild(self, wait=True, presences=True) -> None:
         """
         Trigger a gateway `get_members` event, populating this object with members.
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR changes the default chunking routine to use the REST api instead of gateway commands. 

The main benifit of this is that we can chunk guilds far faster. Through my testing I have found using REST chunking takes approximately 30% less time than traditional gateway chunking. The main bottleneck remains actually creating the member objects. 
The reasoning why this is faster is the fact that the gateway has far more intense ratelimits than the REST api. This means the client is able to make substantionally more requests in the same interval (while still respecting all ratelimts). On top of this, when gateway-chunking, you must wait for each chunk to arrive at a relatively slow rate.  

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Create `guild.http_chunk`
- Create `guild.chunk` which calls `guild.http_chunk`
- Seperate logic from `guild.chunk_guild` into `guild.gateway_chunk`
- Depreciate `guild.chunk_guild`
- Convert `guild_create` processor to use new `guild.chunk` methoid

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
