### PR TITLE
fix: Add delete_message_seconds to ban helpers

### DIFF
--- a/naff/api/http/http_requests/guild.py
+++ b/naff/api/http/http_requests/guild.py
@@ -253,7 +253,7 @@ class GuildRequests(CanRequest):
         self,
         guild_id: "Snowflake_Type",
         user_id: "Snowflake_Type",
-        delete_message_days: int = 0,
+        delete_message_seconds: int = 0,
         reason: str | None = None,
     ) -> None:
         """
@@ -262,11 +262,11 @@ class GuildRequests(CanRequest):
         Args:
             guild_id: The ID of the guild to create the ban in
             user_id: The ID of the user to ban
-            delete_message_days: number of days to delete messages for (0-7)
+            delete_message_seconds: number of seconds to delete messages for (0-604800)
             reason: The reason for this action
 
         """
-        payload = {"delete_message_days": delete_message_days}
+        payload = {"delete_message_seconds": delete_message_seconds}
         await self.request(Route("PUT", f"/guilds/{int(guild_id)}/bans/{int(user_id)}"), payload=payload, reason=reason)
 
     async def remove_guild_ban(

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -1594,7 +1594,8 @@ class Guild(BaseGuild):
     async def ban(
         self,
         user: Union["models.User", "models.Member", Snowflake_Type],
-        delete_message_days: int = 0,
+        delete_message_days: Absent[int] = MISSING,
+        delete_message_seconds: int = 0,
         reason: Absent[str] = MISSING,
     ) -> None:
         """
@@ -1605,11 +1606,15 @@ class Guild(BaseGuild):
 
         Args:
             user: The user to ban
-            delete_message_days: How many days worth of messages to remove
+            delete_message_days: (deprecated) How many days worth of messages to remove
+            delete_message_seconds: How many seconds worth of messages to remove
             reason: The reason for the ban
 
         """
-        await self._client.http.create_guild_ban(self.id, to_snowflake(user), delete_message_days, reason=reason)
+        if delete_message_days is not MISSING:
+            warn("delete_message_days is deprecated and will be removed in a future update", DeprecationWarning)
+            delete_message_seconds = delete_message_days * 3600
+        await self._client.http.create_guild_ban(self.id, to_snowflake(user), delete_message_seconds, reason=reason)
 
     async def fetch_ban(self, user: Union["models.User", "models.Member", Snowflake_Type]) -> Optional[GuildBan]:
         """

--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Iterable, Set, Dict, List, Optional, Union
+from warnings import warn
 
 from naff.client.const import MISSING, logger, Absent
 from naff.client.errors import HTTPException, TooManyChanges
@@ -599,13 +600,19 @@ class Member(DiscordObject, _SendDMMixin):
         """
         await self._client.http.remove_guild_member(self._guild_id, self.id, reason=reason)
 
-    async def ban(self, delete_message_days: int = 0, reason: Absent[str] = MISSING) -> None:
+    async def ban(
+        self, delete_message_days: Absent[int] = MISSING, delete_message_seconds: int = 0, reason: Absent[str] = MISSING
+    ) -> None:
         """
         Ban a member from the guild.
 
         Args:
-            delete_message_days: The number of days of messages to delete
+            delete_message_days: (deprecated) The number of days of messages to delete
+            delete_message_seconds: The number of seconds of messages to delete
             reason: The reason for this ban
 
         """
-        await self._client.http.create_guild_ban(self._guild_id, self.id, delete_message_days, reason=reason)
+        if delete_message_days is not MISSING:
+            warn("delete_message_days  is deprecated and will be removed in a future update", DeprecationWarning)
+            delete_message_seconds = delete_message_days * 3600
+        await self._client.http.create_guild_ban(self._guild_id, self.id, delete_message_seconds, reason=reason)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Discord is deprecating `delete_message_days` on bans in favor of `delete_message_seconds`

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `delete_message_seconds` field to `ban` helper functions in Guild and User
- Add deprecation warning on `delete_message_days` value not being MISSING
  - Convert `delete_message_days` value to `delete_message_seconds` if used

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [X] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [X] I've ensured my code works on `Python 3.10.x`
- [X] I've tested my code
