### PR TITLE
chore: unpin Pre-commit additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,9 +29,9 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-annotations~=2.0
-          - flake8-bandit~=3.0
-          - flake8-docstrings~=1.5
+          - flake8-annotations
+          - flake8-bandit
+          - flake8-docstrings
           - flake8-bugbear
           - flake8-comprehensions
           - flake8-quotes


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [x] Other: Pre-commit

## Description
Pre-commit doesn't update pinned additional_dependencies, so these are slowly getting more and more out of date.

Given the choice between manually updating these by hand, or unpinning, I'd rather go with the latter.

## Changes
* Removed some outdated pins in `.pre-commit-config.yml`


## Test Scenario(s)
I ran `pre-commit run --all-files` after unpinning, and flake8 still passed.

## Checklist
<!-- Please check which actions you have taken -->
- [ ] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've added docstrings to everything I've touched
- [ ] I've ensured my code works on `Python 3.10.x`
- [ ] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [ ] I've updated the documentation - if applicable
