### PR TITLE
feat: add permissions_for to threadchannels

### DIFF
--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -1851,6 +1851,25 @@ class ThreadChannel(BaseChannel, MessageableMixin, WebhookMixin):
         """The permission overwrites for this channel."""
         return []
 
+    def permissions_for(self, instance: Snowflake_Type) -> Permissions:
+        """
+        Calculates permissions for an instance
+
+        Args:
+            instance: Member or Role instance (or its ID)
+
+        Returns:
+            Permissions data
+
+        Raises:
+            ValueError: If could not find any member or role by given ID
+            RuntimeError: If given instance is from another guild
+
+        """
+        if self.parent_channel:
+            return self.parent_channel.permissions_for(instance)
+        return Permissions.NONE
+
     async def fetch_members(self) -> List["models.ThreadMember"]:
         """Get the members that have access to this thread."""
         members_data = await self._client.http.list_thread_members(self.id)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Adds a helper method to `ThreadChannel` allowing users to use `permissions_for` on thread objects. It simply aliases `self.parent_channel.permissions_for`

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- As above

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
