### PR TITLE
docs: fix badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![PyPI](https://img.shields.io/pypi/v/naff)](https://pypi.org/project/naff/)
 [![Downloads](https://static.pepy.tech/personalized-badge/dis-snek?period=total&units=abbreviation&left_color=grey&right_color=green&left_text=pip%20installs)](https://pepy.tech/project/dis-snek)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![pre-commit](https://img.shields.io/github/actions/workflow/status/NAFTeam/NAFF/precommit.yml?branch=master&label=pre-commit&logo=github)](https://github.com/NAFTeam/NAFF/actions/workflows/black.yml)
+[![pre-commit](https://img.shields.io/github/actions/workflow/status/NAFTeam/NAFF/precommit.yml?branch=master&label=pre-commit&logo=github)](https://github.com/NAFTeam/NAFF/actions/workflows/precommit.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/NAFTeam/NAFF/codeql-analysis.yml?branch=master&label=CodeQL&logo=Github)](https://github.com/NAFTeam/NAFF/actions/workflows/codeql-analysis.yml)
 [![Discord](https://img.shields.io/discord/870046872864165888?color=%235865F2&label=Server&logo=discord&logoColor=%235865F2)](https://discord.gg/hpfNhH8BsY)
 [![Documentation Status](https://readthedocs.org/projects/naff-docs/badge/?version=latest)](https://naff-docs.readthedocs.io/en/latest/?version=latest)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![PyPI](https://img.shields.io/pypi/v/naff)](https://pypi.org/project/naff/)
 [![Downloads](https://static.pepy.tech/personalized-badge/dis-snek?period=total&units=abbreviation&left_color=grey&right_color=green&left_text=pip%20installs)](https://pepy.tech/project/dis-snek)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![black-formatted](https://img.shields.io/github/workflow/status/NAFTeam/NAFF/black-action/master?label=Black%20Format&logo=github)](https://github.com/NAFTeam/NAFF/actions/workflows/black.yml)
-[![CodeQL](https://img.shields.io/github/workflow/status/NAFTeam/NAFF/CodeQL/master?label=CodeQL&logo=Github)](https://github.com/NAFTeam/NAFF/actions/workflows/codeql-analysis.yml)
+[![pre-commit](https://img.shields.io/github/actions/workflow/status/NAFTeam/NAFF/precommit.yml?branch=master&label=pre-commit&logo=github)](https://github.com/NAFTeam/NAFF/actions/workflows/black.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/NAFTeam/NAFF/codeql-analysis.yml?branch=master&label=CodeQL&logo=Github)](https://github.com/NAFTeam/NAFF/actions/workflows/codeql-analysis.yml)
 [![Discord](https://img.shields.io/discord/870046872864165888?color=%235865F2&label=Server&logo=discord&logoColor=%235865F2)](https://discord.gg/hpfNhH8BsY)
 [![Documentation Status](https://readthedocs.org/projects/naff-docs/badge/?version=latest)](https://naff-docs.readthedocs.io/en/latest/?version=latest)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [ ] Non-breaking code change
- [ ] Breaking code change
- [x] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
Fixes the badges in the README so they don't show https://github.com/badges/shields/issues/8671 anymore. Also adjusts the Black formatting badge to be the pre-commit badge.


## Changes
- Use the new format for workflow badges as noted in https://github.com/badges/shields/issues/8671.
- Replace the outdated Black formatting badge with the pre-commit workflow badges, since pre-commit replaced it.


## Test Scenario(s)
N/A


## Checklist
<!-- Please check which actions you have taken -->
- [ ] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've added docstrings to everything I've touched
- [ ] I've ensured my code works on `Python 3.10.x`
- [ ] I've ensured my code works on `Python 3.11.x`
- [ ] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [x] I've updated the documentation - if applicable
