### PR TITLE
feat: Allow Sentry extension to catch errors generated by Tasks

### DIFF
--- a/naff/models/naff/tasks/task.py
+++ b/naff/models/naff/tasks/task.py
@@ -72,8 +72,12 @@ class Task:
         next_run = self.next_run
         return next_run - datetime.now() if next_run is not None else None
 
+    def on_error_sentry_hook(self, error: Exception) -> None:
+        """A dummy method for naff.ext.sentry to hook"""
+
     def on_error(self, error: Exception) -> None:
         """Error handler for this task. Called when an exception is raised during execution of the task."""
+        self.on_error_sentry_hook(error)
         naff.Client.default_error_handler("Task", error)
 
     async def __call__(self) -> None:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Allows Sentry extension to catch Task errors, by installing a hook over a dedicated nop method.

It's theoretically gross, but it's the best idea we came up with.

## Changes
Added nop method to Task
Added hook to Sentry.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
