### PR TITLE
fix:  Fail loudly if we attempt to perform a setupless load on an extension module that isn't actually an extension

### DIFF
--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1892,11 +1892,15 @@ class Client(
             else:
                 self.logger.debug("No setup function found in %s", module_name)
 
+                found = False
                 objects = {name: obj for name, obj in inspect.getmembers(module) if isinstance(obj, type)}
                 for obj_name, obj in objects.items():
                     if Extension in obj.__bases__:
                         self.logger.debug(f"Found extension class {obj_name} in {module_name}: Attempting to load")
                         obj(self, **load_kwargs)
+                        found = True
+                if not found:
+                    raise Exception(f"{module_name} contains no Extensions")
 
         except ExtensionLoadException:
             raise


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
The implementation of #671 introduced a bug where it was impossible to test whether a module actually contains an extension, as it would happily find 0 extensions and not throw an error.

This PR causes the client to correctly throw an exception if there is no extension to be loaded.

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->


## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
