### PR TITLE
feat: add dict postprocessing in sync comparison

### DIFF
--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1074,7 +1074,7 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),
     }
-    post_process: Dict[str, Any] = {
+    post_process: Dict[str, Callable] = {
         "choices": lambda l: [d | {"name_localizations": {}} if len(d) == 2 else d for d in l],
     }
 

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1074,6 +1074,9 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),
     }
+    post_process: Dict[str, Any] = {
+        "choices": lambda l: [d | {"name_localizations": {}} if len(d) == 2 else d for d in l],
+    }
 
     if local_opt_list != remote_opt_list:
         if len(local_opt_list) != len(remote_opt_list):
@@ -1091,7 +1094,9 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
                 else:
                     for local_name, comparison_data in options_lookup.items():
                         remote_name, default_value = comparison_data
-                        if local_option.get(local_name, default_value) != remote_option.get(remote_name, default_value):
+                        if local_option.get(local_name, default_value) != post_process.get(remote_name, lambda l: l)(
+                            remote_option.get(remote_name, default_value)
+                        ):
                             return False
 
             else:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Discord loves not sending data, we know that. This pr adds a post_processing system to option comparison, which currently is the problem-child. 

Post processing, in effect, adds any missing keys that discord decided weren't worth sending. The system has been built to be scalable, simply add the field name that needs processing, and a lambda function to inact the change. 

I'm marking this as a discord bug as this is discord deciding not to send data, causing us to have to handle their issues. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add post_processing dict to compare_options
- Call lambda function when comparing options

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
