### PR TITLE
feat 💥: delay non-raw listeners until client ready

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -34,7 +34,6 @@ from discord_typings.interactions.receiving import (
 
 import naff.api.events as events
 import naff.client.const as constants
-from naff.models.naff.context import SendableContext
 from naff.api.events import MessageCreate, RawGatewayEvent, processors, Component, BaseEvent
 from naff.api.gateway.gateway import GatewayClient
 from naff.api.gateway.state import ConnectionState
@@ -99,6 +98,7 @@ from naff.models.discord.modal import Modal
 from naff.models.naff.active_voice_state import ActiveVoiceState
 from naff.models.naff.application_commands import ModalCommand
 from naff.models.naff.auto_defer import AutoDefer
+from naff.models.naff.context import SendableContext
 from naff.models.naff.hybrid_commands import _prefixed_from_slash, _base_subcommand_generator
 from naff.models.naff.listener import Listener
 from naff.models.naff.tasks import Task
@@ -555,7 +555,7 @@ class Client(
     def _queue_task(self, coro: Listener, event: BaseEvent, *args, **kwargs) -> asyncio.Task:
         async def _async_wrap(_coro: Listener, _event: BaseEvent, *_args, **_kwargs) -> None:
             try:
-                if not isinstance(_event, RawGatewayEvent):
+                if not isinstance(_event, (events.Error, events.RawGatewayEvent)):
                     if coro.delay_until_ready and not self.is_ready:
                         await self.wait_until_ready()
 

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -555,6 +555,10 @@ class Client(
     def _queue_task(self, coro: Listener, event: BaseEvent, *args, **kwargs) -> asyncio.Task:
         async def _async_wrap(_coro: Listener, _event: BaseEvent, *_args, **_kwargs) -> None:
             try:
+                if not isinstance(_event, RawGatewayEvent):
+                    if coro.delay_until_ready and not self.is_ready:
+                        await self.wait_until_ready()
+
                 if len(_event.__attrs_attrs__) == 2:
                     # override_name & bot
                     await _coro()

--- a/naff/models/naff/listener.py
+++ b/naff/models/naff/listener.py
@@ -16,20 +16,26 @@ class Listener(CallbackObject):
     """Name of the event to listen to."""
     callback: Coroutine
     """Coroutine to call when the event is triggered."""
+    delay_until_ready: bool
+    """whether to delay the event until the client is ready"""
 
-    def __init__(self, func: Callable[..., Coroutine], event: str) -> None:
+    def __init__(self, func: Callable[..., Coroutine], event: str, *, delay_until_ready: bool = True) -> None:
         super().__init__()
 
         self.event = event
         self.callback = func
+        self.delay_until_ready = delay_until_ready
 
     @classmethod
-    def create(cls, event_name: Absent[str | BaseEvent] = MISSING) -> Callable[[Coroutine], "Listener"]:
+    def create(
+        cls, event_name: Absent[str | BaseEvent] = MISSING, *, delay_until_ready: bool = True
+    ) -> Callable[[Coroutine], "Listener"]:
         """
         Decorator for creating an event listener.
 
         Args:
             event_name: The name of the event to listen to. If left blank, event name will be inferred from the function name or parameter.
+            delay_until_ready: Whether to delay the listener until the client is ready.
 
         Returns:
             A listener object.
@@ -55,20 +61,23 @@ class Listener(CallbackObject):
                 if not name:
                     name = coro.__name__
 
-            return cls(coro, get_event_name(name))
+            return cls(coro, get_event_name(name), delay_until_ready=delay_until_ready)
 
         return wrapper
 
 
-def listen(event_name: Absent[str | BaseEvent] = MISSING) -> Callable[[Callable[..., Coroutine]], Listener]:
+def listen(
+    event_name: Absent[str | BaseEvent] = MISSING, *, delay_until_ready: bool = True
+) -> Callable[[Callable[..., Coroutine]], Listener]:
     """
     Decorator to make a function an event listener.
 
     Args:
         event_name: The name of the event to listen to. If left blank, event name will be inferred from the function name or parameter.
+        delay_until_ready: Whether to delay the listener until the client is ready.
 
     Returns:
         A listener object.
 
     """
-    return Listener.create(event_name)
+    return Listener.create(event_name, delay_until_ready=delay_until_ready)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Delays the execution of listeners until the client is in a ready state. By default, all non-raw listeners are delayed. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `delay_until_ready` attribute to listeners
- On execution, check if client is ready, if not, wait

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
