### PR TITLE
fix💥: handle errors when parsing http exceptions

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -596,8 +596,7 @@ class Client(
         if isinstance(error, HTTPException):
             # HTTPException's are of 3 known formats, we can parse them for human readable errors
             try:
-                errors = error.search_for_message(error.errors)
-                out = f"HTTPException: {error.status}|{error.response.reason}: " + "\n".join(errors)
+                out = [str(error)]
             except Exception:  # noqa : S110
                 pass
 

--- a/naff/client/errors.py
+++ b/naff/client/errors.py
@@ -105,9 +105,15 @@ class HTTPException(NaffException):
         super().__init__(f"{self.status}|{self.response.reason}: {f'({self.code}) ' if self.code else ''}{self.text}")
 
     def __str__(self) -> str:
-        errors = self.search_for_message(self.errors)
+        try:
+            errors = self.search_for_message(self.errors)
+        except (KeyError, ValueError, TypeError):
+            errors = [self.text]
         out = f"HTTPException: {self.status}|{self.response.reason}: " + "\n".join(errors)
         return out
+
+    def __repr__(self) -> str:
+        return str(self)
 
     @staticmethod
     def search_for_message(errors: dict, lookup: Optional[dict] = None) -> list[str]:


### PR DESCRIPTION
breaking in case someone was relying on these exceptions

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This prevents httpexception raising an exception when parsing the error payload, instead falling back on the provided text field. 


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
