### PR TITLE
fix: Fix localisation syncing 

### DIFF
--- a/naff/api/http/http_requests/interactions.py
+++ b/naff/api/http/http_requests/interactions.py
@@ -35,7 +35,7 @@ class InteractionRequests:
         )
 
     async def get_application_commands(
-        self, application_id: "Snowflake_Type", guild_id: "Snowflake_Type"
+        self, application_id: "Snowflake_Type", guild_id: "Snowflake_Type", with_localisations: bool = True
     ) -> List[discord_typings.ApplicationCommandData]:
         """
         Get all application commands for this application from discord.
@@ -43,14 +43,21 @@ class InteractionRequests:
         Args:
             application_id: the what application to query
             guild_id: specify a guild to get commands from
+            with_localisations: whether to include all localisations in the response
 
         Returns:
             Application command data
 
         """
         if guild_id == GLOBAL_SCOPE:
-            return await self.request(Route("GET", f"/applications/{application_id}/commands"))
-        return await self.request(Route("GET", f"/applications/{application_id}/guilds/{guild_id}/commands"))
+            return await self.request(
+                Route("GET", f"/applications/{application_id}/commands"),
+                params={"with_localizations": int(with_localisations)},
+            )
+        return await self.request(
+            Route("GET", f"/applications/{application_id}/guilds/{guild_id}/commands"),
+            params={"with_localizations": int(with_localisations)},
+        )
 
     async def overwrite_application_commands(
         self, app_id: "Snowflake_Type", data: List[Dict], guild_id: "Snowflake_Type" = None

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1074,7 +1074,7 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),
     }
-    post_process: Dict[str, Any] = {
+    post_process: Dict[str, Callable] = {
         "choices": lambda l: [d | {"name_localizations": {}} if len(d) == 2 else d for d in l],
     }
 

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1051,8 +1051,8 @@ def _compare_commands(local_cmd: dict, remote_cmd: dict) -> bool:
         "description": ("description", ""),
         "default_member_permissions": ("default_member_permissions", None),
         "dm_permission": ("dm_permission", True),
-        "name_localized": ("name_localizations", {}),
-        "description_localized": ("description_localizations", {}),
+        "name_localized": ("name_localizations", None),
+        "description_localized": ("description_localizations", None),
     }
 
     for local_name, comparison_data in lookup.items():
@@ -1068,8 +1068,8 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "description": ("description", ""),
         "required": ("required", False),
         "autocomplete": ("autocomplete", False),
-        "name_localized": ("name_localizations", {}),
-        "description_localized": ("description_localizations", {}),
+        "name_localized": ("name_localizations", None),
+        "description_localized": ("description_localizations", None),
         "choices": ("choices", []),
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),
@@ -1087,7 +1087,7 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
 
             if local_option["type"] == remote_option["type"]:
                 if local_option["type"] in (OptionTypes.SUB_COMMAND_GROUP, OptionTypes.SUB_COMMAND):
-                    if not _compare_commands(local_option, remote_option) or _compare_options(
+                    if not _compare_commands(local_option, remote_option) or not _compare_options(
                         local_option.get("options", []), remote_option.get("options", [])
                     ):
                         return False

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1074,6 +1074,9 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),
     }
+    post_process: Dict[str, Any] = {
+        "choices": lambda l: [d | {"name_localizations": {}} if len(d) == 2 else d for d in l],
+    }
 
     if local_opt_list != remote_opt_list:
         if len(local_opt_list) != len(remote_opt_list):
@@ -1091,7 +1094,9 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
                 else:
                     for local_name, comparison_data in options_lookup.items():
                         remote_name, default_value = comparison_data
-                        if local_option.get(local_name, default_value) != remote_option.get(remote_name, default_value):
+                        if local_option.get(local_name, default_value) != post_process.get(remote_name, lambda l: l)(
+                            remote_option.get(remote_name, default_value)
+                        ):
                             return False
 
             else:

--- a/naff/models/naff/localisation.py
+++ b/naff/models/naff/localisation.py
@@ -120,6 +120,9 @@ class LocalisedField:
                 if "locale-code" in attr.metadata:
                     if val := getattr(self, attr.name):
                         data[attr.metadata["locale-code"]] = val
+
+        if not data:
+            data = None  # handle discord being stupid
         return data
 
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR fixes command syncing to accomodate discords ~~bad~~ implimentation of localisation. The changes aren't that extensive but handle weird edge-cases. 

This post-processing from this PR was originally from #613 - however it made more sense to be included in this pr 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Impliment the `with_localization` field of command requests that wolf pointed out wasn't commited 
- Handle discord sending `NoneType` instead of `{}`
- Post-process missing attributes of choices

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
