### PR TITLE
fix: handle no joined_at attribute

### DIFF
--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -230,7 +230,9 @@ class Member(DiscordObject, _SendDMMixin):
     nick: Optional[str] = field(repr=True, default=None, metadata=docs("The user's nickname in this guild'"))
     deaf: bool = field(default=False, metadata=docs("Has this user been deafened in voice channels?"))
     mute: bool = field(default=False, metadata=docs("Has this user been muted in voice channels?"))
-    joined_at: "Timestamp" = field(converter=timestamp_converter, metadata=docs("When the user joined this guild"))
+    joined_at: "Timestamp" = field(
+        default=MISSING, converter=optional(timestamp_converter), metadata=docs("When the user joined this guild")
+    )
     premium_since: Optional["Timestamp"] = field(
         default=None,
         converter=optional_c(timestamp_converter),


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
In threads, discord no longer *always* sends a `joined_at` attribute for members. This handles that.

Resolves #678 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- `joined_at` is now optional

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
