### PR TITLE
fix:  Keep SendableContext in sync with SendMixin

### DIFF
--- a/naff/api/voice/audio.py
+++ b/naff/api/voice/audio.py
@@ -66,6 +66,7 @@ class BaseAudio(ABC):
     def __del__(self) -> None:
         self.cleanup()
 
+    @abstractmethod
     def cleanup(self) -> None:
         """A method to optionally cleanup after this object is no longer required."""
         ...

--- a/naff/client/mixins/send.py
+++ b/naff/client/mixins/send.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 
 import naff.models as models
 
@@ -43,7 +43,7 @@ class SendMixin:
         suppress_embeds: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
         delete_after: Optional[float] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "Message":
         """
         Send a message.

--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -903,6 +903,7 @@ class SendableContext(Protocol):
         self,
         content: Optional[str] = None,
         embeds: Optional[Union[Iterable[Union["Embed", dict]], Union["Embed", dict]]] = None,
+        embed: Optional[Union["Embed", dict]] = None,
         components: Optional[
             Union[
                 Iterable[Iterable[Union["BaseComponent", dict]]],
@@ -914,9 +915,12 @@ class SendableContext(Protocol):
         stickers: Optional[Union[Iterable[Union["Sticker", "Snowflake_Type"]], "Sticker", "Snowflake_Type"]] = None,
         allowed_mentions: Optional[Union["AllowedMentions", dict]] = None,
         reply_to: Optional[Union["MessageReference", "Message", dict, "Snowflake_Type"]] = None,
-        file: Optional[Union["File", "IOBase", "Path", str]] = None,
+        files: Optional[Union["UPLOADABLE_TYPE", Iterable["UPLOADABLE_TYPE"]]] = None,
+        file: Optional["UPLOADABLE_TYPE"] = None,
         tts: bool = False,
+        suppress_embeds: bool = False,
         flags: Optional[Union[int, "MessageFlags"]] = None,
+        delete_after: Optional[float] = None,
         **kwargs: Any,
     ) -> "Message":
         ...


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
SendableContext had drifted away from what `send()` actually looked like.  This brings it back in line.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
