### PR TITLE
fix: Account for function definition of command groups

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1203,12 +1203,12 @@ class Client(
             if group is None or isinstance(command, ContextMenu):
                 self.interaction_tree[scope][command.resolved_name] = command
             elif group is not None:
-                if base not in self.interaction_tree[scope]:
+                if not (current := self.interaction_tree[scope].get(base)) or isinstance(current, SlashCommand):
                     self.interaction_tree[scope][base] = {}
                 if sub is None:
                     self.interaction_tree[scope][base][group] = command
                 else:
-                    if group not in self.interaction_tree[scope][base]:
+                    if not (current := self.interaction_tree[scope][base].get(group)) or isinstance(current, SlashCommand):
                         self.interaction_tree[scope][base][group] = {}
                     self.interaction_tree[scope][base][group][sub] = command
 

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1208,7 +1208,9 @@ class Client(
                 if sub is None:
                     self.interaction_tree[scope][base][group] = command
                 else:
-                    if not (current := self.interaction_tree[scope][base].get(group)) or isinstance(current, SlashCommand):
+                    if not (current := self.interaction_tree[scope][base].get(group)) or isinstance(
+                        current, SlashCommand
+                    ):
                         self.interaction_tree[scope][base][group] = {}
                     self.interaction_tree[scope][base][group][sub] = command
 

--- a/naff/models/naff/extension.py
+++ b/naff/models/naff/extension.py
@@ -103,12 +103,16 @@ class Extension:
                             if group is None or isinstance(val, ContextMenu):
                                 new_cls.interaction_tree[scope][val.resolved_name] = val
                             elif group is not None:
-                                if base not in new_cls.interaction_tree[scope]:
+                                if not (current := new_cls.interaction_tree[scope].get(base)) or isinstance(
+                                    current, naff.InteractionCommand
+                                ):
                                     new_cls.interaction_tree[scope][base] = {}
                                 if sub is None:
                                     new_cls.interaction_tree[scope][base][group] = val
                                 else:
-                                    if group not in new_cls.interaction_tree[scope][base]:
+                                    if not (current := new_cls.interaction_tree[scope][base].get(group)) or isinstance(
+                                        current, naff.InteractionCommand
+                                    ):
                                         new_cls.interaction_tree[scope][base][group] = {}
                                     new_cls.interaction_tree[scope][base][group][sub] = val
                     else:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
An oversight in `Client.interaction_tree` and `Extension.interaction_tree` led to errors during extension registration.

Example of breakage:
```py
@slash_command(name="base", description="I break you")
async def base(self, ctx: InteractionContext):
    ...

@base.slash_command(sub_cmd_name="sub", description="I was broken")
async def sub(self, ctx: InteractionContext):
    await ctx.send("I will never even load, let alone run")
```

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Account for function definition of command groups to avoid errors

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
