### PR TITLE
fix: Correctly reschedule tasks when they return a new trigger

### DIFF
--- a/naff/models/naff/tasks/task.py
+++ b/naff/models/naff/tasks/task.py
@@ -84,7 +84,7 @@ class Task:
                 val = self.callback()
 
             if isinstance(val, BaseTrigger):
-                self.trigger = val
+                self.reschedule(val)
         except Exception as e:
             self.on_error(e)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
When I originally implemented the return trigger functionality, I missed that there was a .reschedule() method.  I also missed that without using it, passing DateTriggers wouldn't work, as the task would have already stopped itself.


## Changes
- Changed `Task.__call__` to use the helper method, rather than assigning `self.trigger` directly.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
