### PR TITLE
fix💥: interaction_id should be int... like all other IDs

### DIFF
--- a/naff/models/naff/context.py
+++ b/naff/models/naff/context.py
@@ -159,7 +159,9 @@ class _BaseInteractionContext(Context):
     _context_type: int = attrs.field(
         repr=False,
     )  # we don't want to convert this in case of a new context type, which is expected
-    interaction_id: str = attrs.field(repr=False, default=None, metadata=docs("The id of the interaction"))
+    interaction_id: "Snowflake_Type" = attrs.field(
+        repr=False, default=None, metadata=docs("The id of the interaction"), converter=to_snowflake
+    )
     target_id: "Snowflake_Type" = attrs.field(
         default=None,
         metadata=docs("The ID of the target, used for context menus to show what was clicked on"),


### PR DESCRIPTION
dammit past polls

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [x] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
`interaction_id` was being stored as `str` instead of `int`. This fixes that

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Store `interaction_id` as int
- Add a converter to achieve the above

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
