### PR TITLE
feat:  Allow tasks to redefine their triggers by returning a trigger

### DIFF
--- a/naff/models/naff/tasks/task.py
+++ b/naff/models/naff/tasks/task.py
@@ -59,9 +59,12 @@ class Task:
     async def __call__(self) -> None:
         try:
             if inspect.iscoroutinefunction(self.callback):
-                await self.callback()
+                val = await self.callback()
             else:
-                self.callback()
+                val = self.callback()
+
+            if isinstance(val, BaseTrigger):
+                self.trigger = val
         except Exception as e:
             self.on_error(e)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
It's incredibly niche, but it'd make my life a lot easier.
This allows a task to return a Replacement Trigger, allowing tasks to dynamically adjust themselves based on load or external influences.

This definitely needs to get documented somewhere, but that's for the docs branch.


## Changes
- Checks the return type of tasks, and if it's a Trigger, replace the existing one.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
