### PR TITLE
fix:  Ensure sets can be serialized

### DIFF
--- a/naff/api/http/http_client.py
+++ b/naff/api/http/http_client.py
@@ -35,7 +35,7 @@ from naff.client.const import (
 )
 from naff.client.errors import DiscordError, Forbidden, GatewayNotFound, HTTPException, NotFound, LoginError
 from naff.client.utils.input_utils import response_decode, OverriddenJson
-from naff.client.utils.serializer import dict_filter_missing
+from naff.client.utils.serializer import dict_filter
 from naff.models import CooldownSystem
 from naff.models.discord.file import UPLOADABLE_TYPE
 from .route import Route
@@ -212,9 +212,9 @@ class HTTPClient(
             return None
 
         if isinstance(payload, dict):
-            payload = dict_filter_missing(payload)
+            payload = dict_filter(payload)
         else:
-            payload = [dict_filter_missing(x) if isinstance(x, dict) else x for x in payload]
+            payload = [dict_filter(x) if isinstance(x, dict) else x for x in payload]
 
         if not files:
             return payload
@@ -262,7 +262,7 @@ class HTTPClient(
         if isinstance(payload, (list, dict)) and not files:
             kwargs["headers"]["Content-Type"] = "application/json"
         if isinstance(params, dict):
-            kwargs["params"] = dict_filter_missing(params)
+            kwargs["params"] = dict_filter(params)
 
         lock = self.get_ratelimit(route)
         # this gets a BucketLock for this route.

--- a/naff/api/http/http_requests/guild.py
+++ b/naff/api/http/http_requests/guild.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import discord_typings
 
 from naff.client.const import Absent, MISSING
-from naff.client.utils.serializer import dict_filter_missing, dict_filter_none
+from naff.client.utils.serializer import dict_filter, dict_filter_none
 
 
 from ..route import Route
@@ -661,7 +661,7 @@ class GuildRequests:
     ) -> dict:
         return await self.request(
             Route("POST", "/guilds"),
-            payload=dict_filter_missing(
+            payload=dict_filter(
                 {
                     "name": name,
                     "icon": icon,

--- a/naff/client/utils/serializer.py
+++ b/naff/client/utils/serializer.py
@@ -9,7 +9,7 @@ from attr import fields, has
 from naff.client.const import MISSING, T
 from naff.models.discord.file import UPLOADABLE_TYPE, File
 
-__all__ = ("no_export_meta", "export_converter", "to_dict", "dict_filter_none", "dict_filter_missing", "to_image_data")
+__all__ = ("no_export_meta", "export_converter", "to_dict", "dict_filter_none", "dict_filter", "to_image_data")
 
 no_export_meta = {"no_export": True}
 
@@ -95,9 +95,9 @@ def dict_filter_none(data: dict) -> dict:
     return {k: v for k, v in data.items() if v is not None}
 
 
-def dict_filter_missing(data: dict) -> dict:
+def dict_filter(data: dict) -> dict:
     """
-    Filters out all values that are MISSING sentinel.
+    Filters out all values that are MISSING sentinel and converts all sets to lists.
 
     Args:
         data: The dict data to filter.
@@ -106,7 +106,13 @@ def dict_filter_missing(data: dict) -> dict:
         The filtered dict data.
 
     """
-    return {k: v for k, v in data.items() if v is not MISSING}
+    filtered = data.copy()
+    for k, v in data.items():
+        if v is MISSING:
+            filtered.pop(k)
+        elif isinstance(v, set):
+            filtered[k] = list(v)
+    return filtered
 
 
 def to_image_data(imagefile: Optional[UPLOADABLE_TYPE]) -> Optional[str]:

--- a/naff/models/discord/role.py
+++ b/naff/models/discord/role.py
@@ -6,7 +6,7 @@ import attrs
 from naff.client.const import MISSING, Absent, T
 from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import optional as optional_c
-from naff.client.utils.serializer import dict_filter_missing
+from naff.client.utils.serializer import dict_filter
 from naff.models.discord.asset import Asset
 from naff.models.discord.emoji import PartialEmoji
 from naff.models.discord.color import Color
@@ -190,7 +190,7 @@ class Role(DiscordObject):
         if isinstance(color, Color):
             color = color.value
 
-        payload = dict_filter_missing(
+        payload = dict_filter(
             {"name": name, "permissions": permissions, "color": color, "hoist": hoist, "mentionable": mentionable}
         )
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
In order to serialize sets, we either:
- need to do it in the serializer level, with a `defaults=` parameter when we call `json.dumps`
- need to convert them to something the default serializer can handle.

Because we don't control aioclient's serializer, I opted with the easier second option.


## Changes
Changed the existing `dict_filter_missing` function to also process sets into lists.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
