### PR TITLE
fix: body-length can't be exceeded anymore

### DIFF
--- a/naff/ext/debug_extension/debug_exec.py
+++ b/naff/ext/debug_extension/debug_exec.py
@@ -81,8 +81,9 @@ class DebugExec(Extension):
             return await self.handle_exec_result(m_ctx, ret, stdout.getvalue(), body)
 
     async def handle_exec_result(self, ctx: ModalContext, result: Any, value: Any, body: str) -> Optional[Message]:
-        if len(body) <= 2000:
-            await ctx.send(f"```py\n{body}```")
+        # body can be of length 2000 and exceed the limit after formatting
+        if len(cmd_body := f"```py\n{body}```") <= 2000:
+            await ctx.send(cmd_body)
 
         else:
             paginator = Paginator.create_from_string(self.bot, body, prefix="```py", suffix="```", page_size=4000)

--- a/naff/ext/debug_extension/debug_exec.py
+++ b/naff/ext/debug_extension/debug_exec.py
@@ -124,8 +124,8 @@ class DebugExec(Extension):
         # prevent token leak
         result = result.replace(self.bot.http.token, "[REDACTED TOKEN]")
 
-        if len(result) <= 2000:
-            return await ctx.send(f"```py\n{result}```")
+        if len(cmd_result := f"```py\n{result}```") <= 2000:
+            return await ctx.send(cmd_result)
 
         else:
             paginator = Paginator.create_from_string(self.bot, result, prefix="```py", suffix="```", page_size=4000)


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
Fix a bug where a body-length near 2000 can cause errors because formatting increases its length

## Changes
<!-- - A bullet-pointed list outlining the changes you have made -->
Move formatting of `body` up so it's length is checked

## Test Scenario(s)
<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. This includes test code. If you don't have a test scenario, please provide an explanation as to why this change does need to be tested. -->
You should see that it works just by looking at it /shrug

## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've added docstrings to everything I've touched
- [x] I've ensured my code works on `Python 3.10.x`
- [x] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [ ] I've updated the documentation - if applicable
