### PR TITLE
fix: remove member from guild/cache on remove

### DIFF
--- a/naff/api/events/processors/member_events.py
+++ b/naff/api/events/processors/member_events.py
@@ -25,9 +25,13 @@ class MemberEvents(EventMixinTemplate):
     async def _on_raw_guild_member_remove(self, event: "RawGatewayEvent") -> None:
         g_id = event.data.pop("guild_id")
         user = self.cache.place_user_data(event.data["user"])
+        member = self.cache.get_member(g_id, user.id)
+
+        self.cache.delete_member(g_id, user.id)
         guild = self.cache.get_guild(g_id)
         guild.member_count -= 1
-        self.dispatch(events.MemberRemove(g_id, self.cache.get_member(g_id, user.id) or user))
+
+        self.dispatch(events.MemberRemove(g_id, member or user))
 
     @Processor.define()
     async def _on_raw_guild_member_update(self, event: "RawGatewayEvent") -> None:

--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -231,7 +231,9 @@ class GlobalCache:
         user_id = to_snowflake(user_id)
         guild_id = to_snowflake(guild_id)
 
-        self.member_cache.pop((guild_id, user_id), None)
+        if member := self.member_cache.pop((guild_id, user_id), None):
+            member.guild._member_ids.discard(user_id)
+
         self.delete_user_guild(user_id, guild_id)
 
     def place_user_guild(self, user_id: "Snowflake_Type", guild_id: "Snowflake_Type") -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This PR ensures that guild members are properly removed from the cache and from the guild when they are removed.


## Changes
- Use the `delete_member` method on the `_on_raw_guild_member_remove` processor. This also changes around the logic a bit so that the member is gotten before deletion.
- Make `delete_member` in the cache also remove the member's ID from the internal list of member IDs for the guild.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
