### PR TITLE
fix: properly remove deleted channel from cache

### DIFF
--- a/naff/api/events/processors/channel_events.py
+++ b/naff/api/events/processors/channel_events.py
@@ -20,11 +20,10 @@ class ChannelEvents(EventMixinTemplate):
 
     @Processor.define()
     async def _on_raw_channel_delete(self, event: "RawGatewayEvent") -> None:
-        # for some reason this event returns the deleted object?
-        # so we cache it regardless
+        # for some reason this event returns the deleted channel data?
+        # so we create an object from it
         channel = self.cache.place_channel_data(event.data)
-        if guild := getattr(channel, "guild", None):
-            guild._channel_ids.discard(channel.id)
+        self.cache.delete_channel(int(event.data.get("id")))
         self.dispatch(events.ChannelDelete(channel))
 
     @Processor.define()

--- a/naff/api/events/processors/channel_events.py
+++ b/naff/api/events/processors/channel_events.py
@@ -23,7 +23,7 @@ class ChannelEvents(EventMixinTemplate):
         # for some reason this event returns the deleted channel data?
         # so we create an object from it
         channel = self.cache.place_channel_data(event.data)
-        self.cache.delete_channel(int(event.data.get("id")))
+        self.cache.delete_channel(event.data.get("id"))
         self.dispatch(events.ChannelDelete(channel))
 
     @Processor.define()

--- a/naff/api/events/processors/channel_events.py
+++ b/naff/api/events/processors/channel_events.py
@@ -2,6 +2,7 @@ import copy
 from typing import TYPE_CHECKING
 
 import naff.api.events as events
+from naff.models.discord.channel import BaseChannel
 from naff.models.discord.invite import Invite
 from naff.client.const import MISSING
 from ._template import EventMixinTemplate, Processor
@@ -22,7 +23,7 @@ class ChannelEvents(EventMixinTemplate):
     async def _on_raw_channel_delete(self, event: "RawGatewayEvent") -> None:
         # for some reason this event returns the deleted channel data?
         # so we create an object from it
-        channel = self.cache.place_channel_data(event.data)
+        channel = BaseChannel.from_dict_factory(event.data, self)
         self.cache.delete_channel(event.data.get("id"))
         self.dispatch(events.ChannelDelete(channel))
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
The processor for channel deletion was not properly deleting the channel from the cache, instead just deleting from the guild's list of channels. This change makes sure that not even `bot.get_channel` or the like can get the deleted channel.


## Changes
- Use the `delete_channel` function in the cache rather than trying to handle the deletion logic in the channel deletion processor.
- Update the comment for this to clarify what's going on with the fix.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
