### PR TITLE
fix: fix minor flaws in appCmd sync detection

### DIFF
--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1105,6 +1105,9 @@ def _compare_commands(local_cmd: dict, remote_cmd: dict) -> bool:
         "name_localized": ("name_localizations", None),
         "description_localized": ("description_localizations", None),
     }
+    if remote_cmd.get("guild_id"):
+        # non-global command
+        del lookup["dm_permission"]
 
     for local_name, comparison_data in lookup.items():
         remote_name, default_value = comparison_data
@@ -1125,7 +1128,7 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),
         "max_length": ("max_length", None),
-        "min_length": ("max_length", None),
+        "min_length": ("min_length", None),
     }
     post_process: Dict[str, Callable] = {
         "choices": lambda l: [d | {"name_localizations": {}} if len(d) == 2 else d for d in l],


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This pr fixes 2 issues with NAFF sync detection 

When syncing a non-global command, the `dm_permission` attribute is redundant and causes erroneous syncs.
In option comparison, `min_length` was being compared against `max_length` causing erroneous syncs 

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Don't bother comparing `dm_permission` attribute on non-global commands
- Actually, compare min against min for options 

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
