### PR TITLE
fix: make fields for automod action optional

### DIFF
--- a/naff/models/discord/auto_mod.py
+++ b/naff/models/discord/auto_mod.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union, Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 import attrs
 
@@ -286,9 +286,9 @@ class AutoModerationAction(ClientObject):
     matched_content: Optional[str] = field(default=None)
     content: Optional[str] = field(default=None)
 
-    _message_id: Union["Snowflake_Type", None] = field(default=None)
-    _alert_system_message_id: "Snowflake_Type" = field()
-    _channel_id: "Snowflake_Type" = field()
+    _message_id: Optional["Snowflake_Type"] = field(default=None)
+    _alert_system_message_id: Optional["Snowflake_Type"] = field(default=None)
+    _channel_id: Optional["Snowflake_Type"] = field(default=None)
     _guild_id: "Snowflake_Type" = field()
 
     @classmethod
@@ -302,11 +302,11 @@ class AutoModerationAction(ClientObject):
         return self._client.get_guild(self._guild_id)
 
     @property
-    def channel(self) -> "GuildText":
+    def channel(self) -> "Optional[GuildText]":
         return self._client.get_channel(self._channel_id)
 
     @property
-    def message(self) -> "Message":
+    def message(self) -> "Optional[Message]":
         return self._client.cache.get_message(self._channel_id, self._message_id)
 
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
This PR goes in to compare [the Discord docs](https://discord.com/developers/docs/topics/gateway#auto-moderation-action-execution-auto-moderation-action-execution-event-fields) with the current `AutoModerationAction` to (try to) ensure every field that can be optional is marked as so.


## Changes

- Make all fields marked as optional on the Discord documentation optional in NAFF.
  - Channels were adjusted so that they report they are optional, too.
  - Since messages are optional, the `message` property has also been marked as optional.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
