### PR TITLE
feat: use async iterator to speedup http chunking

### DIFF
--- a/naff/models/misc/iterator.py
+++ b/naff/models/misc/iterator.py
@@ -36,6 +36,11 @@ class AsyncIterator(_AsyncIterator, ABC):
         """Get how the maximum number of items that should be retrieved."""
         return min(self._limit - len(self._retrieved_objects), 100) if self._limit else 100
 
+    @property
+    def total_retrieved(self) -> int:
+        """Get the total number of objects this iterator has retrieved."""
+        return len(self._retrieved_objects)
+
     async def add_object(self, obj) -> None:
         """Add an object to iterator's queue."""
         return await self._queue.put(obj)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This pr further speeds up guild chunking by leveraging the AsyncIterator to fetch members. This means the bot caches members as it fetches them, rather than fetching them all then caching. It also resolves the blocking problem as the async iterator wont block the event loop. 

Overall this is only a ~10% speed improvement per chunk, but every little helps. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Impliment member iterator 
- Utitlise async iterator in chunking
- Add total_retrieved property to async iterator 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
