### PR TITLE
fix: Type issues with app command permission

### DIFF
--- a/naff/api/http/http_requests/interactions.py
+++ b/naff/api/http/http_requests/interactions.py
@@ -250,7 +250,7 @@ class InteractionRequests(CanRequest):
 
     async def batch_get_application_command_permissions(
         self, application_id: "Snowflake_Type", scope: "Snowflake_Type"
-    ) -> list[discord_typings.ApplicationCommandPermissionsData]:
+    ) -> list[discord_typings.GuildApplicationCommandPermissionData]:
         """
         Get permission data for all commands in a scope.
 
@@ -265,4 +265,4 @@ class InteractionRequests(CanRequest):
         result = await self.request(
             Route("GET", f"/applications/{int(application_id)}/guilds/{int(scope)}/commands/permissions")
         )
-        return cast(list[discord_typings.ApplicationCommandPermissionsData], result)
+        return cast(list[discord_typings.GuildApplicationCommandPermissionData], result)

--- a/naff/models/discord/guild.py
+++ b/naff/models/discord/guild.py
@@ -514,7 +514,7 @@ class Guild(BaseGuild):
 
         for command in data:
             command_permissions = CommandPermissions(client=self._client, command_id=command["id"], guild=self)
-            perms = [ApplicationCommandPermission.from_dict(perm, self) for perm in command["permissions"]]
+            perms = [ApplicationCommandPermission.from_dict(perm, self._client) for perm in command["permissions"]]
 
             command_permissions.update_permissions(*perms)
 


### PR DESCRIPTION
## What type of pull request is this?

<!-- Check whichever applies to your PR -->
- [x] Non-breaking code change
- [ ] Breaking code change
- [ ] Documentation change/addition
- [ ] Tests change
- [ ] CI change
- [ ] Other: [Replace with a description]

## Description
Just some simple type issue fixes


## Changes
- The return type for batch_get_application_command_permissions was wrong
- The client should be passed into from_dict, not the guild object 

## Test Scenario(s)
<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. This includes test code. If you don't have a test scenario, please provide an explanation as to why this change does need to be tested. -->


## Checklist
<!-- Please check which actions you have taken -->
- [x] I've formatted my code with [Black](https://black.readthedocs.io/en/stable/)
- [ ] I've added docstrings to everything I've touched
- [x] I've ensured my code works on `Python 3.10.x`
- [ ] I've ensured my code works on `Python 3.11.x`
- [x] I've tested my changes
- [ ] I've added tests for my code - if applicable
- [ ] I've updated the documentation - if applicable
