### PR TITLE
ci:  More resilience to the guild limit

### DIFF
--- a/.github/workflows/pytest-push.yml
+++ b/.github/workflows/pytest-push.yml
@@ -30,10 +30,12 @@ jobs:
         uses: actions/setup-python@v2.3.1
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install ffmpeg & opus
         run: sudo apt-get update && sudo apt-get install ffmpeg libopus-dev
       - name: Install pytest
         run: |
+          pip install wheel
           pip install -e ${{ matrix.extras }}
           pip install .[tests]
       - name: Run Tests

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,6 +3,8 @@ import os
 from asyncio import AbstractEventLoop
 from contextlib import suppress
 from datetime import datetime
+import random
+import warnings
 
 import pytest
 
@@ -36,8 +38,9 @@ from naff import (
 from naff.api.gateway.websocket import WebsocketClient
 from naff.api.http.route import Route
 from naff.api.voice.audio import AudioVolume
+from naff.client.const import MISSING
 from naff.client.errors import NotFound
-from naff.client.utils.misc_utils import find
+from naff.client.utils.misc_utils import find, find_all
 from naff.models.discord.timestamp import Timestamp
 
 __all__ = ()
@@ -83,7 +86,17 @@ async def guild(bot: Client) -> Guild:
             if age.days > 0:
                 # This from a failed run, let's clean it up
                 await leftover.delete()
-    guild: naff.Guild = await naff.Guild.create("test_suite_guild", bot)
+    try:
+        guild: naff.Guild = await naff.Guild.create("test_suite_guild", bot)
+    except naff.client.errors.HTTPException as e:
+        text = e.text
+        if text is not MISSING and "Maximum number of guilds reached" in text:
+            warnings.warn("Reusing old guild.  Tests may be flaky")
+            guilds = find_all(lambda g: g.is_owner(bot.user.id) and g.name == "test_suite_guild", bot.guilds)
+            random.shuffle(guilds)  # Pick one at random to *reduce* chances two race conditions
+            guild = guilds[0]
+        else:
+            raise
     community_channel = await guild.create_text_channel("community_channel")
 
     await guild.edit(
@@ -287,6 +300,10 @@ async def test_members(bot: Client, guild: Guild, channel: GuildText) -> None:
     with suppress(asyncio.exceptions.TimeoutError):
         await bot.wait_for("member_update", timeout=2)
     assert len(member.roles) != 0
+    await member.remove_role(role)
+    with suppress(asyncio.exceptions.TimeoutError):
+        await bot.wait_for("member_update", timeout=2)
+    assert len(member.roles) == 0
 
     assert member.display_avatar is not None
     assert member.display_name is not None
@@ -545,3 +562,5 @@ async def test_checks(bot: Client, guild: Guild) -> None:
     assert await naff.has_any_role(has_role)(context) is True
     assert await naff.has_any_role(lacks_role)(context) is False
     assert await naff.has_any_role(has_role)(generate_dummy_context(dm=True)) is False
+
+    await member.remove_role(has_role)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [x] Tests change

## Description
This one is *fun*.  And by fun, I mean not at all.

The PR does a few things:
* Randomly picks an existing guild if we get told we're not allowed to create more.  This doesn't guarantee we won't hit race conditions, but it's got a lower failure rate than the current system of "failing immediately".
  * Note that we do throw a warning if we do this, so it's hopefully obvious that the test is failing due to concurrency.
* Fixes up two tests that weren't completely cleaning up after themselves, so that a guild should be in a theoretically clean state should it get reused.
* Makes Polls upset at me.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
