### PR TITLE
refactor: remove usage of @define

### DIFF
--- a/naff/api/events/base.py
+++ b/naff/api/events/base.py
@@ -1,9 +1,11 @@
 import re
 from typing import TYPE_CHECKING, Callable, Coroutine
 
+import attrs
+
 import naff.models as models
 from naff.client.const import MISSING
-from naff.client.utils.attr_utils import define, field, docs
+from naff.client.utils.attr_utils import docs, field
 from naff.models.discord.snowflake import to_snowflake
 
 if TYPE_CHECKING:
@@ -16,7 +18,7 @@ __all__ = ("BaseEvent", "GuildEvent", "RawGatewayEvent")
 _event_reg = re.compile("(?<!^)(?=[A-Z])")
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=False)
 class BaseEvent:
     """A base event that all other events inherit from."""
 
@@ -58,7 +60,7 @@ class BaseEvent:
         return listener
 
 
-@define(slots=False, kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=False)
 class GuildEvent(BaseEvent):
     """A base event that adds guild_id."""
 
@@ -70,7 +72,7 @@ class GuildEvent(BaseEvent):
         return self.bot.cache.get_guild(self.guild_id)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class RawGatewayEvent(BaseEvent):
     """
     An event dispatched from the gateway.

--- a/naff/api/events/discord.py
+++ b/naff/api/events/discord.py
@@ -23,10 +23,12 @@ These are events dispatched by Discord. This is intended as a reference so you k
 
 from typing import TYPE_CHECKING, List, Sequence, Union, Optional
 
+import attrs
+
 import naff.models
 from naff.api.events.base import GuildEvent, BaseEvent
 from naff.client.const import MISSING, Absent
-from naff.client.utils.attr_utils import define, field, docs
+from naff.client.utils.attr_utils import docs, field
 
 __all__ = (
     "ApplicationCommandPermissionsUpdate",
@@ -107,7 +109,7 @@ if TYPE_CHECKING:
     from naff.models.discord.app_perms import ApplicationCommandPermission
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class AutoModExec(BaseEvent):
     """Dispatched when an auto modation action is executed"""
 
@@ -116,41 +118,41 @@ class AutoModExec(BaseEvent):
     guild: "Guild" = field(metadata=docs("The guild the action was executed in"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class AutoModCreated(BaseEvent):
     guild: "Guild" = field(metadata=docs("The guild the rule was modified in"))
     rule: "AutoModRule" = field(metadata=docs("The rule that was modified"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class AutoModUpdated(AutoModCreated):
     """Dispatched when an auto mod rule is modified"""
 
     ...
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class AutoModDeleted(AutoModCreated):
     """Dispatched when an auto mod rule is deleted"""
 
     ...
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ApplicationCommandPermissionsUpdate(BaseEvent):
     guild_id: "Snowflake_Type" = field(metadata=docs("The guild the command permissions were updated in"))
     application_id: "Snowflake_Type" = field(metadata=docs("The application the command permissions were updated for"))
     permissions: List["ApplicationCommandPermission"] = field(factory=list, metadata=docs("The updated permissions"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ChannelCreate(BaseEvent):
     """Dispatched when a channel is created."""
 
     channel: "BaseChannel" = field(metadata=docs("The channel this event is dispatched from"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ChannelUpdate(BaseEvent):
     """Dispatched when a channel is updated."""
 
@@ -160,12 +162,12 @@ class ChannelUpdate(BaseEvent):
     """Channel after this event"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ChannelDelete(ChannelCreate):
     """Dispatched when a channel is deleted."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ChannelPinsUpdate(ChannelCreate):
     """Dispatched when a channel's pins are updated."""
 
@@ -173,29 +175,29 @@ class ChannelPinsUpdate(ChannelCreate):
     """The time at which the most recent pinned message was pinned"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ThreadCreate(BaseEvent):
     """Dispatched when a thread is created, or a thread is new to the client"""
 
     thread: "TYPE_THREAD_CHANNEL" = field(metadata=docs("The thread this event is dispatched from"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class NewThreadCreate(ThreadCreate):
     """Dispatched when a thread is newly created."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ThreadUpdate(ThreadCreate):
     """Dispatched when a thread is updated."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ThreadDelete(ThreadCreate):
     """Dispatched when a thread is deleted."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ThreadListSync(BaseEvent):
     """Dispatched when gaining access to a channel, contains all active threads in that channel."""
 
@@ -208,7 +210,7 @@ class ThreadListSync(BaseEvent):
 
 
 # todo implementation missing
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ThreadMemberUpdate(ThreadCreate):
     """
     Dispatched when the thread member object for the current user is updated.
@@ -223,7 +225,7 @@ class ThreadMemberUpdate(ThreadCreate):
     """The member who was added"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ThreadMembersUpdate(BaseEvent):
     """Dispatched when anyone is added or removed from a thread."""
 
@@ -237,7 +239,7 @@ class ThreadMembersUpdate(BaseEvent):
     """Users removed from the thread"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildJoin(BaseEvent):
     """
     Dispatched when a guild is joined, created, or becomes available.
@@ -251,7 +253,7 @@ class GuildJoin(BaseEvent):
     """The guild that was created"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildUpdate(BaseEvent):
     """Dispatched when a guild is updated."""
 
@@ -261,7 +263,7 @@ class GuildUpdate(BaseEvent):
     """Guild after this event"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildLeft(GuildEvent):
     """Dispatched when a guild is left."""
 
