### PR TITLE
refactor: drop guild timeout log to debug level

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -821,7 +821,10 @@ class Client(
                 try:  # wait to let guilds cache
                     await asyncio.wait_for(self._guild_event.wait(), self.guild_event_timeout)
                 except asyncio.TimeoutError:
-                    self.logger.warning("Timeout waiting for guilds cache: Not all guilds will be in cache")
+                    # this will *mostly* occur when a guild has been shadow deleted by discord T&S.
+                    # there is no way to check for this, so we just need to wait for this to time out.
+                    # We still log it though, just in case.
+                    self.logger.debug("Timeout waiting for guilds cache")
                     break
                 self._guild_event.clear()
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Drops the log level of the guild cache timeout to `debug`. The primary cause of this state is trust and safety shadow-deleting guilds during an investigation. Leaving it at `warning` only scares users and makes them think something is wrong - there isn’t. 

Theoretically, there could be a fault resulting in the bot not caching all guilds, hence me leaving dropping the level instead of removing completely.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- As above

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
