### PR TITLE
fix: check channel_types when syncing

### DIFF
--- a/naff/models/naff/application_commands.py
+++ b/naff/models/naff/application_commands.py
@@ -1124,6 +1124,7 @@ def _compare_options(local_opt_list: dict, remote_opt_list: dict) -> bool:
         "autocomplete": ("autocomplete", False),
         "name_localized": ("name_localizations", None),
         "description_localized": ("description_localizations", None),
+        "channel_types": ("channel_types", None),
         "choices": ("choices", []),
         "max_value": ("max_value", None),
         "min_value": ("min_value", None),


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
Can you tell I'm trying to finish Astro's rewrite?

Anyways, yeah, `channel_types` wasn't being checked for syncing, so this fixes that.


## Changes
- Add an entry for `channel_types` for the `options_lookup` in `_compare_options`.


## Test Scenario(s)
- Make a slash command with a channel option type and with a specified `channel_type`.
- Sync it, change the channel type, then sync again.
- Commands are still the same, the logger shows that no commands were overriden.


## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've added docstrings to everything I've touched
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [x] I've added tests for my code - if applicable
- [x] I've updated the documentation - if applicable
