### PR TITLE
fix: fix 3.11 enum str behaviour

### DIFF
--- a/naff/models/discord/timestamp.py
+++ b/naff/models/discord/timestamp.py
@@ -20,6 +20,9 @@ class TimestampStyles(str, Enum):
     LongDateTime = "F"
     RelativeTime = "R"
 
+    def __str__(self) -> str:
+        return self.value
+
 
 class Timestamp(datetime):
     """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Python 3.11 apparently made a breaking change to `__str__` behaviour for enums. This fixes that without breaking 3.10

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Define our own `__str__` method for TimestampStyles

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my code
