### PR TITLE
tests:  Clean up lost test guilds

### DIFF
--- a/.github/workflows/pytest-pr.yml
+++ b/.github/workflows/pytest-pr.yml
@@ -15,7 +15,6 @@ jobs:
           - .[speedup]
           - .[voice]
           - .[all]
-          - .[docs]
 
     steps:
       - name: Create check run

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ extras_require["tests"] = [
     "pytest-recording",
     "pytest-asyncio",
     "pytest-cov",
+    "python-dotenv",
     "typeguard",
 ]
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -42,6 +42,13 @@ __all__ = ()
 
 from tests.utils import generate_dummy_context
 
+try:
+    import dotenv
+
+    dotenv.load_dotenv()
+except ImportError:
+    pass
+
 TOKEN = os.environ.get("BOT_TOKEN")
 if not TOKEN:
     pytest.skip(f"Skipping {os.path.basename(__file__)} - no token provided", allow_module_level=True)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -37,6 +37,8 @@ from naff.api.gateway.websocket import WebsocketClient
 from naff.api.http.route import Route
 from naff.api.voice.audio import AudioVolume
 from naff.client.errors import NotFound
+from naff.client.utils.misc_utils import find
+from naff.models.discord.timestamp import Timestamp
 
 __all__ = ()
 
@@ -71,7 +73,14 @@ async def bot() -> Client:
 
 
 @pytest.fixture(scope="module")
-async def guild(bot) -> Guild:
+async def guild(bot: Client) -> Guild:
+    if len(bot.guilds) > 9:
+        leftover = find(lambda g: g.is_owner(bot.user.id) and g.name == "test_suite_guild", bot.guilds)
+        if leftover:
+            age = Timestamp.now() - leftover.created_at
+            if age.days > 0:
+                # This from a failed run, let's clean it up
+                await leftover.delete()
     guild: naff.Guild = await naff.Guild.create("test_suite_guild", bot)
     community_channel = await guild.create_text_channel("community_channel")
 


### PR DESCRIPTION

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [x] Tests change

## Description
I noticed that #675 was failing because we hit the ten guild limit.
This should only have happened if we were either:

* Running more than 10 simultaneous test jobs at the same time.
* Or tests have at some point in the past failed so catestrophically that they didn't delete their guild at the end of the run.

This PR adds a (rather naive) check for an existing test guild that's more than a day old, and if so, deletes it.
Definitely could be optimized or improved, but eh, this is good enough for our purposes.


## Changes
- Adds the ability to to load tokens from a .env file (mostly for my own convenience)
- Adds a naive cleanup procedure to the top of the guild fixture.


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
