### PR TITLE
fix: only adjust member count if guild is found

### DIFF
--- a/naff/api/events/processors/member_events.py
+++ b/naff/api/events/processors/member_events.py
@@ -27,7 +27,6 @@ class MemberEvents(EventMixinTemplate):
         member = self.cache.get_member(g_id, user.id)
 
         self.cache.delete_member(g_id, user.id)
-        guild = self.cache.get_guild(g_id)
         if guild := self.cache.get_guild(g_id):
             guild.member_count -= 1
 

--- a/naff/api/events/processors/member_events.py
+++ b/naff/api/events/processors/member_events.py
@@ -16,8 +16,8 @@ class MemberEvents(EventMixinTemplate):
     async def _on_raw_guild_member_add(self, event: "RawGatewayEvent") -> None:
         g_id = event.data.pop("guild_id")
         member = self.cache.place_member_data(g_id, event.data)
-        guild = self.cache.get_guild(g_id)
-        guild.member_count += 1
+        if guild := self.cache.get_guild(g_id):
+            guild.member_count += 1
         self.dispatch(events.MemberAdd(g_id, member))
 
     @Processor.define()
@@ -28,7 +28,8 @@ class MemberEvents(EventMixinTemplate):
 
         self.cache.delete_member(g_id, user.id)
         guild = self.cache.get_guild(g_id)
-        guild.member_count -= 1
+        if guild := self.cache.get_guild(g_id):
+            guild.member_count -= 1
 
         self.dispatch(events.MemberRemove(g_id, member or user))
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
I don't quite have an idea on how it happened, but according [to a message in the NAFF Discord server](https://discord.com/channels/870046872864165888/893158404237979688/1058663510948716564), sometimes, when a member is removed from a guild, the guild they were removed from isn't in the cache and causes the processor to fail.

This PR causes the processor to not error, at the very least.


## Changes
- Only change `guild.member_count` if `guild` isn't `None` in `MemberEvents`.


## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've added docstrings to everything I've touched
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [ ] I've updated the documentation - if applicable
