### PR TITLE
fix: handle regional indicator emoji

### DIFF
--- a/naff/models/discord/emoji.py
+++ b/naff/models/discord/emoji.py
@@ -77,6 +77,9 @@ class PartialEmoji(SnowflakeObject, DictSerializationMixin):
             _emoji_list = emoji.distinct_emoji_list(emoji_str)
             if _emoji_list:
                 return cls(name=_emoji_list[0])
+            if len(emoji_str) == 1:
+                # likely a regional indicator
+                return cls(name=emoji_str)
         return None
 
     def __str__(self) -> str:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
`emoji` does not accept regional indicators as of yet. This pr hotfixes that until they add support

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
