### PR TITLE
fix: pass error to ext for prefixed subcommand checking

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1701,7 +1701,7 @@ class Client(
                             if new_command.error_callback:
                                 await new_command.error_callback(e, context)
                             elif new_command.extension and new_command.extension.extension_error:
-                                await new_command.extension.extension_error(context)
+                                await new_command.extension.extension_error(e, context)
                             else:
                                 await self.on_command_error(context, e)
                             return


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
So I forgot to pass the `e` here... or maybe the `e` was added after this code was made, and someone forgot to put it here. Either way, this PR passes the error for extension error handlers for prefixed subcommand checking.

## Changes

- I, uh, passed an `e`. Just look at the diff it isn't complex--


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
