### PR TITLE
feat 💥: message operations with InteractionContext

### DIFF
--- a/naff/api/http/http_requests/interactions.py
+++ b/naff/api/http/http_requests/interactions.py
@@ -142,7 +142,7 @@ class InteractionRequests(CanRequest):
         payload: dict,
         application_id: "Snowflake_Type",
         token: str,
-        message_id: str = "@original",
+        message_id: "str|Snowflake_Type" = "@original",
         files: list["UPLOADABLE_TYPE"] | None = None,
     ) -> discord_typings.MessageData:
         """

--- a/naff/api/http/http_requests/interactions.py
+++ b/naff/api/http/http_requests/interactions.py
@@ -166,6 +166,20 @@ class InteractionRequests(CanRequest):
         )
         return cast(discord_typings.MessageData, result)
 
+    async def delete_interaction_message(
+        self, application_id: "Snowflake_Type", token: str, message_id: "str | Snowflake_Type" = "@original"
+    ) -> None:
+        """
+        Deletes an existing interaction message.
+
+        Args:
+            application_id: The id of the application.
+            token: The token of the interaction.
+            message_id: The target message to delete. Defaults to @original which represents the initial response message.
+
+        """
+        return await self.request(Route("DELETE", f"/webhooks/{int(application_id)}/{token}/messages/{message_id}"))
+
     async def get_interaction_message(
         self, application_id: "Snowflake_Type", token: str, message_id: str = "@original"
     ) -> discord_typings.MessageData:

--- a/naff/client/errors.py
+++ b/naff/client/errors.py
@@ -350,7 +350,9 @@ class EphemeralEditException(MessageException):
     """
 
     def __init__(self) -> None:
-        super().__init__("Ephemeral messages cannot be edited.")
+        super().__init__(
+            "Ephemeral messages can only be edited with component's `edit_origin` method or using InteractionContext"
+        )
 
 
 class ThreadException(BotException):

--- a/naff/models/discord/message.py
+++ b/naff/models/discord/message.py
@@ -560,7 +560,7 @@ class Message(BaseMessage):
         if message_data:
             return self._client.cache.place_message_data(message_data)
 
-    async def delete(self, delay: int = 0, *, context: "InteractionContext") -> None:
+    async def delete(self, delay: int = 0, *, context: "InteractionContext | None" = None) -> None:
         """
         Delete message.
 
@@ -575,6 +575,8 @@ class Message(BaseMessage):
                 await asyncio.sleep(delay)
 
             if MessageFlags.EPHEMERAL in self.flags:
+                if not context:
+                    raise ValueError("Cannot delete ephemeral message without interaction context parameter")
                 await context.delete(self.id)
             else:
                 await self._client.http.delete_message(self._channel_id, self.id)

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -414,6 +414,16 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
             flags=flags,
         )
 
+    async def delete(self, message: "Snowflake_Type") -> None:
+        """
+        Delete a message sent in response to this interaction.
+
+        Args:
+            message: The message to delete
+
+        """
+        await self._client.http.delete_interaction_message(self._client.app.id, self._token, to_snowflake(message))
+
     @property
     def target(self) -> "Absent[Member | User | Message]":
         """For context menus, this will be the object of which was clicked on."""

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -1,10 +1,11 @@
 import datetime
 from logging import Logger
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Protocol, Union, runtime_checkable
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Protocol, Union, runtime_checkable, Sequence
 
 import attrs
 from aiohttp import FormData
 
+import naff.models as models
 import naff.models.discord.message as message
 from naff.client.const import Absent, MISSING, get_logger
 from naff.client.errors import AlreadyDeferred
@@ -423,6 +424,52 @@ class InteractionContext(_BaseInteractionContext, SendMixin):
 
         """
         await self._client.http.delete_interaction_message(self._client.app.id, self._token, to_snowflake(message))
+
+    async def edit(
+        self,
+        message: "Snowflake_Type",
+        *,
+        content: Optional[str] = None,
+        embeds: Optional[Union[Sequence[Union["models.Embed", dict]], Union["models.Embed", dict]]] = None,
+        embed: Optional[Union["models.Embed", dict]] = None,
+        components: Optional[
+            Union[
+                Sequence[Sequence[Union["models.BaseComponent", dict]]],
+                Sequence[Union["models.BaseComponent", dict]],
+                "models.BaseComponent",
+                dict,
+            ]
+        ] = None,
+        allowed_mentions: Optional[Union["models.AllowedMentions", dict]] = None,
+        attachments: Optional[Optional[Sequence[Union[Attachment, dict]]]] = None,
+        files: Optional[Union[UPLOADABLE_TYPE, Sequence[UPLOADABLE_TYPE]]] = None,
+        file: Optional[UPLOADABLE_TYPE] = None,
+        tts: bool = False,
+    ) -> "models.Message":
+        message_payload = models.process_message_payload(
+            content=content,
+            embeds=embeds or embed,
+            components=components,
+            allowed_mentions=allowed_mentions,
+            attachments=attachments,
+            tts=tts,
+        )
+
+        if file:
+            if files:
+                files = [file, *files]
+            else:
+                files = [file]
+
+        message_data = await self._client.http.edit_interaction_message(
+            payload=message_payload,
+            application_id=self._client.app.id,
+            token=self._token,
+            message_id=to_snowflake(message),
+            files=files,
+        )
+        if message_data:
+            return self._client.cache.place_message_data(message_data)
 
     @property
     def target(self) -> "Absent[Member | User | Message]":

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -178,7 +178,7 @@ async def test_messages(bot: Client, guild: Guild, channel: GuildText) -> None:
         _m = await thread.send("Test")
         ensure_attributes(_m)
 
-        await _m.edit("Test Edit")
+        await _m.edit(content="Test Edit")
         assert _m.content == "Test Edit"
         await _m.add_reaction("❌")
         with suppress(asyncio.exceptions.TimeoutError):


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
A nice chunky PR. Primarily this PR does three things: 
- Add support for editing and deleting messages with `InteractionContext`
- Refactor `Message.edit` to use kwargs
- Refactor `Message.delete` to be all round nicer

### This adds support for editing and deleting ephemeral messages. 
Deleting
```python
message = await ctx.send("test", ephemeral=True)
await context.delete(message)
# or
await message.delete(context=ctx)
```
```python
message = await ctx.send("test", ephemeral=True)
await context.edit(message, content="test edit")
# or
await message.edit(content="test edit", context=ctx)
```

### Kwarg edit
`Message.edit` should really have been kwarg only this whole time. I will die on this hill. 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Refactor `message.delete`
- Add HTTP method for interaction message deletes
- Add `InteractionContext.delete`
- Add `InteractionContext.edit`
- Add interaction deletion support to `Message.delete`
- Add interaction edit support to `Message.edit`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
