### PR TITLE
fix: Converting `before` parameter of list_public_archived_threads() to ISO8601

### DIFF
--- a/naff/api/http/http_requests/threads.py
+++ b/naff/api/http/http_requests/threads.py
@@ -7,6 +7,7 @@ from naff.api.http.route import Route
 from naff.client.const import MISSING, Absent
 from naff.client.utils.attr_converters import timestamp_converter
 from naff.models.discord.enums import ChannelTypes
+from naff.models.discord.timestamp import Timestamp
 
 __all__ = ("ThreadRequests",)
 
@@ -93,7 +94,7 @@ class ThreadRequests:
         if limit:
             payload["limit"] = limit
         if before:
-            payload["before"] = timestamp_converter(before)
+            payload["before"] = Timestamp.from_snowflake(before).isoformat()
         return await self.request(Route("GET", f"/channels/{channel_id}/threads/archived/public"), params=payload)
 
     async def list_private_archived_threads(
@@ -115,7 +116,7 @@ class ThreadRequests:
         if limit:
             payload["limit"] = limit
         if before:
-            payload["before"] = before
+            payload["before"] = Timestamp.from_snowflake(before).isoformat()
         return await self.request(Route("GET", f"/channels/{channel_id}/threads/archived/private"), params=payload)
 
     async def list_joined_private_archived_threads(

--- a/naff/api/http/http_requests/threads.py
+++ b/naff/api/http/http_requests/threads.py
@@ -5,7 +5,6 @@ from aiohttp import FormData
 
 from naff.api.http.route import Route
 from naff.client.const import MISSING, Absent
-from naff.client.utils.attr_converters import timestamp_converter
 from naff.models.discord.enums import ChannelTypes
 from naff.models.discord.timestamp import Timestamp
 

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -142,7 +142,7 @@ class ArchivedForumPosts(AsyncIterator):
             expected = self.get_limit
 
             rcv = await self.channel._client.http.list_public_archived_threads(
-                self.channel.id, limit=expected, before=self.last
+                self.channel.id, limit=expected, before=self.last.id
             )
             threads = [self.channel._client.cache.place_channel_data(data) for data in rcv["threads"]]
 

--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -142,7 +142,7 @@ class ArchivedForumPosts(AsyncIterator):
             expected = self.get_limit
 
             rcv = await self.channel._client.http.list_public_archived_threads(
-                self.channel.id, limit=expected, before=self.last.id
+                self.channel.id, limit=expected, before=to_snowflake(self.last) if self.last else None
             )
             threads = [self.channel._client.cache.place_channel_data(data) for data in rcv["threads"]]
 


### PR DESCRIPTION


## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->

This PR fixes following error caused by forum.archived_posts() iterator
```
Traceback (most recent call last):
  File "naff/client/client.py", line 1832, in _dispatch_prefixed_commands
    await self._run_prefixed_command(command, context)
  File "naff/client/client.py", line 1655, in _run_prefixed_command
    return await command(ctx)
  File "naff/models/naff/command.py", line 120, in __call__
    await self.call_callback(self.callback, context)
  File "naff/models/naff/prefixed_commands.py", line 624, in call_callback
    return await self.call_with_binding(callback, ctx)
  File "naff/models/naff/callback.py", line 43, in call_with_binding
    return await callback(*args, **kwargs)
  File "bot/main.py", line 35, in test
    async for post in ch.archived_posts():
  File "naff/models/misc/iterator.py", line 75, in __anext__
    await self._get_items()
  File "naff/models/misc/iterator.py", line 67, in _get_items
    data = await self.fetch()
  File "naff/models/discord/channel.py", line 144, in fetch
    rcv = await self.channel._client.http.list_public_archived_threads(
  File "naff/api/http/http_requests/threads.py", line 96, in list_public_archived_threads
    payload["before"] = timestamp_converter(before)
  File "naff/client/utils/attr_converters.py", line 29, in timestamp_converter
    raise TypeError("Timestamp must be one of: datetime, int, float, ISO8601 str")
TypeError: Timestamp must be one of: datetime, int, float, ISO8601 str
```

## Changes
<!-- - A bullet pointed list outlining the changes you have made -->
- Fixed fetching data in forums with more than 100 archived posts.

## Checklist

<!-- These are actions you **must** have taken, if you haven't, your PR will be rejected -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've tested my code
