### PR TITLE
fix: dont rechunk guilds on reconnect

### DIFF
--- a/naff/api/events/processors/guild_events.py
+++ b/naff/api/events/processors/guild_events.py
@@ -39,7 +39,7 @@ class GuildEvents(EventMixinTemplate):
 
         self._guild_event.set()
 
-        if self.fetch_members:  # noqa
+        if self.fetch_members and not guild.chunked.is_set():  # noqa
             # delays events until chunking has completed
             await guild.chunk()
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
- This pr prevents the lib from re-chunking guilds on a reconnect event

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Check the chunked state of a guild before requesting a chunk operation


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
