### PR TITLE
fix: fix usage of hybrid cmds with no localized names

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1128,7 +1128,7 @@ class Client(
             prefixed_base = self.prefixed_commands.get(str(command.name))
             if not prefixed_base:
                 prefixed_base = _base_subcommand_generator(
-                    str(command.name), list(command.name.to_locale_dict().values()), str(command.description)
+                    str(command.name), list((command.name.to_locale_dict() or {}).values()), str(command.description)
                 )
                 self.add_prefixed_command(prefixed_base)
 
@@ -1139,7 +1139,7 @@ class Client(
                 if not prefixed_base:
                     prefixed_base = _base_subcommand_generator(
                         str(command.group_name),
-                        list(command.group_name.to_locale_dict().values()),
+                        list((command.group_name.to_locale_dict() or {}).values()),
                         str(command.group_description),
                         group=True,
                     )

--- a/naff/models/naff/hybrid_commands.py
+++ b/naff/models/naff/hybrid_commands.py
@@ -394,9 +394,9 @@ def _prefixed_from_slash(cmd: SlashCommand) -> _HybridPrefixedCommand:
 
     prefixed_cmd = _HybridPrefixedCommand(
         name=str(cmd.sub_cmd_name) if cmd.is_subcommand else str(cmd.name),
-        aliases=list(cmd.sub_cmd_name.to_locale_dict().values())
+        aliases=list((cmd.sub_cmd_name.to_locale_dict() or {}).values())
         if cmd.is_subcommand
-        else list(cmd.name.to_locale_dict().values()),
+        else list((cmd.name.to_locale_dict() or {}).values()),
         help=str(cmd.sub_cmd_description) if cmd.is_subcommand else str(cmd.description),
         callback=cmd.callback,
         extension=cmd.extension,


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Seems like Polls fixed Discord localization syncing by making `to_locale_dict` return `None` if the there's no localization. This screwed over assumptions hybrid commands made, so this PR ensures that there will always be a dict to work with.


## Changes
- Make every usage of `to_locale_dict` use `to_locale_dict() or {}` for hybrid commands. This requires some ugly parenthesis, but otherwise works fine.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
