### PR TITLE
fix💥: make naff always use the correct logger

### DIFF
--- a/naff/api/events/processors/message_events.py
+++ b/naff/api/events/processors/message_events.py
@@ -55,7 +55,7 @@ class MessageEvents(EventMixinTemplate):
         if not message:
             message = BaseMessage.from_dict(event.data, self)
         self.cache.delete_message(event.data["channel_id"], event.data["id"])
-        logger.debug(f"Dispatching Event: {event.resolved_name}")
+        logger().debug(f"Dispatching Event: {event.resolved_name}")
         self.dispatch(events.MessageDelete(message))
 
     @Processor.define()

--- a/naff/api/gateway/gateway.py
+++ b/naff/api/gateway/gateway.py
@@ -176,31 +176,31 @@ class GatewayClient(WebsocketClient):
         match op:
 
             case OPCODE.HEARTBEAT:
-                logger.debug("Received heartbeat request from gateway")
+                logger().debug("Received heartbeat request from gateway")
                 return await self.send_heartbeat()
 
             case OPCODE.HEARTBEAT_ACK:
                 self.latency.append(time.perf_counter() - self._last_heartbeat)
 
                 if self._last_heartbeat != 0 and self.latency[-1] >= 15:
-                    logger.warning(
+                    logger().warning(
                         f"High Latency! shard ID {self.shard[0]} heartbeat took {self.latency[-1]:.1f}s to be acknowledged!"
                     )
                 else:
-                    logger.debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
+                    logger().debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
 
                 return self._acknowledged.set()
 
             case OPCODE.RECONNECT:
-                logger.debug("Gateway requested reconnect. Reconnecting...")
+                logger().debug("Gateway requested reconnect. Reconnecting...")
                 return await self.reconnect(resume=True, url=self.ws_resume_url)
 
             case OPCODE.INVALIDATE_SESSION:
-                logger.warning("Gateway has invalidated session! Reconnecting...")
+                logger().warning("Gateway has invalidated session! Reconnecting...")
                 return await self.reconnect()
 
             case _:
-                return logger.debug(f"Unhandled OPCODE: {op} = {OPCODE(op).name}")
+                return logger().debug(f"Unhandled OPCODE: {op} = {OPCODE(op).name}")
 
     async def dispatch_event(self, data, seq, event) -> None:
         match event:
@@ -212,13 +212,13 @@ class GatewayClient(WebsocketClient):
                 self.ws_resume_url = (
                     f"{data['resume_gateway_url']}?encoding=json&v={__api_version__}&compress=zlib-stream"
                 )
-                logger.info(f"Shard {self.shard[0]} has connected to gateway!")
-                logger.debug(f"Session ID: {self.session_id} Trace: {self._trace}")
+                logger().info(f"Shard {self.shard[0]} has connected to gateway!")
+                logger().debug(f"Session ID: {self.session_id} Trace: {self._trace}")
                 # todo: future polls, improve guild caching here. run the debugger. you'll see why
                 return self.state.client.dispatch(events.WebsocketReady(data))
 
             case "RESUMED":
-                logger.info(f"Successfully resumed connection! Session_ID: {self.session_id}")
+                logger().info(f"Successfully resumed connection! Session_ID: {self.session_id}")
                 self.state.client.dispatch(events.Resume())
                 return
 
@@ -233,9 +233,9 @@ class GatewayClient(WebsocketClient):
                     try:
                         asyncio.create_task(processor(events.RawGatewayEvent(data.copy(), override_name=event_name)))
                     except Exception as ex:
-                        logger.error(f"Failed to run event processor for {event_name}: {ex}")
+                        logger().error(f"Failed to run event processor for {event_name}: {ex}")
                 else:
-                    logger.debug(f"No processor for `{event_name}`")
+                    logger().debug(f"No processor for `{event_name}`")
 
         self.state.client.dispatch(events.RawGatewayEvent(data.copy(), override_name="raw_gateway_event"))
         self.state.client.dispatch(events.RawGatewayEvent(data.copy(), override_name=f"raw_{event.lower()}"))
@@ -264,7 +264,7 @@ class GatewayClient(WebsocketClient):
         serialized = OverriddenJson.dumps(payload)
         await self.ws.send_str(serialized)
 
-        logger.debug(
+        logger().debug(
             f"Shard ID {self.shard[0]} has identified itself to Gateway, requesting intents: {self.state.intents}!"
         )
 
@@ -286,11 +286,11 @@ class GatewayClient(WebsocketClient):
         serialized = OverriddenJson.dumps(payload)
         await self.ws.send_str(serialized)
 
-        logger.debug(f"{self.shard[0]} is attempting to resume a connection")
+        logger().debug(f"{self.shard[0]} is attempting to resume a connection")
 
     async def send_heartbeat(self) -> None:
         await self.send_json({"op": OPCODE.HEARTBEAT, "d": self.sequence}, bypass=True)
-        logger.debug(f"❤ Shard {self.shard[0]} is sending a Heartbeat")
+        logger().debug(f"❤ Shard {self.shard[0]} is sending a Heartbeat")
 
     async def change_presence(self, activity=None, status: Status = Status.ONLINE, since=None) -> None:
         """Update the bot's presence status."""

--- a/naff/api/gateway/state.py
+++ b/naff/api/gateway/state.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import naff
 from naff.api import events
-from naff.client.const import logger, MISSING, Absent
+from naff.client.const import Absent, MISSING
 from naff.client.errors import NaffException, WebSocketClosed
 from naff.client.utils.attr_utils import define, field
 from naff.models.discord.activity import Activity
@@ -68,7 +68,7 @@ class ConnectionState:
         """Connect to the Discord Gateway."""
         self.gateway_url = await self.client.http.get_gateway()
 
-        logger.debug(f"Starting Shard ID {self.shard_id}")
+        self.client.logger.debug(f"Starting Shard ID {self.shard_id}")
         self.start_time = datetime.now()
         self._shard_task = asyncio.create_task(self._ws_connect())
 
@@ -80,7 +80,7 @@ class ConnectionState:
 
     async def stop(self) -> None:
         """Disconnect from the Discord Gateway."""
-        logger.debug(f"Shutting down shard ID {self.shard_id}")
+        self.client.logger.debug(f"Shutting down shard ID {self.shard_id}")
         if self.gateway is not None:
             self.gateway.close()
             self.gateway = None
@@ -98,7 +98,7 @@ class ConnectionState:
 
     async def _ws_connect(self) -> None:
         """Connect to the Discord Gateway."""
-        logger.info(f"Shard {self.shard_id} is attempting to connect to gateway...")
+        self.client.logger.info(f"Shard {self.shard_id} is attempting to connect to gateway...")
         try:
             async with GatewayClient(self, (self.shard_id, self.client.total_shards)) as self.gateway:
                 try:
@@ -123,7 +123,7 @@ class ConnectionState:
 
         except Exception as e:
             self.client.dispatch(events.Disconnect())
-            logger.error("".join(traceback.format_exception(type(e), e, e.__traceback__)))
+            self.client.logger.error("".join(traceback.format_exception(type(e), e, e.__traceback__)))
 
     async def change_presence(
         self, status: Optional[Union[str, Status]] = Status.ONLINE, activity: Absent[Union[Activity, str]] = MISSING
@@ -149,7 +149,7 @@ class ConnectionState:
 
                 if activity.type == ActivityType.STREAMING:
                     if not activity.url:
-                        logger.warning("Streaming activity cannot be set without a valid URL attribute")
+                        self.client.logger.warning("Streaming activity cannot be set without a valid URL attribute")
                 elif activity.type not in [
                     ActivityType.GAME,
                     ActivityType.STREAMING,
@@ -157,7 +157,9 @@ class ConnectionState:
                     ActivityType.WATCHING,
                     ActivityType.COMPETING,
                 ]:
-                    logger.warning(f"Activity type `{ActivityType(activity.type).name}` may not be enabled for bots")
+                    self.client.logger.warning(
+                        f"Activity type `{ActivityType(activity.type).name}` may not be enabled for bots"
+                    )
         else:
             activity = self.client.activity
 
@@ -172,7 +174,7 @@ class ConnectionState:
             if self.client.status:
                 status = self.client.status
             else:
-                logger.warning("Status must be set to a valid status type, defaulting to online")
+                self.client.logger.warning("Status must be set to a valid status type, defaulting to online")
                 status = Status.ONLINE
 
         self.client._status = status

--- a/naff/api/gateway/websocket.py
+++ b/naff/api/gateway/websocket.py
@@ -134,11 +134,11 @@ class WebsocketClient:
             bypass: Should the rate limit be ignored for this send (used for heartbeats)
 
         """
-        logger.debug(f"Sending data to websocket: {data}")
+        logger().debug(f"Sending data to websocket: {data}")
 
         async with self._race_lock:
             if self.ws is None:
-                return logger.warning("Attempted to send data while websocket is not connected!")
+                return logger().warning("Attempted to send data while websocket is not connected!")
             if not bypass:
                 await self.rl_manager.rate_limit()
 
@@ -177,7 +177,7 @@ class WebsocketClient:
             resp = await self.ws.receive()
 
             if resp.type == WSMsgType.CLOSE:
-                logger.debug(f"Disconnecting from gateway! Reason: {resp.data}::{resp.extra}")
+                logger().debug(f"Disconnecting from gateway! Reason: {resp.data}::{resp.extra}")
                 if resp.data >= 4000:
                     # This should propagate to __aexit__() which will forcefully shut down everything
                     # and cleanup correctly.
@@ -232,7 +232,7 @@ class WebsocketClient:
             try:
                 msg = OverriddenJson.loads(msg)
             except Exception as e:
-                logger.error(e)
+                logger().error(e)
                 continue
 
             return msg
@@ -270,7 +270,7 @@ class WebsocketClient:
             await self._start_bee_gees()
         except Exception:
             self.close()
-            logger.error("The heartbeater raised an exception!", exc_info=True)
+            logger().error("The heartbeater raised an exception!", exc_info=True)
 
     async def _start_bee_gees(self) -> None:
         if self.heartbeat_interval is None:
@@ -283,10 +283,10 @@ class WebsocketClient:
         else:
             return
 
-        logger.debug(f"Sending heartbeat every {self.heartbeat_interval} seconds")
+        logger().debug(f"Sending heartbeat every {self.heartbeat_interval} seconds")
         while not self._kill_bee_gees.is_set():
             if not self._acknowledged.is_set():
-                logger.warning(
+                logger().warning(
                     f"Heartbeat has not been acknowledged for {self.heartbeat_interval} seconds,"
                     " likely zombied connection. Reconnect!"
                 )

--- a/naff/api/voice/player.py
+++ b/naff/api/voice/player.py
@@ -99,14 +99,14 @@ class Player(threading.Thread):
         self._stopped.clear()
 
         asyncio.run_coroutine_threadsafe(self.state.ws.speaking(True), self.loop)
-        logger.debug(f"Now playing {self.current_audio!r}")
+        logger().debug(f"Now playing {self.current_audio!r}")
         start = None
 
         try:
             while not self._stop_event.is_set():
                 if not self.state.ws.ready.is_set() or not self._resume.is_set():
                     run_coroutine_threadsafe(self.state.ws.speaking(False), self.loop)
-                    logger.debug("Voice playback has been suspended!")
+                    logger().debug("Voice playback has been suspended!")
 
                     wait_for = []
 
@@ -122,7 +122,7 @@ class Player(threading.Thread):
                         continue
 
                     run_coroutine_threadsafe(self.state.ws.speaking(), self.loop)
-                    logger.debug("Voice playback has been resumed!")
+                    logger().debug("Voice playback has been resumed!")
                     start = None
                     loops = 0
 

--- a/naff/api/voice/voice_gateway.py
+++ b/naff/api/voice/voice_gateway.py
@@ -106,7 +106,7 @@ class VoiceGateway(WebsocketClient):
             resp = await self.ws.receive()
 
             if resp.type == WSMsgType.CLOSE:
-                logger.debug(f"Disconnecting from voice gateway! Reason: {resp.data}::{resp.extra}")
+                logger().debug(f"Disconnecting from voice gateway! Reason: {resp.data}::{resp.extra}")
                 if resp.data in (4006, 4009, 4014, 4015):
                     # these are all recoverable close codes, anything else means we're foobared
                     # codes: session expired, session timeout, disconnected, server crash
@@ -159,7 +159,7 @@ class VoiceGateway(WebsocketClient):
             try:
                 msg = OverriddenJson.loads(msg)
             except Exception as e:
-                logger.error(e)
+                logger().error(e)
 
             return msg
 
@@ -169,26 +169,26 @@ class VoiceGateway(WebsocketClient):
                 self.latency.append(time.perf_counter() - self._last_heartbeat)
 
                 if self._last_heartbeat != 0 and self.latency[-1] >= 15:
-                    logger.warning(f"High Latency! Voice heartbeat took {self.latency[-1]:.1f}s to be acknowledged!")
+                    logger().warning(f"High Latency! Voice heartbeat took {self.latency[-1]:.1f}s to be acknowledged!")
                 else:
-                    logger.debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
+                    logger().debug(f"❤ Heartbeat acknowledged after {self.latency[-1]:.5f} seconds")
 
                 return self._acknowledged.set()
 
             case OP.READY:
-                logger.debug("Discord send VC Ready! Establishing a socket connection...")
+                logger().debug("Discord send VC Ready! Establishing a socket connection...")
                 self.voice_ip = data["ip"]
                 self.voice_port = data["port"]
                 self.ssrc = data["ssrc"]
                 self.voice_modes = [mode for mode in data["modes"] if mode in Encryption.SUPPORTED]
 
                 if len(self.voice_modes) == 0:
-                    logger.critical("NO VOICE ENCRYPTION MODES SHARED WITH GATEWAY!")
+                    logger().critical("NO VOICE ENCRYPTION MODES SHARED WITH GATEWAY!")
 
                 await self.establish_voice_socket()
 
             case OP.SESSION_DESCRIPTION:
-                logger.info(f"Voice connection established; using {data['mode']}")
+                logger().info(f"Voice connection established; using {data['mode']}")
                 self.encryptor = Encryption(data["secret_key"])
                 self.ready.set()
                 if self.cond:
@@ -196,7 +196,7 @@ class VoiceGateway(WebsocketClient):
                         self.cond.notify()
 
             case _:
-                return logger.debug(f"Unhandled OPCODE: {op} = {data = }")
+                return logger().debug(f"Unhandled OPCODE: {op} = {data = }")
 
     async def reconnect(self, *, resume: bool = False, code: int = 1012) -> None:
         async with self._race_lock:
@@ -208,13 +208,13 @@ class VoiceGateway(WebsocketClient):
             self.ws = None
 
             if not resume:
-                logger.debug("Waiting for updated server information...")
+                logger().debug("Waiting for updated server information...")
                 try:
                     await asyncio.wait_for(self._voice_server_update.wait(), timeout=5)
                 except asyncio.TimeoutError:
                     self._kill_bee_gees.set()
                     self.close()
-                    logger.debug("Terminating VoiceGateway due to disconnection")
+                    logger().debug("Terminating VoiceGateway due to disconnection")
                     return
 
                 self._voice_server_update.clear()
@@ -248,7 +248,7 @@ class VoiceGateway(WebsocketClient):
 
     async def establish_voice_socket(self) -> None:
         """Establish the socket connection to discord"""
-        logger.debug("IP Discovery in progress...")
+        logger().debug("IP Discovery in progress...")
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.socket.setblocking(False)
@@ -260,14 +260,14 @@ class VoiceGateway(WebsocketClient):
 
         self.socket.sendto(packet, (self.voice_ip, self.voice_port))
         resp = await self.loop.sock_recv(self.socket, 70)
-        logger.debug(f"Voice Initial Response Received: {resp}")
+        logger().debug(f"Voice Initial Response Received: {resp}")
 
         ip_start = 4
         ip_end = resp.index(0, ip_start)
         self.me_ip = resp[ip_start:ip_end].decode("ascii")
 
         self.me_port = struct.unpack_from(">H", resp, len(resp) - 2)[0]
-        logger.debug(f"IP Discovered: {self.me_ip} #{self.me_port}")
+        logger().debug(f"IP Discovered: {self.me_ip} #{self.me_port}")
 
         await self._select_protocol()
 
@@ -301,7 +301,7 @@ class VoiceGateway(WebsocketClient):
 
     async def send_heartbeat(self) -> None:
         await self.send_json({"op": OP.HEARTBEAT, "d": random.uniform(0.0, 1.0)})
-        logger.debug("❤ Voice Connection is sending Heartbeat")
+        logger().debug("❤ Voice Connection is sending Heartbeat")
 
     async def _identify(self) -> None:
         """Send an identify payload to the voice gateway."""
@@ -317,7 +317,7 @@ class VoiceGateway(WebsocketClient):
         serialized = OverriddenJson.dumps(payload)
         await self.ws.send_str(serialized)
 
-        logger.debug("Voice Connection has identified itself to Voice Gateway")
+        logger().debug("Voice Connection has identified itself to Voice Gateway")
 
     async def _select_protocol(self) -> None:
         """Inform Discord of our chosen protocol."""

--- a/naff/client/auto_shard_client.py
+++ b/naff/client/auto_shard_client.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import naff.api.events as events
 from naff.api.gateway.state import ConnectionState
 from naff.client.client import Client
-from naff.client.const import logger, MISSING
+from naff.client.const import MISSING
 from naff.models import (
     Guild,
     to_snowflake,
@@ -74,7 +74,7 @@ class AutoShardedClient(Client):
 
     async def stop(self) -> None:
         """Shutdown the bot."""
-        logger.debug("Stopping the bot.")
+        self.logger.debug("Stopping the bot.")
         self._ready.clear()
         await self.http.close()
         await asyncio.gather(*(state.stop() for state in self._connection_states))
@@ -122,7 +122,7 @@ class AutoShardedClient(Client):
                 try:
                     await asyncio.wait_for(self._guild_event.wait(), self.guild_event_timeout)
                 except asyncio.TimeoutError:
-                    logger.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
+                    self.logger.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
                     break
                 self._guild_event.clear()
                 if all(self.cache.get_guild(g_id) is not None for g_id in expected_guilds):
@@ -130,16 +130,16 @@ class AutoShardedClient(Client):
                     break
 
             if self.fetch_members:
-                logger.info(f"Shard {shard_id} is waiting for members to be chunked")
+                self.logger.info(f"Shard {shard_id} is waiting for members to be chunked")
                 await asyncio.gather(*(guild.chunked.wait() for guild in self.guilds if guild.id in expected_guilds))
         else:
-            logger.warning(
+            self.logger.warning(
                 f"Shard {shard_id} reports it has 0 guilds, this is an indicator you may be using too many shards"
             )
         # noinspection PyProtectedMember
         connection_state._shard_ready.set()
         self.dispatch(ShardConnect(shard_id))
-        logger.debug(f"Shard {shard_id} is now ready")
+        self.logger.debug(f"Shard {shard_id} is now ready")
 
         # noinspection PyProtectedMember
         await asyncio.gather(*[shard._shard_ready.wait() for shard in self._connection_states])
@@ -169,7 +169,7 @@ class AutoShardedClient(Client):
         Args:
             token: Your bot's token
         """
-        logger.debug("Starting http client...")
+        self.logger.debug("Starting http client...")
         await self.login(token)
 
         tasks = []
@@ -182,7 +182,7 @@ class AutoShardedClient(Client):
 
         for bucket in shard_buckets.values():
             for shard in bucket:
-                logger.debug(f"Starting {shard.shard_id}")
+                self.logger.debug(f"Starting {shard.shard_id}")
                 start = time.perf_counter()
                 tasks.append(asyncio.create_task(shard.start()))
 
@@ -220,11 +220,11 @@ class AutoShardedClient(Client):
             self.total_shards = data["shards"]
         elif data["shards"] != self.total_shards:
             recommended_shards = data["shards"]
-            logger.info(
+            self.logger.info(
                 f"Discord recommends you start with {recommended_shards} shard{'s' if recommended_shards != 1 else ''} instead of {self.total_shards}"
             )
 
-        logger.debug(f"Starting bot with {self.total_shards} shard{'s' if self.total_shards != 1 else ''}")
+        self.logger.debug(f"Starting bot with {self.total_shards} shard{'s' if self.total_shards != 1 else ''}")
         self._connection_states: list[ConnectionState] = [
             ConnectionState(self, self.intents, shard_id) for shard_id in range(self.total_shards)
         ]

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -289,7 +289,7 @@ class Client(
         """The logger NAFF should use. Do not use in combination with `Client.basic_logging` and `Client.logging_level`.
         !!! note
             Different loggers with multiple clients are not supported"""
-        constants.logger = logger
+        constants._logger = logger
 
         # Configuration
         self.sync_interactions: bool = sync_interactions
@@ -496,7 +496,7 @@ class Client(
 
     def _sanity_check(self) -> None:
         """Checks for possible and common errors in the bot's configuration."""
-        logger.debug("Running client sanity checks...")
+        self.logger.debug("Running client sanity checks...")
         contexts = {
             self.interaction_context: InteractionContext,
             self.prefixed_context: PrefixedContext,
@@ -510,20 +510,20 @@ class Client(
                 raise TypeError(f"{obj.__name__} must inherit from {expected.__name__}")
 
         if self.del_unused_app_cmd:
-            logger.warning(
+            self.logger.warning(
                 "As `delete_unused_application_cmds` is enabled, the client must cache all guilds app-commands, this could take a while."
             )
 
         if Intents.GUILDS not in self._connection_state.intents:
-            logger.warning("GUILD intent has not been enabled; this is very likely to cause errors")
+            self.logger.warning("GUILD intent has not been enabled; this is very likely to cause errors")
 
         if self.fetch_members and Intents.GUILD_MEMBERS not in self._connection_state.intents:
             raise BotException("Members Intent must be enabled in order to use fetch members")
         elif self.fetch_members:
-            logger.warning("fetch_members enabled; startup will be delayed")
+            self.logger.warning("fetch_members enabled; startup will be delayed")
 
         if len(self.processors) == 0:
-            logger.warning("No Processors are loaded! This means no events will be processed!")
+            self.logger.warning("No Processors are loaded! This means no events will be processed!")
 
     async def generate_prefixes(self, bot: "Client", message: Message) -> str | Iterable[str]:
         """
@@ -593,7 +593,7 @@ class Client(
             except Exception:  # noqa : S110
                 pass
 
-        logger.error(
+        logger().error(
             "Ignoring exception in {}:{}{}".format(source, "\n" if len(out) > 1 else " ", "".join(out)),
         )
 
@@ -676,7 +676,7 @@ class Client(
             symbol = "/"
         else:
             symbol = "?"  # likely custom context
-        logger.info(f"Command Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
+        self.logger.info(f"Command Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     async def on_component_error(self, ctx: ComponentContext, error: Exception, *args, **kwargs) -> None:
         """
@@ -700,7 +700,7 @@ class Client(
 
         """
         symbol = "¢"
-        logger.info(f"Component Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
+        self.logger.info(f"Component Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     async def on_autocomplete_error(self, ctx: AutocompleteContext, error: Exception, *args, **kwargs) -> None:
         """
@@ -732,7 +732,7 @@ class Client(
 
         """
         symbol = "$"
-        logger.info(f"Autocomplete Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
+        self.logger.info(f"Autocomplete Called: {symbol}{ctx.invoke_target} with {ctx.args = } | {ctx.kwargs = }")
 
     @Listener.create()
     async def on_resume(self) -> None:
@@ -756,7 +756,7 @@ class Client(
                 try:  # wait to let guilds cache
                     await asyncio.wait_for(self._guild_event.wait(), self.guild_event_timeout)
                 except asyncio.TimeoutError:
-                    logger.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
+                    self.logger.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
                     break
                 self._guild_event.clear()
 
@@ -768,7 +768,7 @@ class Client(
                 # ensure all guilds have completed chunking
                 for guild in self.guilds:
                     if guild and not guild.chunked.is_set():
-                        logger.debug(f"Waiting for {guild.id} to chunk")
+                        self.logger.debug(f"Waiting for {guild.id} to chunk")
                         await guild.chunked.wait()
 
             # run any pending startup tasks
@@ -824,7 +824,7 @@ class Client(
         # so im gathering commands here
         self._gather_commands()
 
-        logger.debug("Attempting to login")
+        self.logger.debug("Attempting to login")
         me = await self.http.login(token.strip())
         self._user = NaffUser.from_dict(me, self)
         self.cache.place_user_data(me)
@@ -872,7 +872,7 @@ class Client(
 
     async def stop(self) -> None:
         """Shutdown the bot."""
-        logger.debug("Stopping the bot.")
+        self.logger.debug("Stopping the bot.")
         self._ready.clear()
         await self.http.close()
         await self._connection_state.stop()
@@ -887,7 +887,7 @@ class Client(
         """
         listeners = self.listeners.get(event.resolved_name, [])
         if listeners:
-            logger.debug(f"Dispatching Event: {event.resolved_name}")
+            self.logger.debug(f"Dispatching Event: {event.resolved_name}")
             event.bot = self
             for _listen in listeners:
                 try:
@@ -1235,7 +1235,7 @@ class Client(
                 elif isinstance(func, Listener):
                     self.add_listener(func)
 
-            logger.debug(f"{len(_cmds)} commands have been loaded from `__main__` and `client`")
+            self.logger.debug(f"{len(_cmds)} commands have been loaded from `__main__` and `client`")
 
         process(
             [obj for _, obj in inspect.getmembers(sys.modules["__main__"]) if isinstance(obj, (BaseCommand, Listener))]
@@ -1292,7 +1292,7 @@ class Client(
 
         for scope, remote_cmds in results.items():
             if remote_cmds == MISSING:
-                logger.debug(f"Bot was not invited to guild {scope} with `application.commands` scope")
+                self.logger.debug(f"Bot was not invited to guild {scope} with `application.commands` scope")
                 continue
 
             remote_cmds = {cmd_data["name"]: cmd_data for cmd_data in remote_cmds}
@@ -1304,7 +1304,7 @@ class Client(
                     if cmd_data is MISSING:
                         if cmd_name not in found:
                             if warn_missing:
-                                logger.error(
+                                self.logger.error(
                                     f'Detected yet to sync slash command "/{cmd_name}" for scope '
                                     f"{'global' if scope == GLOBAL_SCOPE else scope}"
                                 )
@@ -1316,7 +1316,7 @@ class Client(
 
             if warn_missing:
                 for cmd_data in remote_cmds.values():
-                    logger.error(
+                    self.logger.error(
                         f"Detected unimplemented slash command \"/{cmd_data['name']}\" for scope "
                         f"{'global' if scope == GLOBAL_SCOPE else scope}"
                     )
@@ -1355,7 +1355,7 @@ class Client(
                 try:
                     remote_commands = await self.http.get_application_commands(self.app.id, cmd_scope)
                 except Forbidden:
-                    logger.warning(f"Bot is lacking `application.commands` scope in {cmd_scope}!")
+                    self.logger.warning(f"Bot is lacking `application.commands` scope in {cmd_scope}!")
                     return
 
                 for local_cmd in self.interactions.get(cmd_scope, {}).values():
@@ -1385,13 +1385,13 @@ class Client(
 
                 if sync_needed_flag or (_delete_cmds and len(sync_payload) < len(remote_commands)):
                     # synchronise commands if flag is set, or commands are to be deleted
-                    logger.info(f"Overwriting {cmd_scope} with {len(sync_payload)} application commands")
+                    self.logger.info(f"Overwriting {cmd_scope} with {len(sync_payload)} application commands")
                     sync_response: list[dict] = await self.http.overwrite_application_commands(
                         self.app.id, sync_payload, cmd_scope
                     )
                     self._cache_sync_response(sync_response, cmd_scope)
                 else:
-                    logger.debug(f"{cmd_scope} is already up-to-date with {len(remote_commands)} commands.")
+                    self.logger.debug(f"{cmd_scope} is already up-to-date with {len(remote_commands)} commands.")
 
             except Forbidden as e:
                 raise InteractionMissingAccess(cmd_scope) from e
@@ -1401,7 +1401,7 @@ class Client(
         await asyncio.gather(*[sync_scope(scope) for scope in cmd_scopes])
 
         t = time.perf_counter() - s
-        logger.debug(f"Sync of {len(cmd_scopes)} scopes took {t} seconds")
+        self.logger.debug(f"Sync of {len(cmd_scopes)} scopes took {t} seconds")
 
     def get_application_cmd_by_id(self, cmd_id: "Snowflake_Type") -> Optional[InteractionCommand]:
         """
@@ -1422,8 +1422,7 @@ class Client(
                     return cmd
         return None
 
-    @staticmethod
-    def _raise_sync_exception(e: HTTPException, cmds_json: dict, cmd_scope: "Snowflake_Type") -> NoReturn:
+    def _raise_sync_exception(self, e: HTTPException, cmds_json: dict, cmd_scope: "Snowflake_Type") -> NoReturn:
         try:
             if isinstance(e.errors, dict):
                 for cmd_num in e.errors.keys():
@@ -1431,9 +1430,9 @@ class Client(
                     output = e.search_for_message(e.errors[cmd_num], cmd)
                     if len(output) > 1:
                         output = "\n".join(output)
-                        logger.error(f"Multiple Errors found in command `{cmd['name']}`:\n{output}")
+                        self.logger.error(f"Multiple Errors found in command `{cmd['name']}`:\n{output}")
                     else:
-                        logger.error(f"Error in command `{cmd['name']}`: {output[0]}")
+                        self.logger.error(f"Error in command `{cmd['name']}`: {output[0]}")
             else:
                 raise e from None
         except Exception:
@@ -1571,7 +1570,7 @@ class Client(
                 ctx = await self.get_context(interaction_data, True)
 
                 ctx.command: SlashCommand = self.interactions[scope][ctx.invoke_target]  # type: ignore
-                logger.debug(f"{scope} :: {ctx.command.name} should be called")
+                self.logger.debug(f"{scope} :: {ctx.command.name} should be called")
 
                 if ctx.command.auto_defer:
                     auto_defer = ctx.command.auto_defer
@@ -1600,7 +1599,7 @@ class Client(
                     finally:
                         await self.on_command(ctx)
             else:
-                logger.error(f"Unknown cmd_id received:: {interaction_id} ({name})")
+                self.logger.error(f"Unknown cmd_id received:: {interaction_id} ({name})")
 
         elif interaction_data["type"] == InteractionTypes.MESSAGE_COMPONENT:
             # Buttons, Selects, ContextMenu::Message
@@ -1796,7 +1795,7 @@ class Client(
             raise ExtensionLoadException(f"Unexpected Error loading {name}") from e
 
         else:
-            logger.debug(f"Loaded Extension: {name}")
+            self.logger.debug(f"Loaded Extension: {name}")
             self.__modules[name] = module
 
             if self.sync_ext and self._ready.is_set():
@@ -1864,7 +1863,7 @@ class Client(
         module = self.__modules.get(name)
 
         if module is None:
-            logger.warning("Attempted to reload extension thats not loaded. Loading extension instead")
+            self.logger.warning("Attempted to reload extension thats not loaded. Loading extension instead")
             return self.load_extension(name, package)
 
         if not load_kwargs:

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1128,7 +1128,7 @@ class Client(
             prefixed_base = self.prefixed_commands.get(str(command.name))
             if not prefixed_base:
                 prefixed_base = _base_subcommand_generator(
-                    str(command.name), list(command.name.to_locale_dict().values()), str(command.description)
+                    str(command.name), list((command.name.to_locale_dict() or {}).values()), str(command.description)
                 )
                 self.add_prefixed_command(prefixed_base)
 
@@ -1139,7 +1139,7 @@ class Client(
                 if not prefixed_base:
                     prefixed_base = _base_subcommand_generator(
                         str(command.group_name),
-                        list(command.group_name.to_locale_dict().values()),
+                        list((command.group_name.to_locale_dict() or {}).values()),
                         str(command.group_description),
                         group=True,
                     )

--- a/naff/client/const.py
+++ b/naff/client/const.py
@@ -86,9 +86,15 @@ __repo_url__ = "https://github.com/Discord-Snake-Pit/NAFF"
 __py_version__ = f"{_ver_info[0]}.{_ver_info[1]}"
 __api_version__ = 10
 logger_name = "naff"
-logger = logging.getLogger(logger_name)
+_logger = logging.getLogger(logger_name)
 default_locale = "english_us"
 kwarg_spam = False
+
+
+def logger() -> logging.Logger:
+    global _logger
+    return _logger
+
 
 DISCORD_EPOCH = 1420070400000
 

--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Dict, Any, Optional, Union
 
 import discord_typings
 
-from naff.client.const import MISSING, logger, Absent
+from naff.client.const import Absent, MISSING
 from naff.client.errors import NotFound, Forbidden
 from naff.client.utils.attr_utils import define, field
 from naff.client.utils.cache import TTLCache
@@ -77,7 +77,7 @@ class GlobalCache:
 
     def __attrs_post_init__(self) -> None:
         if not isinstance(self.message_cache, TTLCache):
-            logger.warning(
+            self._client.logger.warning(
                 "Disabling cache limits for message_cache is not recommended! This can result in very high memory usage"
             )
 
@@ -446,7 +446,9 @@ class GlobalCache:
                 data = await self._client.http.get_channel(channel_id)
                 channel = self.place_channel_data(data)
             except Forbidden:
-                logger.warning(f"Forbidden access to channel {channel_id}. Generating fallback channel object")
+                self._client.logger.warning(
+                    f"Forbidden access to channel {channel_id}. Generating fallback channel object"
+                )
                 channel = BaseChannel.from_dict({"id": channel_id, "type": MISSING}, self._client)
         return channel
 

--- a/naff/client/utils/attr_utils.py
+++ b/naff/client/utils/attr_utils.py
@@ -50,7 +50,7 @@ def str_validator(self: Any, attribute: attrs.Attribute, value: Any) -> None:
         if value is MISSING:
             return
         setattr(self, attribute.name, str(value))
-        logger.warning(
+        logger().warning(
             f"Value of {attribute.name} has been automatically converted to a string. Please use strings in future.\n"
             "Note: Discord will always return value as a string"
         )

--- a/naff/client/utils/input_utils.py
+++ b/naff/client/utils/input_utils.py
@@ -11,7 +11,7 @@ __all__ = ("OverriddenJson", "response_decode", "get_args", "get_first_word")
 try:
     import orjson as json
 except ImportError:
-    logger.warning("orjson not installed, built-in json library will be used")
+    logger().warning("orjson not installed, built-in json library will be used")
     import json as json
 
 

--- a/naff/ext/debug_extension/__init__.py
+++ b/naff/ext/debug_extension/__init__.py
@@ -17,13 +17,13 @@ class DebugExtension(DebugExec, DebugAppCMD, DebugExts, Extension):
         super().__init__(bot)
         self.add_ext_check(checks.is_owner())
 
-        logger.info("Debug Extension is growing!")
+        bot.logger.info("Debug Extension is growing!")
 
     @listen()
     async def on_startup(self) -> None:
-        logger.info(f"Started {self.bot.user.tag} [{self.bot.user.id}] in Debug Mode")
+        self.bot.logger.info(f"Started {self.bot.user.tag} [{self.bot.user.id}] in Debug Mode")
 
-        logger.info(f"Caching System State: \n{get_cache_state(self.bot)}")
+        self.bot.logger.info(f"Caching System State: \n{get_cache_state(self.bot)}")
 
     @slash_command(
         "debug",

--- a/naff/ext/prefixed_help.py
+++ b/naff/ext/prefixed_help.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 import attrs
 from naff import Embed
-from naff.client.const import logger
 from naff.ext.paginators import Paginator
 from naff.models.discord.color import BrandColors, Color
 from naff.models.naff.context import PrefixedContext
@@ -62,7 +61,7 @@ class PrefixedHelpCommand:
 
         # replace existing help command if found
         if "help" in self.client.prefixed_commands:
-            logger.warning("Replacing existing help command.")
+            self.client.logger.warning("Replacing existing help command.")
             del self.client.prefixed_commands["help"]
 
         self.client.add_prefixed_command(self._cmd)  # type: ignore

--- a/naff/ext/sentry.py
+++ b/naff/ext/sentry.py
@@ -13,7 +13,9 @@ from naff.client.const import logger
 try:
     import sentry_sdk
 except ModuleNotFoundError:
-    logger.error("sentry-sdk not installed, cannot enable sentry integration.  Install with `pip install naff[sentry]`")
+    logger().error(
+        "sentry-sdk not installed, cannot enable sentry integration.  Install with `pip install naff[sentry]`"
+    )
     raise
 
 from naff import Extension, Client, listen
@@ -74,7 +76,7 @@ def setup(
     filter: Optional[Callable[[dict[str, Any], dict[str, Any]], Optional[dict[str, Any]]]] = None,
 ) -> None:
     if not token:
-        logger.error("Cannot enable sentry integration, no token provided")
+        bot.logger.error("Cannot enable sentry integration, no token provided")
         return
     if filter is None:
         filter = default_sentry_filter

--- a/naff/models/discord/auto_mod.py
+++ b/naff/models/discord/auto_mod.py
@@ -37,7 +37,7 @@ class BaseAction(DictSerializationMixin):
     def from_dict_factory(cls, data: dict) -> "BaseAction":
         action_class = ACTION_MAPPING.get(data.get("type"))
         if not action_class:
-            logger.error(f"Unknown action type for {data}")
+            logger().error(f"Unknown action type for {data}")
             action_class = cls
 
         return action_class.from_dict({"type": data.get("type")} | data["metadata"])
@@ -73,7 +73,7 @@ class BaseTrigger(DictSerializationMixin):
         trigger_class = TRIGGER_MAPPING.get(data.get("trigger_type"))
         meta = data.get("trigger_metadata", {})
         if not trigger_class:
-            logger.error(f"Unknown trigger type for {data}")
+            logger().error(f"Unknown trigger type for {data}")
             trigger_class = cls
 
         payload = {"type": data.get("trigger_type"), "trigger_metadata": meta}

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -6,7 +6,7 @@ import attrs
 
 import naff.models as models
 
-from naff.client.const import MISSING, DISCORD_EPOCH, Absent, logger
+from naff.client.const import Absent, DISCORD_EPOCH, MISSING
 from naff.client.errors import NotFound, VoiceNotConnected, TooManyChanges
 from naff.client.mixins.send import SendMixin
 from naff.client.mixins.serialization import DictSerializationMixin
@@ -736,7 +736,7 @@ class BaseChannel(DiscordObject):
         channel_type = data.get("type", None)
         channel_class = TYPE_CHANNEL_MAPPING.get(channel_type, None)
         if not channel_class:
-            logger.error(f"Unsupported channel type for {data} ({channel_type}).")
+            client.logger.error(f"Unsupported channel type for {data} ({channel_type}).")
             channel_class = BaseChannel
 
         return channel_class.from_dict(data, client)

--- a/naff/models/discord/enums.py
+++ b/naff/models/discord/enums.py
@@ -83,7 +83,7 @@ SELF = TypeVar("SELF")
 
 
 def _log_type_mismatch(cls, value) -> None:
-    logger.error(
+    logger().error(
         f"Class `{cls.__name__}` received an invalid and unexpected value `{value}`. Please update NAFF or report this issue on GitHub - https://github.com/NAFTeam/NAFF/issues"
     )
 

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
 from warnings import warn
 
 import naff.models as models
-from naff.client.const import MISSING, PREMIUM_GUILD_LIMITS, logger, Absent
+from naff.client.const import Absent, MISSING, PREMIUM_GUILD_LIMITS
 from naff.client.errors import EventLocationNotProvided, NotFound
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_converters import optional
@@ -528,7 +528,7 @@ class Guild(BaseGuild):
             self._client.cache.place_member_data(self.id, member)
 
         self.chunked.set()
-        logger.info(
+        self._client.logger.info(
             f"Cached {iterator.total_retrieved} members for {self.id} in {time.perf_counter() - start_time:.2f} seconds"
         )
 
@@ -596,10 +596,10 @@ class Guild(BaseGuild):
             self._chunk_cache = self._chunk_cache + chunk.get("members")
 
         if chunk.get("chunk_index") != chunk.get("chunk_count") - 1:
-            return logger.debug(f"Cached chunk of {len(chunk.get('members'))} members for {self.id}")
+            return self._client.logger.debug(f"Cached chunk of {len(chunk.get('members'))} members for {self.id}")
         else:
             members = self._chunk_cache
-            logger.info(f"Processing {len(members)} members for {self.id}")
+            self._client.logger.info(f"Processing {len(members)} members for {self.id}")
 
             s = time.monotonic()
             start_time = time.perf_counter()
@@ -615,7 +615,7 @@ class Guild(BaseGuild):
 
             total_time = time.perf_counter() - start_time
             self.chunk_cache = []
-            logger.info(f"Cached members for {self.id} in {total_time:.2f} seconds")
+            self._client.logger.info(f"Cached members for {self.id} in {total_time:.2f} seconds")
             self.chunked.set()
 
     async def fetch_audit_log(

--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Iterable, Set, Dict, List, Optional, Union
 from warnings import warn
 
-from naff.client.const import MISSING, logger, Absent
+from naff.client.const import Absent, MISSING
 from naff.client.errors import HTTPException, TooManyChanges
 from naff.client.mixins.send import SendMixin
 from naff.client.utils.attr_utils import define, field, docs
@@ -272,7 +272,7 @@ class Member(DiscordObject, _SendDMMixin):
                     client, f"guilds/{data['guild_id']}/users/{data['id']}/avatars/{{}}", data.pop("avatar", None)
                 )
             except Exception as e:
-                logger.warning(
+                client.logger.warning(
                     f"[DEBUG NEEDED - REPORT THIS] Incomplete dictionary has been passed to member object: {e}"
                 )
                 raise

--- a/naff/models/naff/active_voice_state.py
+++ b/naff/models/naff/active_voice_state.py
@@ -5,7 +5,7 @@ from discord_typings import VoiceStateData
 
 from naff.api.voice.player import Player
 from naff.api.voice.voice_gateway import VoiceGateway
-from naff.client.const import logger, MISSING
+from naff.client.const import MISSING
 from naff.client.errors import VoiceAlreadyConnected, VoiceConnectionTimeout
 from naff.client.utils import optional
 from naff.client.utils.attr_utils import define, field
@@ -141,7 +141,7 @@ class ActiveVoiceState(VoiceState):
             raise VoiceAlreadyConnected
         await self.gateway.voice_state_update(self._guild_id, self._channel_id, self.self_mute, self.self_deaf)
 
-        logger.debug("Waiting for voice connection data...")
+        self._client.logger.debug("Waiting for voice connection data...")
 
         try:
             self._voice_state, self._voice_server = await asyncio.gather(
@@ -151,7 +151,7 @@ class ActiveVoiceState(VoiceState):
         except asyncio.TimeoutError:
             raise VoiceConnectionTimeout from None
 
-        logger.debug("Attempting to initialise voice gateway...")
+        self._client.logger.debug("Attempting to initialise voice gateway...")
         await self.ws_connect()
 
     async def disconnect(self) -> None:
@@ -176,7 +176,7 @@ class ActiveVoiceState(VoiceState):
             self._channel_id = target_channel
             await self.gateway.voice_state_update(self._guild_id, self._channel_id, self.self_mute, self.self_deaf)
 
-            logger.debug("Waiting for voice connection data...")
+            self._client.logger.debug("Waiting for voice connection data...")
             try:
                 await self._client.wait_for("raw_voice_state_update", self._guild_predicate, timeout=timeout)
             except asyncio.TimeoutError:
@@ -246,7 +246,7 @@ class ActiveVoiceState(VoiceState):
         """
         if after is None:
             # bot disconnected
-            logger.info(f"Disconnecting from voice channel {self._channel_id}")
+            self._client.logger.info(f"Disconnecting from voice channel {self._channel_id}")
             await self._close_connection()
             self._client.cache.delete_bot_voice_state(self._guild_id)
             return

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1008,7 +1008,7 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
             nsfw = cmd_list[0].nsfw
 
             if not all(str(c.description) in (str(base_description), "No Description Set") for c in cmd_list):
-                logger.warning(
+                logger().warning(
                     f"Conflicting descriptions found in `{cmd_list[0].name}` subcommands; `{str(base_description)}` will be used"
                 )
             if not all(c.default_member_permissions == cmd_list[0].default_member_permissions for c in cmd_list):
@@ -1016,7 +1016,7 @@ def application_commands_to_dict(commands: Dict["Snowflake_Type", Dict[str, Inte
             if not all(c.dm_permission == cmd_list[0].dm_permission for c in cmd_list):
                 raise ValueError(f"Conflicting `dm_permission` values found in `{cmd_list[0].name}`")
             if not all(c.nsfw == nsfw for c in cmd_list):
-                logger.warning(f"Conflicting `nsfw` values found in {cmd_list[0].name} - `True` will be used")
+                logger().warning(f"Conflicting `nsfw` values found in {cmd_list[0].name} - `True` will be used")
                 nsfw = True
 
             for cmd in cmd_list:

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -5,7 +5,7 @@ from aiohttp import FormData
 
 import naff.models.discord.message as message
 from naff.models.discord.timestamp import Timestamp
-from naff.client.const import MISSING, logger, Absent
+from naff.client.const import Absent, MISSING
 from naff.client.errors import AlreadyDeferred
 from naff.client.mixins.send import SendMixin
 from naff.client.utils.attr_utils import define, field, docs
@@ -424,7 +424,7 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
                 caches = ((self._client.cache.get_message, (self.channel.id, self.target_id)),)
             case _:
                 # Most likely a new context type, check all rational caches for the target_id
-                logger.warning(f"New Context Type Detected. Please Report: {self._context_type}")
+                self._client.logger.warning(f"New Context Type Detected. Please Report: {self._context_type}")
                 caches = (
                     (self._client.cache.get_message, (self.channel.id, self.target_id)),
                     (self._client.cache.get_member, (self.guild_id, self.target_id)),
@@ -536,7 +536,7 @@ class ComponentContext(InteractionContext):
         message_data = None
         if self.deferred:
             if not self.defer_edit_origin:
-                logger.warning(
+                self._client.logger.warning(
                     "If you want to edit the original message, and need to defer, you must set the `edit_origin` kwarg to True!"
                 )
 

--- a/naff/models/naff/extension.py
+++ b/naff/models/naff/extension.py
@@ -3,7 +3,7 @@ import inspect
 from typing import Awaitable, List, TYPE_CHECKING, Callable, Coroutine, Optional
 
 import naff.models.naff as naff
-from naff.client.const import logger, MISSING
+from naff.client.const import MISSING
 from naff.client.utils.misc_utils import wrap_partial
 from naff.models.naff.tasks import Task
 
@@ -100,7 +100,7 @@ class Extension:
             elif isinstance(val, Task):
                 wrap_partial(val, new_cls)
 
-        logger.debug(
+        bot.logger.debug(
             f"{len(new_cls._commands)} commands and {len(new_cls.listeners)} listeners"
             f" have been loaded from `{new_cls.name}`"
         )
@@ -197,7 +197,7 @@ class Extension:
             self.bot.listeners[func.event].remove(func)
 
         self.bot.ext.pop(self.name, None)
-        logger.debug(f"{self.name} has been drop")
+        self.bot.logger.debug(f"{self.name} has been drop")
 
     def add_ext_auto_defer(self, ephemeral: bool = False, time_until_defer: float = 0.0) -> None:
         """
@@ -305,5 +305,5 @@ class Extension:
             raise TypeError("Callback must be a coroutine")
 
         if self.extension_error:
-            logger.warning("Extension error callback has been overridden!")
+            self.bot.logger.warning("Extension error callback has been overridden!")
         self.extension_error = coroutine

--- a/naff/models/naff/hybrid_commands.py
+++ b/naff/models/naff/hybrid_commands.py
@@ -394,9 +394,9 @@ def _prefixed_from_slash(cmd: SlashCommand) -> _HybridPrefixedCommand:
 
     prefixed_cmd = _HybridPrefixedCommand(
         name=str(cmd.sub_cmd_name) if cmd.is_subcommand else str(cmd.name),
-        aliases=list(cmd.sub_cmd_name.to_locale_dict().values())
+        aliases=list((cmd.sub_cmd_name.to_locale_dict() or {}).values())
         if cmd.is_subcommand
-        else list(cmd.name.to_locale_dict().values()),
+        else list((cmd.name.to_locale_dict() or {}).values()),
         help=str(cmd.sub_cmd_description) if cmd.is_subcommand else str(cmd.description),
         callback=cmd.callback,
         extension=cmd.extension,

--- a/naff/models/naff/tasks/task.py
+++ b/naff/models/naff/tasks/task.py
@@ -116,7 +116,7 @@ class Task:
             self._stop.clear()
             self.task = asyncio.create_task(self._task_loop())
         except RuntimeError:
-            logger.error(
+            logger().error(
                 "Unable to start task without a running event loop! We recommend starting tasks within an `on_startup` event."
             )
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Naff was not always using the correct logger. This was due to the logger being imported before the imported variable was changed on Client initialisation. 

`const.logger` has been converted to a function which ensures the fetched object is the set one.

Technically breaking if anyone imported and used the logger

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- convert `const.logger` to a function

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
