### PR TITLE
fix: restore ability to resume ++

### DIFF
--- a/naff/api/gateway/gateway.py
+++ b/naff/api/gateway/gateway.py
@@ -7,7 +7,7 @@ from types import TracebackType
 from typing import TypeVar, TYPE_CHECKING
 
 from naff.api import events
-from naff.client.const import logger, MISSING
+from naff.client.const import logger, MISSING, __api_version__
 from naff.client.utils.input_utils import OverriddenJson
 from naff.client.utils.serializer import dict_filter_none
 from naff.models.discord.enums import Status
@@ -48,7 +48,6 @@ class GatewayClient(WebsocketClient):
     Multiple `WebsocketClient` instances can be used to implement same-process sharding.
 
     Attributes:
-        buffer: A buffer to hold incoming data until its complete
         sequence: The sequence of this connection
         session_id: The session ID of this connection
 
@@ -83,7 +82,7 @@ class GatewayClient(WebsocketClient):
         self._ready = asyncio.Event()
         self._close_gateway = asyncio.Event()
 
-        # Santity check, it is extremely important that an instance isn't reused.
+        # Sanity check, it is extremely important that an instance isn't reused.
         self._entered = False
 
     async def __aenter__(self: SELF) -> SELF:
@@ -177,6 +176,7 @@ class GatewayClient(WebsocketClient):
         match op:
 
             case OPCODE.HEARTBEAT:
+                logger.debug("Received heartbeat request from gateway")
                 return await self.send_heartbeat()
 
             case OPCODE.HEARTBEAT_ACK:
@@ -192,7 +192,7 @@ class GatewayClient(WebsocketClient):
                 return self._acknowledged.set()
 
             case OPCODE.RECONNECT:
-                logger.info("Gateway requested reconnect. Reconnecting...")
+                logger.debug("Gateway requested reconnect. Reconnecting...")
                 return await self.reconnect(resume=True, url=self.ws_resume_url)
 
             case OPCODE.INVALIDATE_SESSION:
@@ -209,7 +209,9 @@ class GatewayClient(WebsocketClient):
                 self._trace = data.get("_trace", [])
                 self.sequence = seq
                 self.session_id = data["session_id"]
-                self.ws_resume_url = data["resume_gateway_url"]
+                self.ws_resume_url = (
+                    f"{data['resume_gateway_url']}?encoding=json&v={__api_version__}&compress=zlib-stream"
+                )
                 logger.info(f"Shard {self.shard[0]} has connected to gateway!")
                 logger.debug(f"Session ID: {self.session_id} Trace: {self._trace}")
                 # todo: future polls, improve guild caching here. run the debugger. you'll see why
@@ -287,7 +289,7 @@ class GatewayClient(WebsocketClient):
         logger.debug(f"{self.shard[0]} is attempting to resume a connection")
 
     async def send_heartbeat(self) -> None:
-        await self.send_json({"op": OPCODE.HEARTBEAT, "d": self.sequence}, True)
+        await self.send_json({"op": OPCODE.HEARTBEAT, "d": self.sequence}, bypass=True)
         logger.debug(f"❤ Shard {self.shard[0]} is sending a Heartbeat")
 
     async def change_presence(self, activity=None, status: Status = Status.ONLINE, since=None) -> None:

--- a/naff/api/gateway/websocket.py
+++ b/naff/api/gateway/websocket.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import random
 import time
 import zlib
 from abc import abstractmethod
@@ -275,12 +276,12 @@ class WebsocketClient:
         if self.heartbeat_interval is None:
             raise RuntimeError
 
-        # try:
-        #     await asyncio.wait_for(self._kill_bee_gees.wait(), timeout=self.heartbeat_interval * random.uniform(0, 0.5))
-        # except asyncio.TimeoutError:
-        #     pass
-        # else:
-        #     return
+        try:
+            await asyncio.wait_for(self._kill_bee_gees.wait(), timeout=self.heartbeat_interval * random.uniform(0, 0.5))
+        except asyncio.TimeoutError:
+            pass
+        else:
+            return
 
         logger.debug(f"Sending heartbeat every {self.heartbeat_interval} seconds")
         while not self._kill_bee_gees.is_set():


### PR DESCRIPTION
also fixes minor gripes i had while debugging

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR restores NAFF's ability to reliably resume a connection to the gateway. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Recompose resume url to account for missing data 
- Fix minor typos, logging levels
- Restore jitter delay on heartbeater 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
