### PR TITLE
fix: prevent NoneType in guild.channels

### DIFF
--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -314,7 +314,8 @@ class Guild(BaseGuild):
     @property
     def channels(self) -> List["models.TYPE_GUILD_CHANNEL"]:
         """Returns a list of channels associated with this guild."""
-        return [self._client.cache.get_channel(c_id) for c_id in self._channel_ids]
+        channels = [self._client.cache.get_channel(c_id) for c_id in self._channel_ids]
+        return [c for c in channels if c]
 
     @property
     def threads(self) -> List["models.TYPE_THREAD_CHANNEL"]:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Prevent's NoneTypes from being returned by `guild.channels`
![image](https://user-images.githubusercontent.com/22540825/197409528-a0c51e4b-8cb1-4d9a-b28e-cb1200cd73e2.png)

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Filter result of Nones before returning from `guild.channels`

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
