### PR TITLE
refactor 💥: Make component event consistent with other events

### DIFF
--- a/naff/api/events/internal.py
+++ b/naff/api/events/internal.py
@@ -133,7 +133,7 @@ class WebsocketReady(RawGatewayEvent):
 class Component(BaseEvent):
     """Dispatched when a user uses a Component."""
 
-    context: "ComponentContext" = field(metadata=docs("The context of the interaction"))
+    ctx: "ComponentContext" = field(metadata=docs("The context of the interaction"))
 
 
 @define(kw_only=False)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
All other events use `ctx`, this one uses `context`. This is annoying 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Renames `Component.context` -> `Component.ctx`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
