### PR TITLE
refactor💥: Improved ux for select menus

### DIFF
--- a/docs/src/Guides/05 Components.md
+++ b/docs/src/Guides/05 Components.md
@@ -103,7 +103,7 @@ Selects are very similar to Buttons. The main difference is that they need optio
 
 You can also define how many options users can choose by setting `min_values` and `max_values`.
 ```python
-components = Select(
+components = SelectMenu(
     options=[
         SelectOption(
             label="Pizza",

--- a/naff/models/naff/listener.py
+++ b/naff/models/naff/listener.py
@@ -16,20 +16,26 @@ class Listener(CallbackObject):
     """Name of the event to listen to."""
     callback: Coroutine
     """Coroutine to call when the event is triggered."""
+    delay_until_ready: bool
+    """whether to delay the event until the client is ready"""
 
-    def __init__(self, func: Callable[..., Coroutine], event: str) -> None:
+    def __init__(self, func: Callable[..., Coroutine], event: str, *, delay_until_ready: bool = True) -> None:
         super().__init__()
 
         self.event = event
         self.callback = func
+        self.delay_until_ready = delay_until_ready
 
     @classmethod
-    def create(cls, event_name: Absent[str | BaseEvent] = MISSING) -> Callable[[Coroutine], "Listener"]:
+    def create(
+        cls, event_name: Absent[str | BaseEvent] = MISSING, *, delay_until_ready: bool = True
+    ) -> Callable[[Coroutine], "Listener"]:
         """
         Decorator for creating an event listener.
 
         Args:
             event_name: The name of the event to listen to. If left blank, event name will be inferred from the function name or parameter.
+            delay_until_ready: Whether to delay the listener until the client is ready.
 
         Returns:
             A listener object.
@@ -55,20 +61,23 @@ class Listener(CallbackObject):
                 if not name:
                     name = coro.__name__
 
-            return cls(coro, get_event_name(name))
+            return cls(coro, get_event_name(name), delay_until_ready=delay_until_ready)
 
         return wrapper
 
 
-def listen(event_name: Absent[str | BaseEvent] = MISSING) -> Callable[[Callable[..., Coroutine]], Listener]:
+def listen(
+    event_name: Absent[str | BaseEvent] = MISSING, *, delay_until_ready: bool = True
+) -> Callable[[Callable[..., Coroutine]], Listener]:
     """
     Decorator to make a function an event listener.
 
     Args:
         event_name: The name of the event to listen to. If left blank, event name will be inferred from the function name or parameter.
+        delay_until_ready: Whether to delay the listener until the client is ready.
 
     Returns:
         A listener object.
 
     """
-    return Listener.create(event_name)
+    return Listener.create(event_name, delay_until_ready=delay_until_ready)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -383,7 +383,7 @@ async def test_components(bot: Client, channel: GuildText) -> None:
             components=naff.ActionRow(*[naff.Button(1, "test"), naff.Button(1, "test")]),
         )
         await thread.send(
-            "Test - Select",
+            "Test - SelectMenu",
             components=naff.Select([SelectOption("test", "test")]),
         )
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Updates Select Menu ux to be not shit.

Before
```python
await channel.send(
        "Old SelectUX",
        components=Select(
            options=[
                SelectOption("test1", "test1"),
                SelectOption("test2", "test2"),
                SelectOption("test3", "test3"),
            ],
            placeholder="test",
        ),
    )
```
After
```python
await channel.send(
        "New SelectMenu Menu UX test", components=SelectMenu(["test1", "test2", "test3"], placeholder="test")
    )
```
It is worth noting migration *should* be as simple as replacing `Select` with `SelectMenu`


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Options can now be *any* reasonable type, be it `SelectOption`, `dict`, `iterable`, or `str`
- Only `options` arg is positional, everything else is kwarg
- Renamed `Select` -> `SelectMenu` to avoid conflicts with the event called `Select`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
