### PR TITLE
feat: add listener shortcut to event objects

### DIFF
--- a/naff/api/events/internal.py
+++ b/naff/api/events/internal.py
@@ -21,11 +21,12 @@ These are events dispatched by the client. This is intended as a reference so yo
 
 """
 import re
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Callable, Coroutine
 
 from naff.client.const import MISSING
 from naff.models.discord.snowflake import to_snowflake
 from naff.client.utils.attr_utils import define, field, docs
+import naff.models as models
 
 __all__ = (
     "BaseEvent",
@@ -69,6 +70,32 @@ class BaseEvent:
         """The name of the event, defaults to the class name if not overridden."""
         name = self.override_name or self.__class__.__name__
         return _event_reg.sub("_", name).lower()
+
+    @classmethod
+    def listen(cls, coro: Callable[..., Coroutine], client: "Client") -> "models.Listener":
+        """
+        A shortcut for creating a listener for this event
+
+        Args:
+            coro: The coroutine to call when the event is triggered.
+            client: The client instance to listen to.
+
+
+        ??? Hint "Example Usage:"
+            ```python
+            class SomeClass:
+                def __init__(self, bot: Client):
+                    Ready.listen(self.some_func, bot)
+
+                async def some_func(self, event):
+                    print(f"{event.resolved_name} triggered")
+            ```
+        Returns:
+            A listener object.
+        """
+        listener = models.Listener.create(cls().resolved_name)(coro)
+        client.add_listener(listener)
+        return listener
 
 
 @define(slots=False, kw_only=False)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Allows you to add a listener to an event directly from the event class itself. Purely a shortcut method for nicer code.

```python
# before
bot.add_listener(Listener.create("player_update")(self._player_state_update))

# after
PlayerUpdate.listen(self.player_state_update, bot)
```
## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add listener classmethod to `_BaseEvent`


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