@@ -269,7 +271,7 @@ class GuildLeft(GuildEvent):
     """The guild, if it was cached"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildUnavailable(GuildEvent):
     """Dispatched when a guild is not available."""
 
@@ -277,19 +279,19 @@ class GuildUnavailable(GuildEvent):
     """The guild, if it was cached"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class BanCreate(GuildEvent):
     """Dispatched when someone was banned from a guild."""
 
     user: "BaseUser" = field(metadata=docs("The user"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class BanRemove(BanCreate):
     """Dispatched when a users ban is removed."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildEmojisUpdate(GuildEvent):
     """Dispatched when a guild's emojis are updated."""
 
@@ -299,7 +301,7 @@ class GuildEmojisUpdate(GuildEvent):
     """List of emoji after this event"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildStickersUpdate(GuildEvent):
     """Dispatched when a guild's stickers are updated."""
 
@@ -307,14 +309,14 @@ class GuildStickersUpdate(GuildEvent):
     """List of stickers from after this event"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MemberAdd(GuildEvent):
     """Dispatched when a member is added to a guild."""
 
     member: "Member" = field(metadata=docs("The member who was added"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MemberRemove(MemberAdd):
     """Dispatched when a member is removed from a guild."""
 
@@ -323,7 +325,7 @@ class MemberRemove(MemberAdd):
     )
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MemberUpdate(GuildEvent):
     """Dispatched when a member is updated."""
 
@@ -333,7 +335,7 @@ class MemberUpdate(GuildEvent):
     """The state of the member after this event"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class RoleCreate(GuildEvent):
     """Dispatched when a role is created."""
 
@@ -341,7 +343,7 @@ class RoleCreate(GuildEvent):
     """The created role"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class RoleUpdate(GuildEvent):
     """Dispatched when a role is updated."""
 
@@ -351,7 +353,7 @@ class RoleUpdate(GuildEvent):
     """The role after this event"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class RoleDelete(GuildEvent):
     """Dispatched when a guild role is deleted."""
 
@@ -361,7 +363,7 @@ class RoleDelete(GuildEvent):
     """The deleted role"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GuildMembersChunk(GuildEvent):
     """
     Sent in response to Guild Request Members.
@@ -383,19 +385,19 @@ class GuildMembersChunk(GuildEvent):
     """A list of members"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class IntegrationCreate(BaseEvent):
     """Dispatched when a guild integration is created."""
 
     integration: "GuildIntegration" = field()
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class IntegrationUpdate(IntegrationCreate):
     """Dispatched when a guild integration is updated."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class IntegrationDelete(GuildEvent):
     """Dispatched when a guild integration is deleted."""
 
@@ -405,26 +407,26 @@ class IntegrationDelete(GuildEvent):
     """The ID of the bot/application for this integration"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class InviteCreate(BaseEvent):
     """Dispatched when a guild invite is created."""
 
     invite: naff.models.Invite = field()
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class InviteDelete(InviteCreate):
     """Dispatched when an invite is deleted."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MessageCreate(BaseEvent):
     """Dispatched when a message is created."""
 
     message: "Message" = field()
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MessageUpdate(BaseEvent):
     """Dispatched when a message is edited."""
 
@@ -434,14 +436,14 @@ class MessageUpdate(BaseEvent):
     """The message after this event was created"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MessageDelete(BaseEvent):
     """Dispatched when a message is deleted."""
 
     message: "Message" = field()
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MessageDeleteBulk(GuildEvent):
     """Dispatched when multiple messages are deleted at once."""
 
@@ -451,7 +453,7 @@ class MessageDeleteBulk(GuildEvent):
     """A list of message snowflakes"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MessageReactionAdd(BaseEvent):
     """Dispatched when a reaction is added to a message."""
 
@@ -471,12 +473,12 @@ class MessageReactionAdd(BaseEvent):
         return self.reaction.count
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MessageReactionRemove(MessageReactionAdd):
     """Dispatched when a reaction is removed."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MessageReactionRemoveAll(GuildEvent):
     """Dispatched when all reactions are removed from a message."""
 
@@ -484,7 +486,7 @@ class MessageReactionRemoveAll(GuildEvent):
     """The message that was reacted to"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class PresenceUpdate(BaseEvent):
     """A user's presence has changed."""
 
@@ -500,24 +502,24 @@ class PresenceUpdate(BaseEvent):
     """The guild this presence update was dispatched from"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class StageInstanceCreate(BaseEvent):
     """Dispatched when a stage instance is created."""
 
     stage_instance: "StageInstance" = field(metadata=docs("The stage instance"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class StageInstanceDelete(StageInstanceCreate):
     """Dispatched when a stage instance is deleted."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class StageInstanceUpdate(StageInstanceCreate):
     """Dispatched when a stage instance is updated."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class TypingStart(BaseEvent):
     """Dispatched when a user starts typing."""
 
@@ -531,7 +533,7 @@ class TypingStart(BaseEvent):
     """unix time (in seconds) of when the user started typing"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class WebhooksUpdate(GuildEvent):
     """Dispatched when a guild channel webhook is created, updated, or deleted."""
 
@@ -540,14 +542,14 @@ class WebhooksUpdate(GuildEvent):
     """The ID of the webhook was updated"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class InteractionCreate(BaseEvent):
     """Dispatched when a user uses an Application Command."""
 
     interaction: dict = field()
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class VoiceStateUpdate(BaseEvent):
     """Dispatched when a user's voice state changes."""
 
@@ -557,13 +559,13 @@ class VoiceStateUpdate(BaseEvent):
     """The voice state after this event was created or None if the user is no longer in a voice channel"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class BaseVoiceEvent(BaseEvent):
     state: "VoiceState" = field()
     """The current voice state of the user"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class VoiceUserMove(BaseVoiceEvent):
     """Dispatched when a user moves voice channels."""
 
@@ -575,7 +577,7 @@ class VoiceUserMove(BaseVoiceEvent):
     """The new voice channel the user is in"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class VoiceUserMute(BaseVoiceEvent):
     """Dispatched when a user is muted or unmuted."""
 
@@ -587,7 +589,7 @@ class VoiceUserMute(BaseVoiceEvent):
     """The new mute state of the user"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class VoiceUserDeafen(BaseVoiceEvent):
     """Dispatched when a user is deafened or undeafened."""
 
@@ -599,7 +601,7 @@ class VoiceUserDeafen(BaseVoiceEvent):
     """The new deaf state of the user"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class VoiceUserJoin(BaseVoiceEvent):
     """Dispatched when a user joins a voice channel."""
 
@@ -609,7 +611,7 @@ class VoiceUserJoin(BaseVoiceEvent):
     """The voice channel the user joined"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class VoiceUserLeave(BaseVoiceEvent):
     """Dispatched when a user leaves a voice channel."""
 

--- a/naff/api/events/internal.py
+++ b/naff/api/events/internal.py
@@ -23,8 +23,10 @@ These are events dispatched by the client. This is intended as a reference so yo
 import re
 from typing import Any, Optional, TYPE_CHECKING
 
+import attrs
+
 from naff.api.events.base import BaseEvent, RawGatewayEvent
-from naff.client.utils.attr_utils import define, field, docs
+from naff.client.utils.attr_utils import docs, field
 
 __all__ = (
     "ButtonPressed",
@@ -65,41 +67,41 @@ if TYPE_CHECKING:
 _event_reg = re.compile("(?<!^)(?=[A-Z])")
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Login(BaseEvent):
     """The bot has just logged in."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Connect(BaseEvent):
     """The bot is now connected to the discord Gateway."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Resume(BaseEvent):
     """The bot has resumed its connection to the discord Gateway."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Disconnect(BaseEvent):
     """The bot has just disconnected."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ShardConnect(Connect):
     """A shard just connected to the discord Gateway."""
 
     shard_id: int = field(metadata=docs("The ID of the shard"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ShardDisconnect(Disconnect):
     """A shard just disconnected."""
 
     shard_id: int = field(metadata=docs("The ID of the shard"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Startup(BaseEvent):
     """
     The client is now ready for the first time.
@@ -110,7 +112,7 @@ class Startup(BaseEvent):
     """
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Ready(BaseEvent):
     """
     The client is now ready.
@@ -122,66 +124,66 @@ class Ready(BaseEvent):
     """
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class WebsocketReady(RawGatewayEvent):
     """The gateway has reported that it is ready."""
 
     data: dict = field(metadata=docs("The data from the ready event"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Component(BaseEvent):
     """Dispatched when a user uses a Component."""
 
     ctx: "ComponentContext" = field(metadata=docs("The context of the interaction"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ButtonPressed(Component):
     """Dispatched when a user uses a Button."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Select(Component):
     """Dispatched when a user uses a Select."""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class CommandCompletion(BaseEvent):
     """Dispatched after the library ran any command callback."""
 
     ctx: "InteractionContext | PrefixedContext | HybridContext" = field(metadata=docs("The command context"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ComponentCompletion(BaseEvent):
     """Dispatched after the library ran any component callback."""
 
     ctx: "ComponentContext" = field(metadata=docs("The component context"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AutocompleteCompletion(BaseEvent):
     """Dispatched after the library ran any autocomplete callback."""
 
     ctx: "AutocompleteContext" = field(metadata=docs("The autocomplete context"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ModalCompletion(BaseEvent):
     """Dispatched after the library ran any modal callback."""
 
     ctx: "ModalContext" = field(metadata=docs("The modal context"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class _Error(BaseEvent):
     error: Exception = field(metadata=docs("The error that was encountered"))
     args: tuple[Any] = field(factory=tuple)
     kwargs: dict[str, Any] = field(factory=dict)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Error(_Error):
     """Dispatched when the library encounters an error."""
 
@@ -189,28 +191,28 @@ class Error(_Error):
     ctx: Optional["Context"] = field(default=None, metadata=docs("The Context, if one was active"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class CommandError(_Error):
     """Dispatched when the library encounters an error in a command."""
 
     ctx: "InteractionContext | PrefixedContext | HybridContext" = field(metadata=docs("The command context"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ComponentError(_Error):
     """Dispatched when the library encounters an error in a component."""
 
     ctx: "ComponentContext" = field(metadata=docs("The component context"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AutocompleteError(_Error):
     """Dispatched when the library encounters an error in an autocomplete."""
 
     ctx: "AutocompleteContext" = field(metadata=docs("The autocomplete context"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ModalError(_Error):
     """Dispatched when the library encounters an error in a modal."""
 

--- a/naff/api/gateway/state.py
+++ b/naff/api/gateway/state.py
@@ -4,11 +4,13 @@ from datetime import datetime
 from logging import Logger
 from typing import TYPE_CHECKING, Optional, Union
 
+import attrs
+
 import naff
 from naff.api import events
 from naff.client.const import Absent, MISSING, get_logger
 from naff.client.errors import NaffException, WebSocketClosed
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.models.discord.activity import Activity
 from naff.models.discord.enums import Intents, Status, ActivityType
 from .gateway import GatewayClient
@@ -19,7 +21,7 @@ if TYPE_CHECKING:
 __all__ = ("ConnectionState",)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ConnectionState:
     client: "Client"
     """The bot's client"""

--- a/naff/client/mixins/serialization.py
+++ b/naff/client/mixins/serialization.py
@@ -4,13 +4,13 @@ from typing import Any, Dict, List, Type
 import attrs
 
 import naff.client.const as const
-from naff.client.utils.attr_utils import define, field
 import naff.client.utils.serializer as serializer
+from naff.client.utils.attr_utils import field
 
 __all__ = ("DictSerializationMixin",)
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False)
 class DictSerializationMixin:
     logger: Logger = field(init=False, factory=const.get_logger, metadata=serializer.no_export_meta)
 

--- a/naff/client/smart_cache.py
+++ b/naff/client/smart_cache.py
@@ -2,11 +2,12 @@ from contextlib import suppress
 from logging import Logger
 from typing import TYPE_CHECKING, List, Dict, Any, Optional, Union
 
+import attrs
 import discord_typings
 
 from naff.client.const import Absent, MISSING, get_logger
 from naff.client.errors import NotFound, Forbidden
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.client.utils.cache import TTLCache
 from naff.models import VoiceState
 from naff.models.discord.channel import BaseChannel, GuildChannel, ThreadChannel
@@ -52,7 +53,7 @@ def create_cache(
         return TTLCache(hard_limit=hard_limit or float("inf"), soft_limit=soft_limit or 0, ttl=ttl or float("inf"))
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class GlobalCache:
     _client: "Client" = field()
 

--- a/naff/client/utils/cache.py
+++ b/naff/client/utils/cache.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Generic, Iterator, Optional, Tuple, TypeVar
 
 import attrs
 
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 
 __all__ = ("TTLItem", "TTLCache")
 
@@ -13,7 +13,7 @@ KT = TypeVar("KT")
 VT = TypeVar("VT")
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class TTLItem(Generic[VT]):
     value: VT = field()
     expire: float = field()

--- a/naff/ext/paginators.py
+++ b/naff/ext/paginators.py
@@ -3,6 +3,8 @@ import textwrap
 import uuid
 from typing import Callable, Coroutine, List, Optional, Sequence, TYPE_CHECKING, Union
 
+import attrs
+
 from naff import (
     Embed,
     ComponentContext,
@@ -21,7 +23,7 @@ from naff import (
     Color,
     BrandColors,
 )
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import export_converter
 from naff.models.discord.emoji import process_emoji
 
@@ -32,7 +34,7 @@ if TYPE_CHECKING:
 __all__ = ("Paginator",)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Timeout:
     paginator: "Paginator" = field()
     """The paginator that this timeout is associated with."""
@@ -53,7 +55,7 @@ class Timeout:
                 self.ping.clear()
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Page:
     content: str = field()
     """The content of the page."""
@@ -74,7 +76,7 @@ class Page:
         return Embed(description=f"{self.prefix}\n{self.content}\n{self.suffix}", title=self.title)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Paginator:
     client: "Client" = field()
     """The NAFF client to hook listeners into"""

--- a/naff/ext/prefixed_help.py
+++ b/naff/ext/prefixed_help.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 __all__ = ("PrefixedHelpCommand",)
 
 
-@attrs.define(slots=True)
+@attrs.define(eq=False, order=False, hash=False, slots=True)
 class PrefixedHelpCommand:
     """A help command for all prefixed commands in a bot."""
 

--- a/naff/models/discord/activity.py
+++ b/naff/models/discord/activity.py
@@ -1,8 +1,10 @@
 from typing import Optional, List
 
+import attrs
+
 from naff.client.mixins.serialization import DictSerializationMixin
-from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import timestamp_converter, optional
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import dict_filter_none
 from naff.models.discord.emoji import PartialEmoji
 from naff.models.discord.enums import ActivityType, ActivityFlags
@@ -18,7 +20,7 @@ __all__ = (
 )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ActivityTimestamps(DictSerializationMixin):
     start: Optional[Timestamp] = field(default=None, converter=optional(timestamp_converter))
     """The start time of the activity. Shows "elapsed" timer on discord client."""
@@ -26,7 +28,7 @@ class ActivityTimestamps(DictSerializationMixin):
     """The end time of the activity. Shows "remaining" timer on discord client."""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ActivityParty(DictSerializationMixin):
     id: Optional[str] = field(default=None)
     """A unique identifier for this party"""
@@ -34,7 +36,7 @@ class ActivityParty(DictSerializationMixin):
     """Info about the size of the party"""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ActivityAssets(DictSerializationMixin):
     large_image: Optional[str] = field(default=None)
     """The large image for this activity. Uses discord's asset image url format."""
@@ -46,7 +48,7 @@ class ActivityAssets(DictSerializationMixin):
     """Hover text for the small image"""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ActivitySecrets(DictSerializationMixin):
     join: Optional[str] = field(default=None)
     """The secret for joining a party"""
@@ -56,7 +58,7 @@ class ActivitySecrets(DictSerializationMixin):
     """The secret for a specific instanced match"""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Activity(DictSerializationMixin):
     """Represents a discord activity object use for rich presence in discord."""
 

--- a/naff/models/discord/app_perms.py
+++ b/naff/models/discord/app_perms.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING
 
-from naff.client.utils import define, field
+import attrs
+
+from naff.client.utils import field
 from naff.models.discord.base import DiscordObject, ClientObject
 from naff.models.discord.enums import InteractionPermissionTypes
 from naff.models.discord.snowflake import to_snowflake
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
 __all__ = ("ApplicationCommandPermission",)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ApplicationCommandPermission(DiscordObject):
     id: "Snowflake_Type" = field(converter=to_snowflake)
     """ID of the role user or channel"""
@@ -21,7 +23,7 @@ class ApplicationCommandPermission(DiscordObject):
     """Whether the command is enabled for this permission"""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class CommandPermissions(ClientObject):
     command_id: "Snowflake_Type" = field()
     _guild: "Guild" = field()

--- a/naff/models/discord/application.py
+++ b/naff/models/discord/application.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING, List, Optional, Dict, Any
 
+import attrs
+
 from naff.client.const import MISSING
-from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import optional
+from naff.client.utils.attr_utils import field
 from naff.models.discord.asset import Asset
 from naff.models.discord.enums import ApplicationFlags
 from naff.models.discord.snowflake import Snowflake_Type, to_snowflake
@@ -16,7 +18,7 @@ if TYPE_CHECKING:
 __all__ = ("Application",)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Application(DiscordObject):
     """Represents a discord application."""
 

--- a/naff/models/discord/asset.py
+++ b/naff/models/discord/asset.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING, Optional, Union
 
-from naff.client.utils.attr_utils import define, field
+import attrs
+
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import no_export_meta
 
 if TYPE_CHECKING:
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
 __all__ = ("Asset",)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Asset:
     """
     Represents a discord asset.

--- a/naff/models/discord/auto_mod.py
+++ b/naff/models/discord/auto_mod.py
@@ -5,7 +5,7 @@ import attrs
 from naff.client.const import get_logger, MISSING, Absent
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils import list_converter, optional
-from naff.client.utils.attr_utils import define, field, docs
+from naff.client.utils.attr_utils import docs, field
 from naff.models.discord.base import ClientObject, DiscordObject
 from naff.models.discord.enums import AutoModTriggerType, AutoModAction, AutoModEvent, AutoModLanuguageType
 from naff.models.discord.snowflake import to_snowflake_list, to_snowflake
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 __all__ = ("AutoModerationAction", "AutoModRule")
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class BaseAction(DictSerializationMixin):
     """A base implementation of a moderation action
 
@@ -48,7 +48,7 @@ class BaseAction(DictSerializationMixin):
         return data
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class BaseTrigger(DictSerializationMixin):
     """A base implementation of an auto-mod trigger
 
@@ -93,7 +93,7 @@ def _keyword_converter(filter: str | list[str]) -> list[str]:
     return [filter]
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class KeywordTrigger(BaseTrigger):
     """A trigger that checks if content contains words from a user defined list of keywords"""
 
@@ -108,7 +108,7 @@ class KeywordTrigger(BaseTrigger):
     )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class HarmfulLinkFilter(BaseTrigger):
     """A trigger that checks if content contains any harmful links"""
 
@@ -121,7 +121,7 @@ class HarmfulLinkFilter(BaseTrigger):
     ...
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class KeywordPresetTrigger(BaseTrigger):
     """A trigger that checks if content contains words from internal pre-defined wordsets"""
 
@@ -139,14 +139,14 @@ class KeywordPresetTrigger(BaseTrigger):
     )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class MentionSpamTrigger(BaseTrigger):
     """A trigger that checks if content contains more mentions than allowed"""
 
     mention_total_limit: int = field(default=3, repr=True, metadata=docs("The maximum number of mentions allowed"))
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class BlockMessage(BaseAction):
     """blocks the content of a message according to the rule"""
 
@@ -154,7 +154,7 @@ class BlockMessage(BaseAction):
     ...
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AlertMessage(BaseAction):
     """logs user content to a specified channel"""
 
@@ -162,7 +162,7 @@ class AlertMessage(BaseAction):
     type: AutoModAction = field(default=AutoModAction.ALERT_MESSAGE, converter=AutoModAction)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class TimeoutUser(BaseAction):
     """timeout user for a specified duration"""
 
@@ -170,7 +170,7 @@ class TimeoutUser(BaseAction):
     type: AutoModAction = field(default=AutoModAction.TIMEOUT_USER, converter=AutoModAction)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AutoModRule(DiscordObject):
     """A representation of an auto mod rule"""
 
@@ -282,7 +282,7 @@ class AutoModRule(DiscordObject):
         return AutoModRule.from_dict(out, self._client)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AutoModerationAction(ClientObject):
     rule_trigger_type: AutoModTriggerType = field(converter=AutoModTriggerType)
     rule_id: "Snowflake_Type" = field()

--- a/naff/models/discord/base.py
+++ b/naff/models/discord/base.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Type
 
+import attrs
+
 from naff.client.const import T
 from naff.client.mixins.serialization import DictSerializationMixin
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import no_export_meta
 from naff.models.discord.snowflake import SnowflakeObject
 
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
 __all__ = ("ClientObject", "DiscordObject")
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False)
 class ClientObject(DictSerializationMixin):
     """Serializable object that requires client reference."""
 
@@ -39,6 +41,6 @@ class ClientObject(DictSerializationMixin):
         return self
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False)
 class DiscordObject(SnowflakeObject, ClientObject):
     pass

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -6,14 +6,13 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Callable
 import attrs
 
 import naff.models as models
-
 from naff.client.const import Absent, DISCORD_EPOCH, MISSING
 from naff.client.errors import NotFound, VoiceNotConnected, TooManyChanges
 from naff.client.mixins.send import SendMixin
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_converters import optional as optional_c
 from naff.client.utils.attr_converters import timestamp_converter
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.client.utils.misc_utils import get
 from naff.client.utils.serializer import to_dict, to_image_data
 from naff.models.discord.base import DiscordObject
@@ -156,7 +155,7 @@ class ArchivedForumPosts(AsyncIterator):
         raise QueueEmpty
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class PermissionOverwrite(SnowflakeObject, DictSerializationMixin):
     """
     Channel Permissions Overwrite object.
@@ -219,7 +218,7 @@ class PermissionOverwrite(SnowflakeObject, DictSerializationMixin):
             self.deny |= perm
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class MessageableMixin(SendMixin):
     last_message_id: Optional[Snowflake_Type] = field(
         default=None
@@ -462,7 +461,7 @@ class MessageableMixin(SendMixin):
         return Typing(self)
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class InvitableMixin:
     async def create_invite(
         self,
@@ -524,7 +523,7 @@ class InvitableMixin:
         return models.Invite.from_list(invites_data, self._client)
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class ThreadableMixin:
     async def create_thread(
         self,
@@ -700,7 +699,7 @@ class ThreadableMixin:
         return threads
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class WebhookMixin:
     async def create_webhook(self, name: str, avatar: Absent[UPLOADABLE_TYPE] = MISSING) -> "models.Webhook":
         """
@@ -741,7 +740,7 @@ class WebhookMixin:
         return [models.Webhook.from_dict(d, self._client) for d in resp]
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class BaseChannel(DiscordObject):
     name: Optional[str] = field(repr=True, default=None)
     """The name of the channel (1-100 characters)"""
@@ -877,7 +876,7 @@ class BaseChannel(DiscordObject):
 # DMs
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class DMChannel(BaseChannel, MessageableMixin):
     recipients: List["models.User"] = field(factory=list)
     """The users of the DM that will receive messages sent"""
@@ -898,7 +897,7 @@ class DMChannel(BaseChannel, MessageableMixin):
         return self.recipients
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class DM(DMChannel):
     @property
     def recipient(self) -> "models.User":
@@ -906,7 +905,7 @@ class DM(DMChannel):
         return self.recipients[0]
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class DMGroup(DMChannel):
     owner_id: Snowflake_Type = field(repr=True)
     """id of the creator of the group DM"""
@@ -971,7 +970,7 @@ class DMGroup(DMChannel):
 # Guild
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class GuildChannel(BaseChannel):
     position: Optional[int] = field(default=0)
     """Sorting position of the channel"""
@@ -1289,7 +1288,7 @@ class GuildChannel(BaseChannel):
         )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildCategory(GuildChannel):
     @property
     def channels(self) -> List["TYPE_GUILD_CHANNEL"]:
@@ -1556,7 +1555,7 @@ class GuildCategory(GuildChannel):
         )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildNews(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin, WebhookMixin):
     topic: Optional[str] = field(default=None)
     """The channel topic (0-1024 characters)"""
@@ -1645,7 +1644,7 @@ class GuildNews(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
         )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin, WebhookMixin):
     topic: Optional[str] = field(default=None)
     """The channel topic (0-1024 characters)"""
@@ -1785,7 +1784,7 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
 # Guild Threads
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class ThreadChannel(BaseChannel, MessageableMixin, WebhookMixin):
     parent_id: Snowflake_Type = field(default=None, converter=optional_c(to_snowflake))
     """id of the text channel this thread was created"""
@@ -1918,7 +1917,7 @@ class ThreadChannel(BaseChannel, MessageableMixin, WebhookMixin):
         return await super().edit(locked=locked, archived=True, reason=reason)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildNewsThread(ThreadChannel):
     async def edit(
         self,
@@ -1956,7 +1955,7 @@ class GuildNewsThread(ThreadChannel):
         )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildPublicThread(ThreadChannel):
     async def edit(
         self,
@@ -1996,7 +1995,7 @@ class GuildPublicThread(ThreadChannel):
         )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildForumPost(GuildPublicThread):
     """
     A forum post
@@ -2098,7 +2097,7 @@ class GuildForumPost(GuildPublicThread):
         await self.edit(flags=flags, reason=reason)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildPrivateThread(ThreadChannel):
     invitable: bool = field(default=False)
     """Whether non-moderators can add other non-moderators to a thread"""
@@ -2146,7 +2145,7 @@ class GuildPrivateThread(ThreadChannel):
 # Guild Voices
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False, kw_only=True)
 class VoiceChannel(GuildChannel):  # May not be needed, can be directly just GuildVoice.
     bitrate: int = field()
     """The bitrate (in bits) of the voice channel"""
@@ -2254,12 +2253,12 @@ class VoiceChannel(GuildChannel):  # May not be needed, can be directly just Gui
             raise VoiceNotConnected
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildVoice(VoiceChannel, InvitableMixin, MessageableMixin):
     pass
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildStageVoice(GuildVoice):
     stage_instance: "models.StageInstance" = field(default=MISSING)
     """The stage instance that this voice channel belongs to"""
@@ -2318,7 +2317,7 @@ class GuildStageVoice(GuildVoice):
         await self.stage_instance.delete(reason=reason)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildForum(GuildChannel):
     available_tags: List[ThreadTag] = field(factory=list)
     """A list of tags available to assign to threads"""

--- a/naff/models/discord/color.py
+++ b/naff/models/discord/color.py
@@ -3,7 +3,9 @@ import re
 from enum import Enum
 from random import randint
 
-from naff.client.utils.attr_utils import define, field
+import attrs
+
+from naff.client.utils.attr_utils import field
 
 __all__ = (
     "COLOR_TYPES",
@@ -26,7 +28,7 @@ COLOR_TYPES = tuple[int, int, int] | list[int] | str | int
 hex_regex = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
 
 
-@define(init=False)
+@attrs.define(eq=False, order=False, hash=False, init=False)
 class Color:
     value: int = field(repr=True)
     """The color value as an integer."""

--- a/naff/models/discord/components.py
+++ b/naff/models/discord/components.py
@@ -6,7 +6,7 @@ import attrs
 from naff.client.const import SELECTS_MAX_OPTIONS, SELECT_MAX_NAME_LENGTH, ACTION_ROW_MAX_ITEMS, MISSING
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils import list_converter
-from naff.client.utils.attr_utils import define, field, str_validator
+from naff.client.utils.attr_utils import field, str_validator
 from naff.client.utils.serializer import export_converter
 from naff.models.discord.emoji import process_emoji
 from naff.models.discord.enums import ButtonStyles, ComponentTypes, ChannelTypes
@@ -57,7 +57,7 @@ class BaseComponent(DictSerializationMixin):
         return component_class.from_dict(data)
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False)
 class InteractiveComponent(BaseComponent):
     """
     A base interactive component class.
@@ -74,7 +74,7 @@ class InteractiveComponent(BaseComponent):
         return False
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Button(InteractiveComponent):
     """
     Represents a discord ui button.
@@ -126,7 +126,7 @@ class Button(InteractiveComponent):
             raise TypeError("You must have at least a label or emoji on a button.")
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class SelectOption(BaseComponent):
     """
     Represents a select option.
@@ -183,7 +183,7 @@ class SelectOption(BaseComponent):
             raise ValueError("Description length must be 100 or lower.")
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class BaseSelectMenu(InteractiveComponent):
     """
     Represents a select menu component
@@ -232,7 +232,7 @@ class BaseSelectMenu(InteractiveComponent):
             raise TypeError("Selects max value cannot be less than min value.")
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class StringSelectMenu(BaseSelectMenu):
     """
     Represents a string select component.
@@ -271,7 +271,7 @@ class StringSelectMenu(BaseSelectMenu):
         self.options.append(option)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class UserSelectMenu(BaseSelectMenu):
     """
     Represents a user select component.
@@ -290,7 +290,7 @@ class UserSelectMenu(BaseSelectMenu):
     )
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class RoleSelectMenu(BaseSelectMenu):
     """
     Represents a role select component.
@@ -309,7 +309,7 @@ class RoleSelectMenu(BaseSelectMenu):
     )
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class MentionableSelectMenu(BaseSelectMenu):
     """
     Represents a mentionable select component.
@@ -328,7 +328,7 @@ class MentionableSelectMenu(BaseSelectMenu):
     )
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ChannelSelectMenu(BaseSelectMenu):
     """
     Represents a channel select component.
@@ -350,7 +350,7 @@ class ChannelSelectMenu(BaseSelectMenu):
     )
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ActionRow(BaseComponent):
     """
     Represents an action row.

--- a/naff/models/discord/embed.py
+++ b/naff/models/discord/embed.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+import attrs
 from attrs.validators import instance_of
 from attrs.validators import optional as v_optional
 
@@ -12,9 +13,9 @@ from naff.client.const import (
     EMBED_FIELD_VALUE_LENGTH,
 )
 from naff.client.mixins.serialization import DictSerializationMixin
-from naff.client.utils.attr_utils import define, field
-from naff.client.utils.attr_converters import timestamp_converter
 from naff.client.utils.attr_converters import optional as c_optional
+from naff.client.utils.attr_converters import timestamp_converter
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import no_export_meta, export_converter
 from naff.models.discord.color import Color, process_color
 from naff.models.discord.enums import EmbedTypes
@@ -32,7 +33,7 @@ __all__ = (
 )
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class EmbedField(DictSerializationMixin):
     """
     Representation of an embed field.
@@ -62,7 +63,7 @@ class EmbedField(DictSerializationMixin):
         return len(self.name) + len(self.value)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class EmbedAuthor(DictSerializationMixin):
     """
     Representation of an embed author.
@@ -89,7 +90,7 @@ class EmbedAuthor(DictSerializationMixin):
         return len(self.name)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class EmbedAttachment(DictSerializationMixin):  # thumbnail or image or video
     """
     Representation of an attachment.
@@ -118,7 +119,7 @@ class EmbedAttachment(DictSerializationMixin):  # thumbnail or image or video
         return self.height, self.width
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class EmbedFooter(DictSerializationMixin):
     """
     Representation of an Embed Footer.
@@ -154,7 +155,7 @@ class EmbedFooter(DictSerializationMixin):
         return len(self.text)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class EmbedProvider(DictSerializationMixin):
     """
     Represents an embed's provider.
@@ -172,7 +173,7 @@ class EmbedProvider(DictSerializationMixin):
     url: Optional[str] = field(default=None)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Embed(DictSerializationMixin):
     """Represents a discord embed object."""
 

--- a/naff/models/discord/emoji.py
+++ b/naff/models/discord/emoji.py
@@ -1,12 +1,13 @@
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import attrs
 import emoji
 
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_converters import list_converter
 from naff.client.utils.attr_converters import optional
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import dict_filter_none, no_export_meta
 from naff.models.discord.base import ClientObject
 from naff.models.discord.snowflake import SnowflakeObject, to_snowflake
@@ -23,7 +24,7 @@ __all__ = ("PartialEmoji", "CustomEmoji", "process_emoji_req_format", "process_e
 emoji_regex = re.compile(r"<?(a)?:(\w*):(\d*)>?")
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class PartialEmoji(SnowflakeObject, DictSerializationMixin):
     """Represent a basic ("partial") emoji used in discord."""
 
@@ -101,7 +102,7 @@ class PartialEmoji(SnowflakeObject, DictSerializationMixin):
             return self.name
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class CustomEmoji(PartialEmoji, ClientObject):
     """Represent a custom emoji in a guild with all its properties."""
 

--- a/naff/models/discord/file.py
+++ b/naff/models/discord/file.py
@@ -2,12 +2,14 @@ from io import IOBase
 from pathlib import Path
 from typing import BinaryIO, Optional, Union
 
-from naff.client.utils.attr_utils import define, field
+import attrs
+
+from naff.client.utils.attr_utils import field
 
 __all__ = ("File", "open_file", "UPLOADABLE_TYPE")
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class File:
     """
     Representation of a file.

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -6,15 +6,19 @@ from functools import cmp_to_key
 from typing import List, Optional, Union, Set, Dict, Any, TYPE_CHECKING
 from warnings import warn
 
+import attrs
+
 import naff.models as models
 from naff.client.const import Absent, MISSING, PREMIUM_GUILD_LIMITS
 from naff.client.errors import EventLocationNotProvided, NotFound
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_converters import optional
 from naff.client.utils.attr_converters import timestamp_converter
-from naff.client.utils.attr_utils import define, field, docs
+from naff.client.utils.attr_utils import docs, field
 from naff.client.utils.deserialise_app_cmds import deserialize_app_cmds
 from naff.client.utils.serializer import to_image_data, no_export_meta
+from naff.models.discord.app_perms import CommandPermissions, ApplicationCommandPermission
+from naff.models.discord.auto_mod import AutoModRule, BaseAction, BaseTrigger
 from naff.models.discord.file import UPLOADABLE_TYPE
 from naff.models.misc.iterator import AsyncIterator
 from .base import DiscordObject, ClientObject
@@ -34,9 +38,7 @@ from .enums import (
     AutoModEvent,
     AutoModTriggerType,
 )
-from naff.models.discord.auto_mod import AutoModRule, BaseAction, BaseTrigger
 from .snowflake import to_snowflake, Snowflake_Type, to_optional_snowflake, to_snowflake_list
-from naff.models.discord.app_perms import CommandPermissions, ApplicationCommandPermission
 
 if TYPE_CHECKING:
     from naff.client.client import Client
@@ -60,7 +62,7 @@ __all__ = (
 )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildBan:
     reason: Optional[str]
     """The reason for the ban"""
@@ -68,7 +70,7 @@ class GuildBan:
     """The banned user"""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class BaseGuild(DiscordObject):
     name: str = field(repr=True)
     """Name of guild. (2-100 characters, excluding trailing and leading whitespace)"""
@@ -97,7 +99,7 @@ class BaseGuild(DiscordObject):
         return data
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildWelcome(ClientObject):
     description: Optional[str] = field(default=None, metadata=docs("Welcome Screen server description"))
     welcome_channels: List["models.GuildWelcomeChannel"] = field(
@@ -105,7 +107,7 @@ class GuildWelcome(ClientObject):
     )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildPreview(BaseGuild):
     """A partial guild object."""
 
@@ -141,7 +143,7 @@ class MemberIterator(AsyncIterator):
         raise QueueEmpty
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Guild(BaseGuild):
     """Guilds in Discord represent an isolated collection of users and channels, and are often referred to as "servers" in the UI."""
 
@@ -1994,7 +1996,7 @@ class Guild(BaseGuild):
         return sorted_channels
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildTemplate(ClientObject):
     code: str = field(repr=True, metadata=docs("the template code (unique ID)"))
     name: str = field(repr=True, metadata=docs("the name"))
@@ -2050,7 +2052,7 @@ class GuildTemplate(ClientObject):
         await self._client.http.delete_guild_template(self.source_guild_id, self.code)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class GuildWelcomeChannel(ClientObject):
     channel_id: Snowflake_Type = field(repr=True, metadata=docs("Welcome Channel ID"))
     description: str = field(metadata=docs("Welcome Channel description"))
@@ -2177,7 +2179,7 @@ class GuildWidget(DiscordObject):
         return [await self._client.fetch_user(member_id) for member_id in self._member_ids]
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AuditLogChange(ClientObject):
     key: str = field(repr=True)
     """name of audit log change key"""
@@ -2187,7 +2189,7 @@ class AuditLogChange(ClientObject):
     """old value of the key"""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AuditLogEntry(DiscordObject):
     target_id: Optional["Snowflake_Type"] = field(converter=optional(to_snowflake))
     """id of the affected entity (webhook, user, role, etc.)"""
@@ -2210,7 +2212,7 @@ class AuditLogEntry(DiscordObject):
         return data
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AuditLog(ClientObject):
     """Contains entries and other data given from selected"""
 

--- a/naff/models/discord/invite.py
+++ b/naff/models/discord/invite.py
@@ -1,9 +1,11 @@
 from typing import TYPE_CHECKING, Optional, Union, Dict, Any
 
+import attrs
+
 from naff.client.const import MISSING, Absent
-from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import optional as optional_c
 from naff.client.utils.attr_converters import timestamp_converter
+from naff.client.utils.attr_utils import field
 from naff.models.discord.application import Application
 from naff.models.discord.enums import InviteTargetTypes
 from naff.models.discord.guild import GuildPreview
@@ -21,7 +23,7 @@ if TYPE_CHECKING:
 __all__ = ("Invite",)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Invite(ClientObject):
     code: str = field(repr=True)
     """the invite code (unique ID)"""

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -3,14 +3,17 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Sequence, Union, Mapping
 
+import attrs
+
 import naff.models as models
 from naff.client.const import GUILD_WELCOME_MESSAGES, MISSING, Absent
 from naff.client.errors import EphemeralEditException, ThreadOutsideOfGuild
 from naff.client.mixins.serialization import DictSerializationMixin
-from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import optional as optional_c
 from naff.client.utils.attr_converters import timestamp_converter
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import dict_filter_none
+from naff.models.discord.channel import BaseChannel
 from naff.models.discord.file import UPLOADABLE_TYPE
 from .base import DiscordObject
 from .enums import (
@@ -23,7 +26,6 @@ from .enums import (
     AutoArchiveDuration,
 )
 from .snowflake import to_snowflake, Snowflake_Type, to_snowflake_list, to_optional_snowflake
-from naff.models.discord.channel import BaseChannel
 
 if TYPE_CHECKING:
     from naff.client import Client
@@ -46,7 +48,7 @@ __all__ = (
 channel_mention = re.compile(r"<#(?P<id>[0-9]{17,})>")
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Attachment(DiscordObject):
     filename: str = field()
     """name of file attached"""
@@ -73,7 +75,7 @@ class Attachment(DiscordObject):
         return self.height, self.width
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ChannelMention(DiscordObject):
     guild_id: "Snowflake_Type" = field()
     """id of the guild containing the channel"""
@@ -91,7 +93,7 @@ class MessageActivity:
     """party_id from a Rich Presence event"""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class MessageReference(DictSerializationMixin):
     """
     Reference to an originating message.
@@ -130,7 +132,7 @@ class MessageReference(DictSerializationMixin):
         )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class MessageInteraction(DiscordObject):
     type: InteractionTypes = field(converter=InteractionTypes)
     """the type of interaction"""
@@ -150,7 +152,7 @@ class MessageInteraction(DiscordObject):
         return await self.get_user(self._user_id)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class AllowedMentions(DictSerializationMixin):
     """
     The allowed mention field allows for more granular control over mentions without various hacks to the message content.
@@ -227,7 +229,7 @@ class AllowedMentions(DictSerializationMixin):
         return cls()
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class BaseMessage(DiscordObject):
     _channel_id: "Snowflake_Type" = field(default=MISSING, converter=to_optional_snowflake)
     _thread_channel_id: Optional["Snowflake_Type"] = field(default=None, converter=to_optional_snowflake)
@@ -267,7 +269,7 @@ class BaseMessage(DiscordObject):
         return MISSING
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Message(BaseMessage):
     content: str = field(default=MISSING)
     """Contents of the message"""

--- a/naff/models/discord/modal.py
+++ b/naff/models/discord/modal.py
@@ -6,9 +6,9 @@ import attrs
 
 from naff.client.const import MISSING
 from naff.client.mixins.serialization import DictSerializationMixin
-from naff.models.naff.application_commands import CallbackTypes
+from naff.client.utils.attr_utils import field, str_validator
 from naff.models.discord.components import InteractiveComponent, ComponentTypes
-from naff.client.utils.attr_utils import define, field, str_validator
+from naff.models.naff.application_commands import CallbackTypes
 
 __all__ = ("InputText", "Modal", "ParagraphText", "ShortText", "TextStyles")
 
@@ -18,7 +18,7 @@ class TextStyles(IntEnum):
     PARAGRAPH = 2
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class InputText(InteractiveComponent):
     """An input component for modals"""
 
@@ -47,21 +47,21 @@ class InputText(InteractiveComponent):
     """the maximum input length for a text input, min 1, max 4000. Must be more than min_length."""
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ShortText(InputText):
     """A single line input component for modals"""
 
     style: Union[TextStyles, int] = field(default=TextStyles.SHORT, kw_only=True)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class ParagraphText(InputText):
     """A multi line input component for modals"""
 
     style: Union[TextStyles, int] = field(default=TextStyles.PARAGRAPH, kw_only=True)
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class Modal(DictSerializationMixin):
     """Form submission style component on discord"""
 

--- a/naff/models/discord/reaction.py
+++ b/naff/models/discord/reaction.py
@@ -2,8 +2,10 @@ from asyncio import QueueEmpty
 from collections import namedtuple
 from typing import TYPE_CHECKING, List, Optional
 
+import attrs
+
 from naff.client.const import MISSING
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.models.discord.emoji import PartialEmoji
 from naff.models.discord.snowflake import to_snowflake
 from naff.models.misc.iterator import AsyncIterator
@@ -64,7 +66,7 @@ class ReactionUsers(AsyncIterator):
             raise QueueEmpty
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Reaction(ClientObject):
     count: int = field()
     """times this emoji has been used to react"""

--- a/naff/models/discord/role.py
+++ b/naff/models/discord/role.py
@@ -4,12 +4,12 @@ from typing import Any, TYPE_CHECKING
 import attrs
 
 from naff.client.const import MISSING, T, Missing
-from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import optional as optional_c
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import dict_filter
 from naff.models.discord.asset import Asset
-from naff.models.discord.emoji import PartialEmoji
 from naff.models.discord.color import COLOR_TYPES, Color, process_color
+from naff.models.discord.emoji import PartialEmoji
 from naff.models.discord.enums import Permissions
 from .base import DiscordObject
 
@@ -30,7 +30,7 @@ def sentinel_converter(value: bool | T | None, sentinel: T = attrs.NOTHING) -> b
     return value
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 @total_ordering
 class Role(DiscordObject):
     _sentinel = object()

--- a/naff/models/discord/scheduled_event.py
+++ b/naff/models/discord/scheduled_event.py
@@ -1,17 +1,19 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import attrs
+
 from naff.client.const import MISSING, Absent
 from naff.client.errors import EventLocationNotProvided
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils import to_image_data
 from naff.client.utils.attr_converters import optional
 from naff.client.utils.attr_converters import timestamp_converter
+from naff.client.utils.attr_utils import field
+from naff.models.discord.asset import Asset
+from naff.models.discord.file import UPLOADABLE_TYPE
 from naff.models.discord.snowflake import Snowflake_Type, to_snowflake
 from naff.models.discord.timestamp import Timestamp
 from .base import DiscordObject
 from .enums import ScheduledEventPrivacyLevel, ScheduledEventType, ScheduledEventStatus
-from naff.models.discord.asset import Asset
-from naff.models.discord.file import UPLOADABLE_TYPE
-from naff.client.utils import to_image_data
 
 if TYPE_CHECKING:
     from naff.client import Client
@@ -23,7 +25,7 @@ if TYPE_CHECKING:
 __all__ = ("ScheduledEvent",)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ScheduledEvent(DiscordObject):
     name: str = field(repr=True)
     description: str = field(default=MISSING)

--- a/naff/models/discord/snowflake.py
+++ b/naff/models/discord/snowflake.py
@@ -1,8 +1,10 @@
 from typing import Union, List, SupportsInt, Optional
 
+import attrs
+
 import naff.models as models
 from naff.client.const import MISSING, Absent
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 
 __all__ = ("to_snowflake", "to_optional_snowflake", "to_snowflake_list", "SnowflakeObject", "Snowflake_Type")
 
@@ -52,7 +54,7 @@ def to_snowflake_list(snowflakes: List[Snowflake_Type]) -> List[int]:
     return [to_snowflake(c) for c in snowflakes]
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False)
 class SnowflakeObject:
     id: int = field(repr=True, converter=to_snowflake, metadata={"docs": "Discord unique snowflake ID"})
 

--- a/naff/models/discord/stage_instance.py
+++ b/naff/models/discord/stage_instance.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING, Optional
 
+import attrs
+
 from naff.client.const import MISSING, Absent
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.models.discord.enums import StagePrivacyLevel
 from naff.models.discord.snowflake import to_snowflake
 from .base import DiscordObject
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
 __all__ = ("StageInstance",)
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class StageInstance(DiscordObject):
     topic: str = field()
     privacy_level: StagePrivacyLevel = field()

--- a/naff/models/discord/sticker.py
+++ b/naff/models/discord/sticker.py
@@ -1,9 +1,11 @@
 from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Union
 
+import attrs
+
 from naff.client.const import MISSING, Absent
-from naff.client.utils.attr_utils import define, field
 from naff.client.utils.attr_converters import optional
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import dict_filter_none
 from naff.models.discord.snowflake import to_snowflake
 from .base import DiscordObject
@@ -33,7 +35,7 @@ class StickerFormatTypes(IntEnum):
     LOTTIE = 3
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class StickerItem(DiscordObject):
     name: str = field(repr=True)
     """Name of the sticker."""
@@ -41,7 +43,7 @@ class StickerItem(DiscordObject):
     """Type of sticker image format."""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Sticker(StickerItem):
     """Represents a sticker that can be sent in messages."""
 
@@ -145,7 +147,7 @@ class Sticker(StickerItem):
         await self._client.http.delete_guild_sticker(self._guild_id, self.id, reason)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class StickerPack(DiscordObject):
     """Represents a pack of standard stickers."""
 

--- a/naff/models/discord/team.py
+++ b/naff/models/discord/team.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING, List, Optional, Dict, Any, Union
 
-from naff.client.utils.attr_utils import define, field
+import attrs
+
+from naff.client.utils.attr_utils import field
 from naff.models.discord.asset import Asset
 from naff.models.discord.enums import TeamMembershipState
 from naff.models.discord.snowflake import to_snowflake
@@ -14,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ("TeamMember", "Team")
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class TeamMember(DiscordObject):
     membership_state: TeamMembershipState = field(converter=TeamMembershipState)
     """Rhe user's membership state on the team"""
@@ -31,7 +33,7 @@ class TeamMember(DiscordObject):
         return data
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Team(DiscordObject):
     icon: Optional[Asset] = field(default=None)
     """A hash of the image of the team's icon"""

--- a/naff/models/discord/thread.py
+++ b/naff/models/discord/thread.py
@@ -1,11 +1,13 @@
 from typing import TYPE_CHECKING, List, Dict, Any, Union, Optional
 
+import attrs
+
 import naff.models as models
 from naff.client.const import MISSING
 from naff.client.mixins.send import SendMixin
 from naff.client.utils.attr_converters import optional
 from naff.client.utils.attr_converters import timestamp_converter
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.models.discord.emoji import PartialEmoji
 from naff.models.discord.snowflake import to_snowflake
 from naff.models.discord.timestamp import Timestamp
@@ -27,7 +29,7 @@ __all__ = (
 )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ThreadMember(DiscordObject, SendMixin):
     """A thread member is used to indicate whether a user has joined a thread or not."""
 
@@ -85,7 +87,7 @@ class ThreadMember(DiscordObject, SendMixin):
         return await self._client.http.create_message(message_payload, dm_id, files=files)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ThreadList(ClientObject):
     """Represents a list of one or more threads."""
 
@@ -108,7 +110,7 @@ class ThreadList(ClientObject):
         return data
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ThreadTag(DiscordObject):
     name: str = field()
     emoji_id: "Snowflake_Type" = field(default=None)

--- a/naff/models/discord/user.py
+++ b/naff/models/discord/user.py
@@ -2,13 +2,15 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Iterable, Set, Dict, List, Optional, Union
 from warnings import warn
 
+import attrs
+
 from naff.client.const import Absent, MISSING
 from naff.client.errors import HTTPException, TooManyChanges
 from naff.client.mixins.send import SendMixin
-from naff.client.utils.attr_utils import define, field, docs
 from naff.client.utils.attr_converters import list_converter, optional
 from naff.client.utils.attr_converters import optional as optional_c
 from naff.client.utils.attr_converters import timestamp_converter
+from naff.client.utils.attr_utils import docs, field
 from naff.client.utils.serializer import to_image_data
 from naff.models.discord.activity import Activity
 from naff.models.discord.asset import Asset
@@ -41,7 +43,7 @@ class _SendDMMixin(SendMixin):
         return await self._client.http.create_message(message_payload, dm_id, files=files)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class BaseUser(DiscordObject, _SendDMMixin):
     """Base class for User, essentially partial user discord model."""
 
@@ -102,7 +104,7 @@ class BaseUser(DiscordObject, _SendDMMixin):
         ]
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class User(BaseUser):
     bot: bool = field(repr=True, default=False, metadata=docs("Is this user a bot?"))
     system: bool = field(
@@ -154,7 +156,7 @@ class User(BaseUser):
         return [member for member in member_objs if member]
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class NaffUser(User):
     verified: bool = field(repr=True, metadata={"docs": "Whether the email on this account has been verified"})
     mfa_enabled: bool = field(
@@ -224,7 +226,7 @@ class NaffUser(User):
             self._client.cache.place_user_data(resp)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Member(DiscordObject, _SendDMMixin):
     bot: bool = field(repr=True, default=False, metadata=docs("Is this user a bot?"))
     nick: Optional[str] = field(repr=True, default=None, metadata=docs("The user's nickname in this guild'"))

--- a/naff/models/discord/voice_state.py
+++ b/naff/models/discord/voice_state.py
@@ -1,11 +1,13 @@
 import copy
 from typing import TYPE_CHECKING, Optional, Dict, Any
 
+import attrs
+
 from naff.client.const import MISSING
-from naff.client.utils.attr_utils import define, field
+from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils.attr_converters import optional as optional_c
 from naff.client.utils.attr_converters import timestamp_converter
-from naff.client.mixins.serialization import DictSerializationMixin
+from naff.client.utils.attr_utils import field
 from naff.models.discord.snowflake import to_snowflake
 from naff.models.discord.timestamp import Timestamp
 from .base import ClientObject
@@ -19,7 +21,7 @@ if TYPE_CHECKING:
 __all__ = ("VoiceState", "VoiceRegion")
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class VoiceState(ClientObject):
     user_id: "Snowflake_Type" = field(default=MISSING, converter=to_snowflake)
     """the user id this voice state is for"""
@@ -91,7 +93,7 @@ class VoiceState(ClientObject):
         return data
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class VoiceRegion(DictSerializationMixin):
     """A voice region."""
 

--- a/naff/models/discord/webhooks.py
+++ b/naff/models/discord/webhooks.py
@@ -1,11 +1,13 @@
+import re
 from enum import IntEnum
 from typing import Optional, TYPE_CHECKING, Union, Dict, Any, List
-import re
+
+import attrs
 
 from naff.client.const import MISSING, Absent
 from naff.client.errors import ForeignWebhookException, EmptyMessageException
 from naff.client.mixins.send import SendMixin
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.client.utils.serializer import to_image_data
 from naff.models.discord.message import process_message_payload
 from naff.models.discord.snowflake import to_snowflake, to_optional_snowflake
@@ -39,7 +41,7 @@ class WebhookTypes(IntEnum):
     """Application webhooks are webhooks used with Interactions"""
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Webhook(DiscordObject, SendMixin):
     type: WebhookTypes = field()
     """The type of webhook"""

--- a/naff/models/naff/active_voice_state.py
+++ b/naff/models/naff/active_voice_state.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Optional, TYPE_CHECKING
 
+import attrs
 from discord_typings import VoiceStateData
 
 from naff.api.voice.player import Player
@@ -8,7 +9,7 @@ from naff.api.voice.voice_gateway import VoiceGateway
 from naff.client.const import MISSING
 from naff.client.errors import VoiceAlreadyConnected, VoiceConnectionTimeout
 from naff.client.utils import optional
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.models.discord.snowflake import Snowflake_Type, to_snowflake
 from naff.models.discord.voice_state import VoiceState
 
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
 __all__ = ("ActiveVoiceState",)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ActiveVoiceState(VoiceState):
     ws: Optional[VoiceGateway] = field(default=None)
     """The websocket for this voice state"""

--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -19,7 +19,7 @@ from naff.client.const import (
 )
 from naff.client.mixins.serialization import DictSerializationMixin
 from naff.client.utils import optional
-from naff.client.utils.attr_utils import define, field, docs, attrs_validator
+from naff.client.utils.attr_utils import attrs_validator, docs, field
 from naff.client.utils.misc_utils import get_parameters
 from naff.client.utils.serializer import no_export_meta
 from naff.models.discord.enums import ChannelTypes, CommandTypes, Permissions
@@ -75,7 +75,9 @@ def desc_validator(_: Any, attr: Attribute, value: str) -> None:
             raise ValueError(f"Description must be between 1 and {SLASH_CMD_MAX_DESC_LENGTH} characters long")
 
 
-@define(field_transformer=attrs_validator(name_validator, skip_fields=["default_locale"]))
+@attrs.define(
+    eq=False, order=False, hash=False, field_transformer=attrs_validator(name_validator, skip_fields=["default_locale"])
+)
 class LocalisedName(LocalisedField):
     """A localisation object for names."""
 
@@ -83,7 +85,9 @@ class LocalisedName(LocalisedField):
         return super().__repr__()
 
 
-@define(field_transformer=attrs_validator(desc_validator, skip_fields=["default_locale"]))
+@attrs.define(
+    eq=False, order=False, hash=False, field_transformer=attrs_validator(desc_validator, skip_fields=["default_locale"])
+)
 class LocalisedDesc(LocalisedField):
     """A localisation object for descriptions."""
 
@@ -150,7 +154,7 @@ class CallbackTypes(IntEnum):
     MODAL = 9
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class InteractionCommand(BaseCommand):
     """
     Represents a discord abstract interaction command.
@@ -273,7 +277,7 @@ class InteractionCommand(BaseCommand):
         return True
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ContextMenu(InteractionCommand):
     """
     Represents a discord context menu.
@@ -304,7 +308,7 @@ class ContextMenu(InteractionCommand):
         return data
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class SlashCommandChoice(DictSerializationMixin):
     """
     Represents a discord slash command choice.
@@ -322,7 +326,7 @@ class SlashCommandChoice(DictSerializationMixin):
         return {"name": str(self.name), "value": self.value, "name_localizations": self.name.to_locale_dict()}
 
 
-@define(kw_only=False)
+@attrs.define(eq=False, order=False, hash=False, kw_only=False)
 class SlashCommandOption(DictSerializationMixin):
     """
     Represents a discord slash command option.
@@ -439,7 +443,7 @@ class SlashCommandOption(DictSerializationMixin):
         return data
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class SlashCommand(InteractionCommand):
     name: LocalisedName = field(converter=LocalisedName.converter)
     description: LocalisedDesc = field(default="No Description Set", converter=LocalisedDesc.converter)
@@ -599,14 +603,14 @@ class SlashCommand(InteractionCommand):
         return wrapper
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ComponentCommand(InteractionCommand):
     # right now this adds no extra functionality, but for future dev ive implemented it
     name: str = field()
     listeners: list[str] = field(factory=list)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ModalCommand(ComponentCommand):
     ...
 

--- a/naff/models/naff/auto_defer.py
+++ b/naff/models/naff/auto_defer.py
@@ -1,8 +1,10 @@
 import asyncio
 from typing import TYPE_CHECKING
 
+import attrs
+
 from naff.client.errors import AlreadyDeferred, NotFound, BadRequest, HTTPException
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 
 if TYPE_CHECKING:
     from naff.models.naff.context import InteractionContext
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 __all__ = ("AutoDefer",)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AutoDefer:
     """Automatically defer application commands for you!"""
 

--- a/naff/models/naff/command.py
+++ b/naff/models/naff/command.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import asyncio
 import copy
 import functools
@@ -6,13 +7,15 @@ import re
 import typing
 from typing import Annotated, Awaitable, Callable, Coroutine, Optional, Tuple, Any, TYPE_CHECKING
 
-from naff.models.naff.callback import CallbackObject
+import attrs
+
 from naff.client.const import MISSING
 from naff.client.errors import CommandOnCooldown, CommandCheckFailure, MaxConcurrencyReached
 from naff.client.mixins.serialization import DictSerializationMixin
-from naff.client.utils.attr_utils import define, field, docs
+from naff.client.utils.attr_utils import docs, field
 from naff.client.utils.misc_utils import get_parameters, get_object_name, maybe_coroutine
 from naff.client.utils.serializer import no_export_meta
+from naff.models.naff.callback import CallbackObject
 from naff.models.naff.cooldowns import Cooldown, Buckets, MaxConcurrency
 from naff.models.naff.protocols import Converter
 
@@ -26,7 +29,7 @@ kwargs_reg = re.compile(r"^\*\*\w")
 args_reg = re.compile(r"^\*\w")
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class BaseCommand(DictSerializationMixin, CallbackObject):
     """
     An object all commands inherit from. Outlines the basic structure of a command, and handles checks.

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -2,19 +2,20 @@ import datetime
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Protocol, Union, runtime_checkable
 
+import attrs
 from aiohttp import FormData
 
 import naff.models.discord.message as message
-from naff.models.discord.timestamp import Timestamp
 from naff.client.const import Absent, MISSING, get_logger
 from naff.client.errors import AlreadyDeferred
 from naff.client.mixins.send import SendMixin
-from naff.client.utils.attr_utils import define, field, docs
 from naff.client.utils.attr_converters import optional
+from naff.client.utils.attr_utils import docs, field
 from naff.models.discord.enums import MessageFlags, CommandTypes, Permissions
 from naff.models.discord.file import UPLOADABLE_TYPE
 from naff.models.discord.message import Attachment
 from naff.models.discord.snowflake import to_snowflake, to_optional_snowflake
+from naff.models.discord.timestamp import Timestamp
 from naff.models.naff.application_commands import CallbackTypes, OptionTypes
 
 if TYPE_CHECKING:
@@ -50,7 +51,7 @@ __all__ = (
 )
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Resolved:
     """Represents resolved data in an interaction."""
 
@@ -106,7 +107,7 @@ class Resolved:
         return new_cls
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class Context:
     """Represents the context of a command."""
 
@@ -140,7 +141,7 @@ class Context:
         return self._client.cache.get_bot_voice_state(self.guild_id)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class _BaseInteractionContext(Context):
     """An internal object used to define the attributes of interaction context and its children."""
 
@@ -289,7 +290,7 @@ class _BaseInteractionContext(Context):
         return modal
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class InteractionContext(_BaseInteractionContext, SendMixin):
     """
     Represents the context of an interaction.
@@ -449,7 +450,7 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
         return thing
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ComponentContext(InteractionContext):
     custom_id: str = field(default="", metadata=docs("The ID given to the component that has been pressed"))
     component_type: int = field(default=0, metadata=docs("The type of component that has been pressed"))
@@ -571,7 +572,7 @@ class ComponentContext(InteractionContext):
             return self.message
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class AutocompleteContext(_BaseInteractionContext):
     focussed_option: str = field(default=MISSING, metadata=docs("The option the user is currently filling in"))
 
@@ -618,7 +619,7 @@ class AutocompleteContext(_BaseInteractionContext):
         await self._client.http.post_initial_response(payload, self.interaction_id, self._token)
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class ModalContext(InteractionContext):
     custom_id: str = field(default="")
 
@@ -643,7 +644,7 @@ class ModalContext(InteractionContext):
         return self.kwargs
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class PrefixedContext(Context, SendMixin):
     prefix: str = field(default=MISSING, metadata=docs("The prefix used to invoke this command"))
 
@@ -678,7 +679,7 @@ class PrefixedContext(Context, SendMixin):
         return await self._client.http.create_message(message_payload, self.channel.id, files=files)
 
 
-@define
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class HybridContext(Context):
     """
     Represents the context for hybrid commands, a slash command that can also be used as a prefixed command.

--- a/naff/models/naff/hybrid_commands.py
+++ b/naff/models/naff/hybrid_commands.py
@@ -1,15 +1,14 @@
-import inspect
-import functools
 import asyncio
-
+import functools
+import inspect
 from typing import Any, Callable, Coroutine, TYPE_CHECKING, Optional, TypeGuard
 
+import attrs
 
 from naff.client.const import Absent, GLOBAL_SCOPE, MISSING, T
 from naff.client.errors import BadArgument
-from naff.client.utils.attr_utils import define, field
+from naff.client.utils.attr_utils import field
 from naff.client.utils.misc_utils import get_object_name, maybe_coroutine
-from naff.models.naff.command import BaseCommand
 from naff.models.naff.application_commands import (
     SlashCommand,
     LocalisedName,
@@ -18,8 +17,8 @@ from naff.models.naff.application_commands import (
     SlashCommandChoice,
     OptionTypes,
 )
-from naff.models.naff.prefixed_commands import _convert_to_bool, PrefixedCommand
-from naff.models.naff.protocols import Converter
+from naff.models.naff.command import BaseCommand
+from naff.models.naff.context import HybridContext, InteractionContext, PrefixedContext
 from naff.models.naff.converters import (
     _LiteralConverter,
     NoArgumentConverter,
@@ -28,7 +27,8 @@ from naff.models.naff.converters import (
     RoleConverter,
     BaseChannelConverter,
 )
-from naff.models.naff.context import HybridContext, InteractionContext, PrefixedContext
+from naff.models.naff.prefixed_commands import _convert_to_bool, PrefixedCommand
+from naff.models.naff.protocols import Converter
 
 if TYPE_CHECKING:
     from naff.models.naff.checks import TYPE_CHECK_FUNCTION
@@ -228,7 +228,7 @@ class _StackedNoArgConverter(NoArgumentConverter):
         return await maybe_coroutine(self._additional_converter_func, ctx, part_one)
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class HybridCommand(SlashCommand):
     """A subclass of SlashCommand that handles the logic for hybrid commands."""
 
@@ -281,7 +281,7 @@ class HybridCommand(SlashCommand):
         return wrapper
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class _HybridPrefixedCommand(PrefixedCommand):
     _uses_subcommand_func: bool = field(default=False)
 

--- a/naff/models/naff/localisation.py
+++ b/naff/models/naff/localisation.py
@@ -1,12 +1,14 @@
 from functools import cached_property
 
+import attrs
+
 from naff.client import const
-from naff.client.utils import define, field
+from naff.client.utils import field
 
 __all__ = ("LocalisedField", "LocalizedField")
 
 
-@define(slots=False)
+@attrs.define(eq=False, order=False, hash=False, slots=False)
 class LocalisedField:
     """
     An object that enables support for localising fields.

--- a/naff/models/naff/prefixed_commands.py
+++ b/naff/models/naff/prefixed_commands.py
@@ -9,12 +9,12 @@ import attrs
 
 from naff.client.const import MISSING
 from naff.client.errors import BadArgument
+from naff.client.utils.attr_utils import docs, field
 from naff.client.utils.input_utils import _quotes
-from naff.client.utils.attr_utils import define, field, docs
 from naff.client.utils.misc_utils import get_object_name, maybe_coroutine
-from naff.models.naff.protocols import Converter
-from naff.models.naff.converters import _LiteralConverter, NoArgumentConverter, Greedy, NAFF_MODEL_TO_CONVERTER
 from naff.models.naff.command import BaseCommand
+from naff.models.naff.converters import _LiteralConverter, NoArgumentConverter, Greedy, NAFF_MODEL_TO_CONVERTER
+from naff.models.naff.protocols import Converter
 
 if TYPE_CHECKING:
     from naff.models.naff.context import PrefixedContext
@@ -28,7 +28,7 @@ __all__ = (
 _STARTING_QUOTES = frozenset(_quotes.keys())
 
 
-@attrs.define(slots=True)
+@attrs.define(eq=False, order=False, hash=False, slots=True)
 class PrefixedCommandParameter:
     """
     An object representing parameters in a prefixed command.
@@ -62,7 +62,7 @@ class PrefixedCommandParameter:
         return self.default != MISSING
 
 
-@attrs.define(slots=True)
+@attrs.define(eq=False, order=False, hash=False, slots=True)
 class _PrefixedArgsIterator:
     """
     An iterator over the arguments of a prefixed command.
@@ -257,7 +257,7 @@ async def _greedy_convert(
     return greedy_args, broke_off
 
 
-@define()
+@attrs.define(eq=False, order=False, hash=False, kw_only=True)
 class PrefixedCommand(BaseCommand):
     name: str = field(metadata=docs("The name of the command."))
     parameters: list[PrefixedCommandParameter] = field(metadata=docs("The parameters of the command."), factory=list)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR removes usage of the cheat `@define` decorator defined in `attr_utils`. This change improves type checker and intelisense behaviour across the board. Most got confused with the partial object decloration. 
Care has been taken to preserve any custom deviation from the normal `@define` kwargs. 

The `@define` definition itself has been preserved as I am aware downstream project leverage it, however, I'd discourage its usage.  

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Regex replace of `@define` in all files 


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
