### PR TITLE
fix: add in missing rate_limit_per_user

### DIFF
--- a/naff/models/discord/channel.py
+++ b/naff/models/discord/channel.py
@@ -1717,6 +1717,7 @@ class GuildText(GuildChannel, MessageableMixin, InvitableMixin, ThreadableMixin,
             topic=topic,
             type=channel_type,
             default_auto_archive_duration=default_auto_archive_duration,
+            rate_limit_per_user=rate_limit_per_user,
             reason=reason,
             **kwargs,
         )


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
So someone forgot a line... and I found out the hard way.


## Changes
- Add in `rate_limit_per_user` for the `super().edit` for `GuildText`.


## Test Scenario(s)
Just take any "regular" text channel in a guild and try editing `rate_limit_per_user`.

## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've added docstrings to everything I've touched
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [x] I've added tests for my code - if applicable
- [x] I've updated the documentation - if applicable
