### PR TITLE
feat: file description for NAFF's File object

### DIFF
--- a/naff/client/mixins/send.py
+++ b/naff/client/mixins/send.py
@@ -85,7 +85,25 @@ class SendMixin:
             **kwargs,
         )
 
-        message_data = await self._send_http_request(message_payload, files=files or file)
+        files = files or file
+        if not isinstance(files, list):
+            files = [files]
+
+        if files:
+            attachments = []
+            for i, file in enumerate(files):
+                if isinstance(file, models.File):
+                    # NOTE: This adds the ability to send files with a description
+                    attachments.append(
+                        {
+                            "id": i,
+                            "description": file.description,
+                            "filename": file.file_name,
+                        }
+                    )
+            message_payload.update({"attachments": attachments})
+
+        message_data = await self._send_http_request(message_payload, files=files)
         if message_data:
             message = self._client.cache.place_message_data(message_data)
             if delete_after:

--- a/naff/models/discord/file.py
+++ b/naff/models/discord/file.py
@@ -20,6 +20,8 @@ class File:
     """Location of file to send or the bytes."""
     file_name: Optional[str] = attrs.field(repr=True, default=None)
     """Set a filename that will be displayed when uploaded to discord. If you leave this empty, the file will be called `file` by default"""
+    description: Optional[str] = attrs.field(repr=True, default=None)
+    """Optional description (ALT text) for the file."""
 
     def open_file(self) -> BinaryIO:
         """


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
<!-- Clearly and concisely describe what this PR is for, and why you feel it should be merged. -->
This PR adds the ability to send files with ALT text 
![image](https://user-images.githubusercontent.com/58155937/211218984-756d18dc-b422-49f2-afb0-19a39a67b542.png)



## Changes
<!-- - A bullet-pointed list outlining the changes you have made -->
- Add `description` field to `File` model
- Edited SendMixin to adjust the attachment dict in message payload for files

## Test Scenario(s)
<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. This includes test code. If you don't have a test scenario, please provide an explanation as to why this change does need to be tested. -->
```py
@naff.listen()
async def on_startup():
    channel = await bot.fetch_channel(1061554907540357220)
    file1 = naff.File("./Screenshot_20230107_033228.png", "Screenshot_20230107_033228.png", description="123")
    file2 = naff.File("./Screenshot_20230107_011359.png", "Screenshot_20230107_011359.png", description="123")
    await channel.send("123", files=[file1, file2])
```

## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [x] I've added docstrings to everything I've touched
- [ ] I've ensured my code works on `Python 3.10.x`
- [x] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [ ] I've updated the documentation - if applicable
