### PR TITLE
feat: support new select menus

### DIFF
--- a/docs/src/Guides/05 Components.md
+++ b/docs/src/Guides/05 Components.md
@@ -99,20 +99,18 @@ await channel.send("Look a Button!", components=components)
 
 Sometimes there might be more than a handful options which users need to decide between. That's when a `Select` should probably be used.
 
-Selects are very similar to Buttons. The main difference is that they need options, which you supply by passing a list of `SelectOption`.
+Selects are very similar to Buttons. The main difference is that you get a list of options to choose from.
+
+If you want to use string options, then you use `StringSelect`. Simply pass a list of strings to `options` and you are good to go. You can also explicitly pass `SelectOptions` to control the value attribute.
 
 You can also define how many options users can choose by setting `min_values` and `max_values`.
+
 ```python
-components = SelectMenu(
+from naff import StringSelectMenu, SelectOption
+
+components = StringSelectMenu(
     options=[
-        SelectOption(
-            label="Pizza",
-            value="Pizza"
-        ),
-        SelectOption(
-            label="Egg Sandwich",
-            value="Egg Sandwich"
-        ),
+        "Pizza", "Pasta", "Burger", "Salad"
     ],
     placeholder="What is your favourite food?",
     min_values=1,
@@ -123,6 +121,10 @@ await channel.send("Look a Select!", components=components)
 ```
     ??? note
         You can only have upto 25 options in a Select
+
+Alternatively, you can use `RoleSelectMenu`, `UserSelectMenu` and `ChannelSelectMenu` to select roles, users and channels respectively. These select menus are very similar to `StringSelectMenu`, but they don't allow you to pass a list of options; it's all done behind the scenes.
+
+```python
 
 For more information, please visit the API reference [here](/API Reference/models/Discord/components/#naff.models.discord.components.Select).
 

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1703,7 +1703,7 @@ class Client(
             ctx = await self.get_context(interaction_data, True)
             component_type = interaction_data["data"]["component_type"]
 
-            self.dispatch(events.Component(ctx=ctx))
+            self.dispatch(events.Component(context=ctx))
             if callback := self._component_callbacks.get(ctx.custom_id):
                 ctx.command = callback
                 try:

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1718,7 +1718,7 @@ class Client(
                     self.dispatch(events.ComponentCompletion(ctx=ctx))
             if component_type == ComponentTypes.BUTTON:
                 self.dispatch(events.Button(ctx))
-            if component_type == ComponentTypes.SELECT:
+            if component_type == ComponentTypes.STRING_SELECT:
                 self.dispatch(events.Select(ctx))
 
         elif interaction_data["type"] == InteractionTypes.MODAL_RESPONSE:

--- a/naff/ext/paginators.py
+++ b/naff/ext/paginators.py
@@ -16,7 +16,7 @@ from naff import (
     Message,
     MISSING,
     Snowflake_Type,
-    SelectMenu,
+    StringSelectMenu,
     SelectOption,
     Color,
     BrandColors,
@@ -257,7 +257,7 @@ class Paginator:
         if self.show_select_menu:
             current = self.pages[self.page_index]
             output.append(
-                SelectMenu(
+                StringSelectMenu(
                     [
                         SelectOption(f"{i+1} {p.get_summary if isinstance(p, Page) else p.title}", str(i))
                         for i, p in enumerate(self.pages)

--- a/naff/models/discord/enums.py
+++ b/naff/models/discord/enums.py
@@ -543,10 +543,18 @@ class ComponentTypes(CursedIntEnum):
     """Container for other components"""
     BUTTON = 2
     """Button object"""
-    SELECT = 3
-    """Select menu for picking from choices"""
+    STRING_SELECT = 3
+    """Select menu for picking from text choices"""
     INPUT_TEXT = 4
     """Text input object"""
+    USER_SELECT = 5
+    """Select menu for picking from users"""
+    ROLE_SELECT = 6
+    """Select menu for picking from roles"""
+    MENTIONABLE_SELECT = 7
+    """Select menu for picking from mentionable objects"""
+    CHANNEL_SELECT = 8
+    """Select menu for picking from channels"""
 
 
 class CommandTypes(CursedIntEnum):

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -459,6 +459,7 @@ class ComponentContext(InteractionContext):
         new_cls = super().from_dict(data, client)
         new_cls.token = data["token"]
         new_cls.interaction_id = data["id"]
+        new_cls.invoke_target = data["data"]["custom_id"]
         new_cls.custom_id = data["data"]["custom_id"]
         new_cls.component_type = data["data"]["component_type"]
         new_cls.message = client.cache.place_message_data(data["message"])

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -382,8 +382,8 @@ async def test_components(bot: Client, channel: GuildText) -> None:
             components=naff.ActionRow(*[naff.Button(1, "test"), naff.Button(1, "test")]),
         )
         await thread.send(
-            "Test - SelectMenu",
-            components=naff.SelectMenu([SelectOption("test", "test")]),
+            "Test - StringSelectMenu",
+            components=naff.StringSelectMenu([SelectOption("test", "test")]),
         )
 
         Modal("Test Modal", [ParagraphText("test", value="test value, press send")])


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Supports the new fancy Select Menu Types (https://discord.com/developers/docs/interactions/message-components#select-menus)

Intentionally breaking anything referencing `SelectMenu` and `Select` enum, hence 2.x target.
![image](https://user-images.githubusercontent.com/22540825/195775081-2e43a9f8-dd52-4885-81cb-01facb4cc2cd.png)
![image](https://user-images.githubusercontent.com/22540825/195775031-19c126f2-aa9a-4411-9da9-7c13dab8bac8.png)

Overall Test Script:
```python
@listen()
async def on_ready(self):
    print("Ready!")
    components = [
        UserSelectMenu(custom_id="test", placeholder="Select a user"),
        RoleSelectMenu(custom_id="test", placeholder="Select a role"),
        MentionableSelectMenu(custom_id="test", placeholder="Select a mentionable"),
        ChannelSelectMenu(custom_id="test", placeholder="Select a channel"),
        ChannelSelectMenu(
            custom_id="test", placeholder="Select a VOICE channel", channel_types=[ChannelTypes.GUILD_VOICE]
        ),
    ]
    channel = self.get_channel(1030354509156847666)
    for component in components:
        await channel.send(components=[component])

@component_callback("test")
async def test(self, ctx):
    resolved = [
        f"Channels: {ctx.resolved.channels}",
        f"Members: {ctx.resolved.members}",
        "Users: {ctx.resolved.users}",
        f"Roles: {ctx.resolved.roles}",
        f"Messages: {ctx.resolved.messages}",
        f"Attachments: {ctx.resolved.attachments}",
    ]
    resolved = "\n".join(resolved)

    await ctx.send(f"You selected {ctx.values[0]}\n{resolved}", ephemeral=True)
```


## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Minor bugfix in component callbacks needed for testing
- Create base SelectMenu object for shared attributes
- Impliment specific objects for each new Select Menu
- Update component mappings
- Update component enums
- Update docs
- Update test bot 


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
