### PR TITLE
fix: dont use resume_url on invalid session

### DIFF
--- a/naff/api/gateway/gateway.py
+++ b/naff/api/gateway/gateway.py
@@ -197,7 +197,7 @@ class GatewayClient(WebsocketClient):
 
             case OPCODE.INVALIDATE_SESSION:
                 logger.warning("Gateway has invalidated session! Reconnecting...")
-                return await self.reconnect(resume=data, url=self.ws_resume_url if data else None)
+                return await self.reconnect()
 
             case _:
                 return logger.debug(f"Unhandled OPCODE: {op} = {OPCODE(op).name}")


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
As per https://github.com/discord/discord-api-docs/pull/5323 : We shouldnt be using the gw resume url on invalidation of the session 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
