### PR TITLE
fix: handle discord not sending an error attrib in exceptions

### DIFF
--- a/naff/client/errors.py
+++ b/naff/client/errors.py
@@ -105,8 +105,11 @@ class HTTPException(NaffException):
         super().__init__(f"{self.status}|{self.response.reason}: {f'({self.code}) ' if self.code else ''}{self.text}")
 
     def __str__(self) -> str:
-        errors = self.search_for_message(self.errors)
-        out = f"HTTPException: {self.status}|{self.response.reason}: " + "\n".join(errors)
+        if self.errors:
+            errors = self.search_for_message(self.errors)
+            out = f"HTTPException: {self.status}|{self.response.reason}: " + "\n".join(errors)
+        else:
+            out = f"HTTPException: {self.status}|{self.response.reason} || {self.text}"
         return out
 
     @staticmethod


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This pr handles discord not sending an error attribute with exceptions. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Use text attribute when no error attribute passed

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
