### PR TITLE
fix: Use Iterable instead of List to prevent covariance issues in Contexts and SendMixin

### DIFF
--- a/naff/client/mixins/send.py
+++ b/naff/client/mixins/send.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Optional, Union
 
 import naff.models as models
 
@@ -34,7 +34,7 @@ class SendMixin:
                 dict,
             ]
         ] = None,
-        stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
+        stickers: Optional[Union[Iterable[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
         files: Optional[Union["UPLOADABLE_TYPE", Iterable["UPLOADABLE_TYPE"]]] = None,

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Union, runtime_checkable
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Protocol, Union, runtime_checkable
 
 from aiohttp import FormData
 
@@ -320,7 +320,7 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
         self.deferred = True
 
     async def _send_http_request(
-        self, message_payload: Union[dict, "FormData"], files: list["UPLOADABLE_TYPE"] | None = None
+        self, message_payload: Union[dict, "FormData"], files: Iterable["UPLOADABLE_TYPE"] | None = None
     ) -> dict:
         if self.responded:
             message_data = await self._client.http.post_followup(
@@ -345,15 +345,20 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
     async def send(
         self,
         content: Optional[str] = None,
-        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
         embed: Optional[Union["Embed", dict]] = None,
         components: Optional[
-            Union[List[List[Union["BaseComponent", dict]]], List[Union["BaseComponent", dict]], "BaseComponent", dict]
+            Union[
+                Iterable[Iterable[Union["BaseComponent", dict]]],
+                Iterable[Union["BaseComponent", dict]],
+                "BaseComponent",
+                dict,
+            ]
         ] = None,
-        stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
+        stickers: Optional[Union[Iterable[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        files: Optional[Union[UPLOADABLE_TYPE, List[UPLOADABLE_TYPE]]] = None,
+        files: Optional[Union[UPLOADABLE_TYPE, Iterable[UPLOADABLE_TYPE]]] = None,
         file: Optional[UPLOADABLE_TYPE] = None,
         tts: bool = False,
         suppress_embeds: bool = False,
@@ -494,13 +499,18 @@ class ComponentContext(InteractionContext):
     async def edit_origin(
         self,
         content: str = None,
-        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
         embed: Optional[Union["Embed", dict]] = None,
         components: Optional[
-            Union[List[List[Union["BaseComponent", dict]]], List[Union["BaseComponent", dict]], "BaseComponent", dict]
+            Union[
+                Iterable[Iterable[Union["BaseComponent", dict]]],
+                Iterable[Union["BaseComponent", dict]],
+                "BaseComponent",
+                dict,
+            ]
         ] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
-        files: Optional[Union[UPLOADABLE_TYPE, List[UPLOADABLE_TYPE]]] = None,
+        files: Optional[Union[UPLOADABLE_TYPE, Iterable[UPLOADABLE_TYPE]]] = None,
         file: Optional[UPLOADABLE_TYPE] = None,
         tts: bool = False,
     ) -> "Message":
@@ -573,7 +583,7 @@ class AutocompleteContext(_BaseInteractionContext):
         """The text the user has entered so far."""
         return self.kwargs.get(self.focussed_option, "")
 
-    async def send(self, choices: List[Union[str, int, float, Dict[str, Union[str, int, float]]]]) -> None:
+    async def send(self, choices: Iterable[Union[str, int, float, Dict[str, Union[str, int, float]]]]) -> None:
         """
         Send your autocomplete choices to discord. Choices must be either a list of strings, or a dictionary following the following format:
 
@@ -651,7 +661,7 @@ class PrefixedContext(Context, SendMixin):
     async def reply(
         self,
         content: Optional[str] = None,
-        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
         embed: Optional[Union["Embed", dict]] = None,
         **kwargs,
     ) -> "Message":
@@ -659,7 +669,7 @@ class PrefixedContext(Context, SendMixin):
         return await self.send(content=content, reply_to=self.message, embeds=embeds or embed, **kwargs)
 
     async def _send_http_request(
-        self, message_payload: Union[dict, "FormData"], files: list["UPLOADABLE_TYPE"] | None = None
+        self, message_payload: Union[dict, "FormData"], files: Iterable["UPLOADABLE_TYPE"] | None = None
     ) -> dict:
         return await self._client.http.create_message(message_payload, self.channel.id, files=files)
 
@@ -779,7 +789,7 @@ class HybridContext(Context):
     async def reply(
         self,
         content: Optional[str] = None,
-        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
         embed: Optional[Union["Embed", dict]] = None,
         **kwargs,
     ) -> "Message":
@@ -805,17 +815,17 @@ class HybridContext(Context):
     async def send(
         self,
         content: Optional[str] = None,
-        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
         embed: Optional[Union["Embed", dict]] = None,
         components: Optional[
             Union[
-                List[List[Union["BaseComponent", dict]]],
-                List[Union["BaseComponent", dict]],
+                Iterable[Iterable[Union["BaseComponent", dict]]],
+                Iterable[Union["BaseComponent", dict]],
                 "BaseComponent",
                 dict,
             ]
         ] = None,
-        stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
+        stickers: Optional[Union[Iterable[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
         file: Optional[Union["File", "IOBase", "Path", str]] = None,
@@ -887,16 +897,16 @@ class SendableContext(Protocol):
     async def send(
         self,
         content: Optional[str] = None,
-        embeds: Optional[Union[List[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
         components: Optional[
             Union[
-                List[List[Union["BaseComponent", dict]]],
-                List[Union["BaseComponent", dict]],
+                Iterable[Iterable[Union["BaseComponent", dict]]],
+                Iterable[Union["BaseComponent", dict]],
                 "BaseComponent",
                 dict,
             ]
         ] = None,
-        stickers: Optional[Union[List[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
+        stickers: Optional[Union[Iterable[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
         file: Optional[Union["File", "IOBase", "Path", str]] = None,


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
More progress towards not using mutable covariant collections in our parameter typings.

Nowhere near finished with this ordeal, but progress is progress, and these ones are throwing warnings in my own bots :P


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
