### PR TITLE
ci: Add Dependabot for Github Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    target-branch: dev


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
Dependabot will automatically keep the Github Actions dependencies up to date.   We've currently got a bunch that are outdated and spewing warnings about depreciated versions.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [ ] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
