### PR TITLE
fix 💥: change default delay until ready behavior

### DIFF
--- a/naff/models/naff/listener.py
+++ b/naff/models/naff/listener.py
@@ -26,7 +26,7 @@ class Listener(CallbackObject):
         func: Callable[..., Coroutine],
         event: str,
         *,
-        delay_until_ready: bool = True,
+        delay_until_ready: bool = False,
         delete_if_overridden: bool = False,
     ) -> None:
         super().__init__()
@@ -41,7 +41,7 @@ class Listener(CallbackObject):
         cls,
         event_name: Absent[str | BaseEvent] = MISSING,
         *,
-        delay_until_ready: bool = True,
+        delay_until_ready: bool = False,
         delete_if_overridden: bool = False,
     ) -> Callable[[Coroutine], "Listener"]:
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
In retrospect, I believe the default behaviour shouldn't have been to `delay_until_ready`, instead it should be an optional enable. This also has the perk of quickly fixing a bug where NAFF internal listeners weren't being fired.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Change the default listener `delay_until_ready` state to False

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
