### PR TITLE
fix: sync on max/min length change

### DIFF
--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1073,6 +1073,8 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "choices": ("choices", []),
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),
+        "max_length": ("max_length", None),
+        "min_length": ("max_length", None),
     }
     post_process: Dict[str, Callable] = {
         "choices": lambda l: [d | {"name_localizations": {}} if len(d) == 2 else d for d in l],


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Fixes syncing when `min_length` or `max_length` is changed on an option

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Add `min`/`max_length` to `options_lookup`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
