### PR TITLE
perf: adjust parts of message processing

### DIFF
--- a/naff/api/events/processors/message_events.py
+++ b/naff/api/events/processors/message_events.py
@@ -25,14 +25,11 @@ class MessageEvents(EventMixinTemplate):
         if not msg._guild_id and event.data.get("guild_id"):
             msg._guild_id = event.data["guild_id"]
 
-        if not msg.author:
-            # sometimes discord will only send an author ID, not the author. this catches that
-            await self.cache.fetch_channel(to_snowflake(msg._channel_id)) if not msg.channel else msg.channel
-            if msg._guild_id:
-                await self.cache.fetch_guild(msg._guild_id) if not msg.guild else msg.guild
-                await self.cache.fetch_member(msg._guild_id, msg._author_id)
-            else:
-                await self.cache.fetch_user(to_snowflake(msg._author_id))
+        if msg._guild_id and not msg.guild:
+            await self.cache.fetch_guild(msg._guild_id)
+
+        if not msg.channel:
+            await self.cache.fetch_channel(to_snowflake(msg._channel_id))
 
         self.dispatch(events.MessageCreate(msg))
 

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1752,7 +1752,7 @@ class Client(
         else:
             raise NotImplementedError(f"Unknown Interaction Received: {interaction_data['type']}")
 
-    @Listener.create("raw_message_create")
+    @Listener.create("raw_message_create", is_default_listener=True)
     async def _dispatch_prefixed_commands(self, event: RawGatewayEvent) -> None:
         """Determine if a prefixed command is being triggered, and dispatch it."""
         # don't waste time processing this if there are no prefixed commands

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1781,10 +1781,8 @@ class Client(
         # this huge if statement basically checks if the message hasn't been fully processed by
         # the processor yet, which would mean that these fields aren't fully filled
         if message and (
-            not message._guild_id
-            and event.data.get("guild_id")
-            or message._guild_id
-            and not message.guild
+            (not message._guild_id and event.data.get("guild_id"))
+            or (message._guild_id and not message.guild)
             or not message.channel
         ):
             message = None

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -33,7 +33,7 @@ from discord_typings.interactions.receiving import (
 
 import naff.api.events as events
 import naff.client.const as constants
-from naff.api.events import MessageCreate, RawGatewayEvent, processors, Component, BaseEvent
+from naff.api.events import BaseEvent, Component, RawGatewayEvent, processors
 from naff.api.gateway.gateway import GatewayClient
 from naff.api.gateway.state import ConnectionState
 from naff.api.http.http_client import HTTPClient

--- a/naff/client/client.py
+++ b/naff/client/client.py
@@ -1790,9 +1790,9 @@ class Client(
         # if we didn't get a message, then we know we should wait for the message create event
         if not message:
             try:
-                # i think 10 seconds is a very generous timeout limit
+                # i think 2 seconds is a very generous timeout limit
                 event: MessageCreate = await self.wait_for(
-                    MessageCreate, checks=lambda e: int(e.message.id) == int(data["id"]), timeout=10
+                    MessageCreate, checks=lambda e: int(e.message.id) == int(data["id"]), timeout=2
                 )
                 message = event.message
             except asyncio.TimeoutError:


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
This PR touches on the `message_create` processor, removing the (hopefully) unneeded `author` patch and adjusting the rest of the code to match.

However, more importantly, this adjusts `_dispatch_prefixed_commands` to use the `raw_message_create` event instead of `message_create`, as there are several cases that can be used to filter out actually processing a message before we serialize it. More specifically, we can filter out common cases like not having any prefixed commands or `content` being empty. While I haven't tested the speed difference, I'm willing to gauge that it is a decent speedup in most cases.

Sadly, we still need to serialize the message relatively early due to `generate_prefixes` using the message as an argument.

## Changes

- For `_on_raw_message_create`: remove the author check and move some of the other checks out of it, since they can still be needed independently of it.
- For `_dispatch_prefixed_commands`:
  - Make it use `raw_message_create` instead of `message_create` and try to detect for a few common cases to not run a prefixed command (the user being a bot, there being no content in the message, having no prefixed commands in the first place) before serializing.
  - Make the rest of the code not use nested if statements, using early returns instead to clean it up.


## Test Scenario(s)
<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. This includes test code. If you don't have a test scenario, please provide an explanation as to why this change does need to be tested. -->

I used a test bot running code from my (Realms Playerlist Bot)[https://github.com/Astrea49/RealmsPlayerlistBot] to make sure everything still functioned how it should, since that has a couple of debug prefixed commands. Also, the core logic of actually processing the content and all hasn't been touched, so it would pretty weird if it *did* break something.


## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've added docstrings to everything I've touched
- [x] I've ensured my code works on `Python 3.10.x`
- [ ] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [ ] I've updated the documentation - if applicable
