### PR TITLE
feat: implement dunder str in httpexception

### DIFF
--- a/naff/client/errors.py
+++ b/naff/client/errors.py
@@ -104,6 +104,11 @@ class HTTPException(NaffException):
                 self.text = data
         super().__init__(f"{self.status}|{self.response.reason}: {f'({self.code}) ' if self.code else ''}{self.text}")
 
+    def __str__(self) -> str:
+        errors = self.search_for_message(self.errors)
+        out = f"HTTPException: {self.status}|{self.response.reason}: " + "\n".join(errors)
+        return out
+
     @staticmethod
     def search_for_message(errors: dict, lookup: Optional[dict] = None) -> list[str]:
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This pr implements a `__str__` method in `http_exception` which helps prevent `Invalid Form Body` appearing in your logs

```python
print(e)
```
Before:
![image](https://user-images.githubusercontent.com/22540825/187523766-48cfa83a-5cda-455a-a156-3e6455e2ba80.png)
After:
![image](https://user-images.githubusercontent.com/22540825/187523842-3cdacfcc-fc8d-47f2-972b-768c0aa61288.png)


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
