### PR TITLE
fix: use eq method for ne for SnowflakeObject

### DIFF
--- a/naff/models/discord/snowflake.py
+++ b/naff/models/discord/snowflake.py
@@ -63,7 +63,7 @@ class SnowflakeObject:
         return self.id == other
 
     def __ne__(self, other: "SnowflakeObject") -> bool:
-        return self.id != other.id
+        return not self.__eq__(other)
 
     def __hash__(self) -> int:
         return self.id << 32


### PR DESCRIPTION
This makes sure objects without an "id" attribute are still correctly compared.

## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
Trying to compare a `SnowflakeObject` to something else that didn't have an `id` attribute via `!=` would always error out. This PR fixes that by making `__ne__` use `__eq__`.


## Changes
- Make `SnowflakeObject.__ne__` return the opposite of `__eq__` instead of using custom logic. Honestly, I think you could just remove it altogether, but this was safer.


## Test Scenario(s)
Just use `SnowflakeObject(SOME_ID) != None`.


## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've added docstrings to everything I've touched
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [ ] I've updated the documentation - if applicable
