### PR TITLE
fix 💥: only dispatch thread_create on new threads

### DIFF
--- a/naff/api/events/processors/thread_events.py
+++ b/naff/api/events/processors/thread_events.py
@@ -14,7 +14,10 @@ __all__ = ("ThreadEvents",)
 class ThreadEvents(EventMixinTemplate):
     @Processor.define()
     async def _on_raw_thread_create(self, event: "RawGatewayEvent") -> None:
-        self.dispatch(events.ThreadCreate(self.cache.place_channel_data(event.data)))
+        thread = self.cache.place_channel_data(event.data)
+
+        if event.data.get("newly_created"):
+            self.dispatch(events.ThreadCreate(thread))
 
     @Processor.define()
     async def _on_raw_thread_update(self, event: "RawGatewayEvent") -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR prevents thread create events from being dispatched unless the thread has just been created. this prevents double dispatches 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Check if thread is newly created before dispatching 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
