### PR TITLE
feat: restore asyncio debug in debug ext

### DIFF
--- a/naff/ext/debug_extension/__init__.py
+++ b/naff/ext/debug_extension/__init__.py
@@ -1,5 +1,6 @@
-import logging
+import asyncio
 import platform
+import tracemalloc
 
 from naff import Client, Extension, listen, slash_command, InteractionContext, Timestamp, TimestampStyles, Intents
 from naff.client.const import logger, __version__, __py_version__
@@ -14,10 +15,18 @@ __all__ = ("DebugExtension",)
 
 class DebugExtension(DebugExec, DebugAppCMD, DebugExts, Extension):
     def __init__(self, bot: Client) -> None:
+        logger.info("Debug Extension is mounting!")
+
         super().__init__(bot)
         self.add_ext_check(checks.is_owner())
 
-        logger.info("Debug Extension is growing!")
+        tracemalloc.start()
+        logger.warning("Tracemalloc started")
+
+    async def async_start(self) -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_debug(True)
+        logger.warning("Asyncio debug mode is enabled")
 
     @listen()
     async def on_startup(self) -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This pr restores the debug ext behaviour of setting asyncio to its DEBUG mode and enabling tracemaloc. This functionality was removed when we migrated to not using the loop variable in accordance with asyncio. This adds it in a compliant manor.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Set asyncio to debug in an async start task
- Start tracemaloc on ext load
- Log the above at warning level 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
