### PR TITLE
fix: handle guild not existing in the cache

### DIFF
--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -232,7 +232,8 @@ class GlobalCache:
         guild_id = to_snowflake(guild_id)
 
         if member := self.member_cache.pop((guild_id, user_id), None):
-            member.guild._member_ids.discard(user_id)
+            if member.guild:
+                member.guild._member_ids.discard(user_id)
 
         self.delete_user_guild(user_id, guild_id)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Should the guild be not in the in the cache, an attribute error will occur on removal of a member (incld the bot itself), this fixes that. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Check if the guild exists before trying to access it 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
